### PR TITLE
Added some code improvements

### DIFF
--- a/Forms/AppInfoForm.cs
+++ b/Forms/AppInfoForm.cs
@@ -32,7 +32,7 @@ public partial class AppInfoForm : BaseKryptonForm
 	/// This field is used to keep track of the control that is currently selected
 	/// for clipboard operations, such as copying text.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -284,7 +284,7 @@ public partial class AppInfoForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Assuming CopyToClipboard is a helper method in BaseKryptonForm or similar

--- a/Forms/CheckAstorbDatForm.cs
+++ b/Forms/CheckAstorbDatForm.cs
@@ -41,7 +41,7 @@ public partial class CheckAstorbDatForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to store the currently selected control for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -331,7 +331,7 @@ public partial class CheckAstorbDatForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/CheckMpcorbDatForm.cs
+++ b/Forms/CheckMpcorbDatForm.cs
@@ -41,7 +41,7 @@ public partial class CheckMpcorbDatForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to store the currently selected control for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -331,7 +331,7 @@ public partial class CheckMpcorbDatForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -1,4 +1,6 @@
-﻿using Planetoid_DB.Forms;
+﻿using NLog;
+
+using Planetoid_DB.Forms;
 
 using System.ComponentModel;
 using System.Diagnostics;
@@ -14,6 +16,22 @@ namespace Planetoid_DB;
 [DebuggerDisplay(value: "{" + nameof(GetDebuggerDisplay) + "(),nq}")]
 public partial class DatabaseDifferencesForm : BaseKryptonForm
 {
+	/// <summary>
+	/// NLog logger instance for the class.
+	/// </summary>
+	/// <remarks>
+	/// This logger is used to log messages for the database downloader.
+	/// </remarks>
+	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+	/// <summary>
+	/// Stores the currently selected control for clipboard operations.
+	/// </summary>
+	/// <remarks>
+	/// This field is used to store the currently selected control for clipboard operations.
+	/// </remarks>
+	private Control? currentControl;
+
 	#region constructor
 
 	/// <summary>
@@ -277,22 +295,36 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	#region DoubleClick event handlers
 
 	/// <summary>
-	/// Called when a control is double-clicked. If the <paramref name="sender"/> is a <see cref="Control"/>,
-	/// its <see cref="Control.Text"/> value is copied to the clipboard using the shared helper.
+	/// Called when a control is double-clicked. If the <paramref name="sender"/> is a <see cref="Control"/>
+	/// or a <see cref="ToolStripItem"/>, its <see cref="Control.Text"/> value is copied to the clipboard
+	/// using the shared helper.
 	/// </summary>
-	/// <param name="sender">Event source — expected to be a <see cref="Control"/>.</param>
+	/// <param name="sender">Event source — expected to be a <see cref="Control"/> or a <see cref="ToolStripItem"/>.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>
-	/// This event is used to handle double-click operations for the control.
+	/// If the <paramref name="sender"/> is a <see cref="Control"/>, its <see cref="Control.Text"/> value is copied to the clipboard.
+	/// If the <paramref name="sender"/> is a <see cref="ToolStripItem"/>, its <see cref="ToolStripItem.Text"/> value is copied to the clipboard.
 	/// </remarks>
 	private void CopyToClipboard_DoubleClick(object sender, EventArgs e)
 	{
 		// Check if the sender is null
 		ArgumentNullException.ThrowIfNull(argument: sender);
-		if (sender is Control control)
+		// Get the text to copy based on the sender type
+		string? textToCopy = sender switch
 		{
-			// Copy the text to the clipboard
-			CopyToClipboard(text: control.Text);
+			Control c => c.Text,
+			ToolStripItem => currentControl?.Text,
+			_ => null
+		};
+		// Check if the text to copy is not null or empty
+		if (!string.IsNullOrEmpty(value: textToCopy))
+		{
+			// Try to set the clipboard text
+			try { CopyToClipboard(text: textToCopy); }
+			catch
+			{ // Throw an exception
+				throw new ArgumentException(message: "Unsupported sender type", paramName: nameof(sender));
+			}
 		}
 	}
 

--- a/Forms/DatabaseDownloaderForm.cs
+++ b/Forms/DatabaseDownloaderForm.cs
@@ -27,7 +27,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 	/// <remarks>
 	/// This logger is used to log messages for the database downloader.
 	/// </remarks>
-	private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
 	/// <summary>
 	/// Shared <see cref="HttpClient"/> used for HTTP requests. Initialized in the constructor.
@@ -260,7 +260,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 		//if (!await HasInternetAsync(client: httpClient, url: url))
 		{
 			// Log the error if there is no internet connection
-			Logger.Error(message: "No internet connection available.");
+			logger.Error(message: "No internet connection available.");
 			// Show an error message if there is no internet connection
 			ShowErrorMessage(message: I10nStrings.NoInternetConnectionText);
 			return;
@@ -321,7 +321,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			// Notify the user of successful completion
 			labelStatusValue.Text = "Download completed";
 			_ = MessageBox.Show(text: "Download completed successfully!", caption: "Finished", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
-			Logger.Info(message: "Download and extraction completed successfully.");
+			logger.Info(message: "Download and extraction completed successfully.");
 			// Set the dialog result to OK and close the form
 			DialogResult = DialogResult.OK;
 			Close();
@@ -336,7 +336,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			labelStatusValue.Text = "Download canceled";
 			//TODO: Optionally disable the Cancel button here to prevent multiple clicks
 			_ = MessageBox.Show(text: "Download canceled!", caption: "Canceled", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
-			Logger.Info(message: "Download canceled by user.");
+			logger.Info(message: "Download canceled by user.");
 			DialogResult = DialogResult.Cancel;
 		}
 		// Handle other exceptions
@@ -349,7 +349,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			labelStatusValue.Text = "Download error";
 			//TODO: Optionally disable the Cancel button here to prevent multiple clicks
 			_ = MessageBox.Show(text: $"Error during download: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
-			Logger.Error(exception: ex, message: "Download failed. Url={Url}, TempFile={TempFile}", url, strFilenameTemp);
+			logger.Error(exception: ex, message: "Download failed. Url={Url}, TempFile={TempFile}", url, strFilenameTemp);
 			DialogResult = DialogResult.Abort;
 		}
 		// Reset UI elements and clean up resources
@@ -550,7 +550,7 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/DatabaseInformationForm.Designer.cs
+++ b/Forms/DatabaseInformationForm.Designer.cs
@@ -52,8 +52,8 @@ namespace Planetoid_DB
 			labelDateCreatedValue = new KryptonLabel();
 			labelDateAccessedValue = new KryptonLabel();
 			labelDateWritedValue = new KryptonLabel();
-			labelAttributesValue = new KryptonLabel();
 			tableLayoutPanel = new KryptonTableLayoutPanel();
+			labelAttributesValue = new KryptonLabel();
 			toolStripContainer = new ToolStripContainer();
 			statusStrip = new KryptonStatusStrip();
 			labelInformation = new ToolStripStatusLabel();
@@ -236,7 +236,7 @@ namespace Planetoid_DB
 			contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
 			contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCpyToClipboard });
 			contextMenuCopyToClipboard.Name = "contextMenuStrip";
-			contextMenuCopyToClipboard.Size = new Size(214, 48);
+			contextMenuCopyToClipboard.Size = new Size(214, 26);
 			contextMenuCopyToClipboard.TabStop = true;
 			contextMenuCopyToClipboard.Text = "ContextMenu";
 			toolTip.SetToolTip(contextMenuCopyToClipboard, "Context Menu for copying to clipboard");
@@ -364,27 +364,6 @@ namespace Planetoid_DB
 			labelDateWritedValue.MouseEnter += SetStatusBar_Enter;
 			labelDateWritedValue.MouseLeave += ClearStatusBar_Leave;
 			// 
-			// labelAttributesValue
-			// 
-			labelAttributesValue.AccessibleDescription = "Shows the attributes of the database";
-			labelAttributesValue.AccessibleName = "Attributes value";
-			labelAttributesValue.AccessibleRole = AccessibleRole.Text;
-			labelAttributesValue.ContextMenuStrip = contextMenuCopyToClipboard;
-			labelAttributesValue.Dock = DockStyle.Fill;
-			labelAttributesValue.Location = new Point(114, 159);
-			labelAttributesValue.Margin = new Padding(4, 3, 4, 3);
-			labelAttributesValue.Name = "labelAttributesValue";
-			labelAttributesValue.Size = new Size(252, 25);
-			labelAttributesValue.TabIndex = 13;
-			toolTip.SetToolTip(labelAttributesValue, "Shows the attributes of the database");
-			labelAttributesValue.Values.Text = "..........";
-			labelAttributesValue.DoubleClick += CopyToClipboard_DoubleClick;
-			labelAttributesValue.Enter += SetStatusBar_Enter;
-			labelAttributesValue.Leave += ClearStatusBar_Leave;
-			labelAttributesValue.MouseDown += Control_MouseDown;
-			labelAttributesValue.MouseEnter += SetStatusBar_Enter;
-			labelAttributesValue.MouseLeave += ClearStatusBar_Leave;
-			// 
 			// tableLayoutPanel
 			// 
 			tableLayoutPanel.AccessibleDescription = "Groups the information";
@@ -425,6 +404,28 @@ namespace Planetoid_DB
 			tableLayoutPanel.TabIndex = 0;
 			tableLayoutPanel.TabStop = true;
 			toolTip.SetToolTip(tableLayoutPanel, "Groups the information");
+			// 
+			// labelAttributesValue
+			// 
+			labelAttributesValue.AccessibleDescription = "Shows the attributes of the database";
+			labelAttributesValue.AccessibleName = "Attributes value";
+			labelAttributesValue.AccessibleRole = AccessibleRole.Text;
+			labelAttributesValue.ContextMenuStrip = contextMenuCopyToClipboard;
+			labelAttributesValue.Dock = DockStyle.Fill;
+			labelAttributesValue.Location = new Point(114, 159);
+			labelAttributesValue.Margin = new Padding(4, 3, 4, 3);
+			labelAttributesValue.Name = "labelAttributesValue";
+			labelAttributesValue.Size = new Size(252, 25);
+			labelAttributesValue.TabIndex = 13;
+			toolTip.SetToolTip(labelAttributesValue, "Shows the attributes of the database");
+			labelAttributesValue.ToolTipValues.Description = "";
+			labelAttributesValue.Values.Text = "..........";
+			labelAttributesValue.DoubleClick += CopyToClipboard_DoubleClick;
+			labelAttributesValue.Enter += SetStatusBar_Enter;
+			labelAttributesValue.Leave += ClearStatusBar_Leave;
+			labelAttributesValue.MouseDown += Control_MouseDown;
+			labelAttributesValue.MouseEnter += SetStatusBar_Enter;
+			labelAttributesValue.MouseLeave += ClearStatusBar_Leave;
 			// 
 			// toolStripContainer
 			// 

--- a/Forms/DerivedOrbitElementsForm.cs
+++ b/Forms/DerivedOrbitElementsForm.cs
@@ -38,7 +38,7 @@ public partial class DerivedOrbitElementsForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to keep track of the control that is currently selected for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	/// <summary>
 	/// Stores the current tag text of the control.
@@ -646,7 +646,7 @@ public partial class DerivedOrbitElementsForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/DownloadMpcorbDatForm.cs
+++ b/Forms/DownloadMpcorbDatForm.cs
@@ -94,7 +94,7 @@ public partial class DownloadMpcorbDatForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to store the currently selected control for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -663,7 +663,7 @@ public partial class DownloadMpcorbDatForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -73,7 +73,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to store the currently selected control for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -697,7 +697,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -50,7 +50,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>
 	/// This control is used for clipboard operations such as copy and paste.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	/// <summary>
 	/// Stores the current tag text of the control.
@@ -3175,7 +3175,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/PreloadForm.cs
+++ b/Forms/PreloadForm.cs
@@ -26,7 +26,15 @@ public partial class PreloadForm : BaseKryptonForm
 	/// <remarks>
 	/// This logger is used to log events and errors that occur within the form.
 	/// </remarks>
-	private static readonly Logger Logger = LogManager.GetCurrentClassLogger(); // NLog logger instance
+	private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+	/// <summary>
+	/// Stores the currently selected control for clipboard operations.
+	/// </summary>
+	/// <remarks>
+	/// This field is used to store the currently selected control for clipboard operations.
+	/// </remarks>
+	private Control? currentControl;
 
 	#region constructor
 
@@ -293,10 +301,22 @@ public partial class PreloadForm : BaseKryptonForm
 	{
 		// Check if the sender is null
 		ArgumentNullException.ThrowIfNull(argument: sender);
-		if (sender is Control control)
+		// Get the text to copy based on the sender type
+		string? textToCopy = sender switch
 		{
-			// Copy the text to the clipboard
-			CopyToClipboard(text: control.Text);
+			Control c => c.Text,
+			ToolStripItem => currentControl?.Text,
+			_ => null
+		};
+		// Check if the text to copy is not null or empty
+		if (!string.IsNullOrEmpty(value: textToCopy))
+		{
+			// Try to set the clipboard text
+			try { CopyToClipboard(text: textToCopy); }
+			catch
+			{ // Throw an exception
+				throw new ArgumentException(message: "Unsupported sender type", paramName: nameof(sender));
+			}
 		}
 	}
 

--- a/Forms/SplashScreenForm.cs
+++ b/Forms/SplashScreenForm.cs
@@ -22,7 +22,7 @@ public partial class SplashScreenForm : BaseKryptonForm
 	/// <remarks>
 	/// This field is used to keep track of the control that is currently selected for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	/// <summary>
 	/// NLog logger instance.
@@ -158,7 +158,7 @@ public partial class SplashScreenForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text

--- a/Forms/TableModeForm.cs
+++ b/Forms/TableModeForm.cs
@@ -214,7 +214,7 @@ public partial class TableModeForm : BaseKryptonForm
 	/// <remarks>
 	/// This field stores the currently selected control for clipboard operations.
 	/// </remarks>
-	private Control currentControl;
+	private Control? currentControl;
 
 	#region constructor
 
@@ -700,7 +700,7 @@ public partial class TableModeForm : BaseKryptonForm
 			ToolStripItem => currentControl?.Text,
 			_ => null
 		};
-		// If we have text to copy, use the helper method to copy it to the clipboard
+		// Check if the text to copy is not null or empty
 		if (!string.IsNullOrEmpty(value: textToCopy))
 		{
 			// Try to set the clipboard text


### PR DESCRIPTION
## Pull request overview

This PR introduces code improvements focusing on nullable reference types, logging infrastructure, and clipboard operation enhancements across multiple form classes. However, several critical bugs and inconsistencies have been introduced.

**Changes:**
- Added nullable annotation (`Control?`) to `currentControl` field declarations across 13 forms to improve null safety
- Added NLog logger instances to 3 forms (RecordsMainForm, DatabaseDifferencesForm, DatabaseInformationForm) and standardized logger naming in DatabaseDownloaderForm
- Enhanced `CopyToClipboard_DoubleClick` method in 3 forms to support ToolStripItem senders with pattern matching
- Improved file information handling in DatabaseInformationForm with explicit culture formatting and file existence validation
- Updated various inline comments for clarity

### Reviewed changes

Copilot reviewed 14 out of 15 changed files in this pull request and generated 20 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| Forms/TableModeForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/SplashScreenForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/RecordsMainForm.cs | Added NLog logger and currentControl field; updated CopyToClipboard_DoubleClick with ToolStripItem support |
| Forms/PreloadForm.cs | Added currentControl field; updated CopyToClipboard_DoubleClick with ToolStripItem support |
| Forms/PlanetoidDBForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/ListReadableDesignationsForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/DownloadMpcorbDatForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/DerivedOrbitElementsForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/DatabaseInformationForm.cs | Added NLog logger, currentControl field, file existence check, culture-aware date formatting, simplified file attributes display; removed unused System.Text import |
| Forms/DatabaseInformationForm.Designer.cs | Reordered field declarations and updated context menu size |
| Forms/DatabaseDownloaderForm.cs | Changed Logger to logger (camelCase) throughout the file; updated comment |
| Forms/DatabaseDifferencesForm.cs | Added NLog logger and currentControl field; updated CopyToClipboard_DoubleClick with ToolStripItem support |
| Forms/CheckMpcorbDatForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/CheckAstorbDatForm.cs | Added nullable annotation to currentControl field; updated comment |
| Forms/AppInfoForm.cs | Added nullable annotation to currentControl field; updated comment |
</details>


<details>
<summary>Files not reviewed (1)</summary>

* **Forms/DatabaseInformationForm.Designer.cs**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (11)</summary>

**Forms/CheckAstorbDatForm.cs:123**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			var response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckAstorbDatForm.cs:152**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckMpcorbDatForm.cs:123**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckMpcorbDatForm.cs:152**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/DownloadMpcorbDatForm.cs:181**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpRequestMessage request = new(method: HttpMethod.Head, requestUri: uri);
```
**Forms/PlanetoidDBForm.cs:1371**
* Possible loss of precision: any fraction will be lost.
```
				float percent = 100 * fileSizeRead / fileSize; // Variable to store the percentage of the file read
```
**Forms/TableModeForm.cs:551**
* Local scope variable 'listView' shadows [TableModeForm.listView](1).
```
		if (sender is not ListView listView)
```
**Forms/PlanetoidDBForm.cs:463**
* These 'if' statements can be combined.
```
		if (response.IsSuccessStatusCode)
		{
			// Check if the Last-Modified header is present and return its value
			if (response.Content.Headers.LastModified.HasValue)
			{
				// Return the last modified date in UTC
				return response.Content.Headers.LastModified.Value.UtcDateTime;
			}
		}
```
**Forms/PlanetoidDBForm.cs:518**
* These 'if' statements can be combined.
```
		if (response.IsSuccessStatusCode)
		{
			// Check if the Content-Length header is present and return its value
			if (response.Content.Headers.ContentLength.HasValue)
			{
				// Return the content length
				return response.Content.Headers.ContentLength.Value;
			}
		}
```
**Forms/DatabaseDownloaderForm.cs:79**
* This variable is manually [disposed](1) in a [finally block](2) - consider a C# using statement as a preferable resource management technique.
```
	private CancellationTokenSource? cancellationTokenSource;
```
**Forms/DownloadMpcorbDatForm.cs:194**
* Both branches of this 'if' statement return - consider using '?' to express intent better.
```
			if (response.IsSuccessStatusCode)
			{
				// Return the content length or 0 if not available
				return response.Content.Headers.ContentLength ?? 0;
			}
			else
			{
				// Return 0 to indicate an error
				return 0;
			}
```
</details>