### PR TITLE
Added some code improvements

### DIFF
--- a/Forms/AppInfoForm.Designer.cs
+++ b/Forms/AppInfoForm.Designer.cs
@@ -39,6 +39,8 @@ namespace Planetoid_DB
 			components = new Container();
 			ComponentResourceManager resources = new ComponentResourceManager(typeof(AppInfoForm));
 			labelVersion = new KryptonLabel();
+			contextMenuStripCopyToClipboard = new ContextMenuStrip(components);
+			ToolStripMenuItemCpyToClipboard = new ToolStripMenuItem();
 			labelTitle = new KryptonLabel();
 			labelDescription = new KryptonLabel();
 			toolTip = new ToolTip(components);
@@ -46,14 +48,12 @@ namespace Planetoid_DB
 			labelCopyright = new KryptonLabel();
 			linkLabelEmail = new KryptonLinkLabel();
 			linkLabelWebsite = new KryptonLinkLabel();
-			contextMenuStripCopyToClipboard = new ContextMenuStrip(components);
-			ToolStripMenuItemCpyToClipboard = new ToolStripMenuItem();
 			panel = new KryptonPanel();
 			statusStrip = new KryptonStatusStrip();
 			labelInformation = new ToolStripStatusLabel();
 			kryptonManager = new KryptonManager(components);
-			((ISupportInitialize)pictureBoxBanner).BeginInit();
 			contextMenuStripCopyToClipboard.SuspendLayout();
+			((ISupportInitialize)pictureBoxBanner).BeginInit();
 			((ISupportInitialize)panel).BeginInit();
 			panel.SuspendLayout();
 			statusStrip.SuspendLayout();
@@ -78,6 +78,38 @@ namespace Planetoid_DB
 			labelVersion.MouseDown += Control_MouseDown;
 			labelVersion.MouseEnter += SetStatusBar_Enter;
 			labelVersion.MouseLeave += ClearStatusBar_Leave;
+			// 
+			// contextMenuStripCopyToClipboard
+			// 
+			contextMenuStripCopyToClipboard.AccessibleDescription = "Shows context menu for some options";
+			contextMenuStripCopyToClipboard.AccessibleName = "Some options";
+			contextMenuStripCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
+			contextMenuStripCopyToClipboard.AllowClickThrough = true;
+			contextMenuStripCopyToClipboard.Font = new Font("Segoe UI", 9F);
+			contextMenuStripCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCpyToClipboard });
+			contextMenuStripCopyToClipboard.Name = "contextMenuStrip";
+			contextMenuStripCopyToClipboard.Size = new Size(214, 26);
+			contextMenuStripCopyToClipboard.TabStop = true;
+			contextMenuStripCopyToClipboard.Text = "ContextMenu";
+			toolTip.SetToolTip(contextMenuStripCopyToClipboard, "Context Menu for copying to clipboard");
+			contextMenuStripCopyToClipboard.MouseEnter += SetStatusBar_Enter;
+			contextMenuStripCopyToClipboard.MouseLeave += ClearStatusBar_Leave;
+			// 
+			// ToolStripMenuItemCpyToClipboard
+			// 
+			ToolStripMenuItemCpyToClipboard.AccessibleDescription = "Copies the text/value to the clipboard";
+			ToolStripMenuItemCpyToClipboard.AccessibleName = "Copy to clipboard";
+			ToolStripMenuItemCpyToClipboard.AccessibleRole = AccessibleRole.MenuItem;
+			ToolStripMenuItemCpyToClipboard.AutoToolTip = true;
+			ToolStripMenuItemCpyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
+			ToolStripMenuItemCpyToClipboard.Name = "ToolStripMenuItemCpyToClipboard";
+			ToolStripMenuItemCpyToClipboard.ShortcutKeyDisplayString = "Strg+C";
+			ToolStripMenuItemCpyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
+			ToolStripMenuItemCpyToClipboard.Size = new Size(213, 22);
+			ToolStripMenuItemCpyToClipboard.Text = "&Copy to clipboard";
+			ToolStripMenuItemCpyToClipboard.Click += CopyToClipboard_DoubleClick;
+			ToolStripMenuItemCpyToClipboard.MouseEnter += SetStatusBar_Enter;
+			ToolStripMenuItemCpyToClipboard.MouseLeave += ClearStatusBar_Leave;
 			// 
 			// labelTitle
 			// 
@@ -198,38 +230,6 @@ namespace Planetoid_DB
 			linkLabelWebsite.MouseEnter += SetStatusBar_Enter;
 			linkLabelWebsite.MouseLeave += ClearStatusBar_Leave;
 			// 
-			// contextMenuStripCopyToClipboard
-			// 
-			contextMenuStripCopyToClipboard.AccessibleDescription = "Shows context menu for some options";
-			contextMenuStripCopyToClipboard.AccessibleName = "Some options";
-			contextMenuStripCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
-			contextMenuStripCopyToClipboard.AllowClickThrough = true;
-			contextMenuStripCopyToClipboard.Font = new Font("Segoe UI", 9F);
-			contextMenuStripCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCpyToClipboard });
-			contextMenuStripCopyToClipboard.Name = "contextMenuStrip";
-			contextMenuStripCopyToClipboard.Size = new Size(214, 26);
-			contextMenuStripCopyToClipboard.TabStop = true;
-			contextMenuStripCopyToClipboard.Text = "ContextMenu";
-			toolTip.SetToolTip(contextMenuStripCopyToClipboard, "Context Menu for copying to clipboard");
-			contextMenuStripCopyToClipboard.MouseEnter += SetStatusBar_Enter;
-			contextMenuStripCopyToClipboard.MouseLeave += ClearStatusBar_Leave;
-			// 
-			// ToolStripMenuItemCpyToClipboard
-			// 
-			ToolStripMenuItemCpyToClipboard.AccessibleDescription = "Copies the text/value to the clipboard";
-			ToolStripMenuItemCpyToClipboard.AccessibleName = "Copy to clipboard";
-			ToolStripMenuItemCpyToClipboard.AccessibleRole = AccessibleRole.MenuItem;
-			ToolStripMenuItemCpyToClipboard.AutoToolTip = true;
-			ToolStripMenuItemCpyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
-			ToolStripMenuItemCpyToClipboard.Name = "ToolStripMenuItemCpyToClipboard";
-			ToolStripMenuItemCpyToClipboard.ShortcutKeyDisplayString = "Strg+C";
-			ToolStripMenuItemCpyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
-			ToolStripMenuItemCpyToClipboard.Size = new Size(213, 22);
-			ToolStripMenuItemCpyToClipboard.Text = "&Copy to clipboard";
-			ToolStripMenuItemCpyToClipboard.Click += CopyToClipboard_DoubleClick;
-			ToolStripMenuItemCpyToClipboard.MouseEnter += SetStatusBar_Enter;
-			ToolStripMenuItemCpyToClipboard.MouseLeave += ClearStatusBar_Leave;
-			// 
 			// panel
 			// 
 			panel.AccessibleDescription = "Groups the data";
@@ -307,10 +307,9 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Program information";
 			toolTip.SetToolTip(this, "Program information");
-			FormClosed += AppInfoForm_FormClosed;
 			Load += AppInfoForm_Load;
-			((ISupportInitialize)pictureBoxBanner).EndInit();
 			contextMenuStripCopyToClipboard.ResumeLayout(false);
+			((ISupportInitialize)pictureBoxBanner).EndInit();
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);
 			panel.PerformLayout();

--- a/Forms/AppInfoForm.cs
+++ b/Forms/AppInfoForm.cs
@@ -118,17 +118,6 @@ public partial class AppInfoForm : BaseKryptonForm
 		ClearStatusBar();
 	}
 
-	/// <summary>
-	/// Fired when the application info form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void AppInfoForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/CheckAstorbDatForm.Designer.cs
+++ b/Forms/CheckAstorbDatForm.Designer.cs
@@ -387,7 +387,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Check ASTORB.DAT";
 			toolTip.SetToolTip(this, "Check ASTORB.DAT");
-			FormClosed += CheckAstorbDatForm_FormClosed;
 			Load += CheckAstorbDatForm_Load;
 			contextMenuCopyToClipboard.ResumeLayout(false);
 			tableLayoutPanel.ResumeLayout(false);

--- a/Forms/CheckAstorbDatForm.cs
+++ b/Forms/CheckAstorbDatForm.cs
@@ -226,16 +226,6 @@ public partial class CheckAstorbDatForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>
-	/// Event handler for closing the form.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void CheckAstorbDatForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/CheckMpcorbDatForm.Designer.cs
+++ b/Forms/CheckMpcorbDatForm.Designer.cs
@@ -387,7 +387,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Check MPCORB.DAT";
 			toolTip.SetToolTip(this, "Check MPCORB.DAT");
-			FormClosed += CheckMpcorbDatForm_FormClosed;
 			Load += CheckMpcorbDatForm_Load;
 			contextMenuCopyToClipboard.ResumeLayout(false);
 			tableLayoutPanel.ResumeLayout(false);

--- a/Forms/CheckMpcorbDatForm.cs
+++ b/Forms/CheckMpcorbDatForm.cs
@@ -226,16 +226,6 @@ public partial class CheckMpcorbDatForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>
-	/// Event handler for closing the form.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void CheckMpcorbDatForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/CopyDataToClipboardForm.Designer.cs
+++ b/Forms/CopyDataToClipboardForm.Designer.cs
@@ -412,7 +412,7 @@ namespace Planetoid_DB
 			buttonFlags.MouseEnter += SetStatusBar_Enter;
 			buttonFlags.MouseLeave += ClearStatusBar_Leave;
 			// 
-			// buttonComputername
+			// buttonComputerName
 			// 
 			buttonComputerName.AccessibleDescription = "Copy to clipboard: Computer name";
 			buttonComputerName.AccessibleName = "Copy to clipboard: Computer name";
@@ -420,7 +420,7 @@ namespace Planetoid_DB
 			buttonComputerName.ButtonStyle = ButtonStyle.Form;
 			buttonComputerName.Location = new Point(327, 264);
 			buttonComputerName.Margin = new Padding(4, 3, 4, 3);
-			buttonComputerName.Name = "buttonComputername";
+			buttonComputerName.Name = "buttonComputerName";
 			buttonComputerName.Size = new Size(306, 29);
 			buttonComputerName.TabIndex = 17;
 			toolTip.SetToolTip(buttonComputerName, "Computer name");
@@ -558,6 +558,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// CopyDataToClipboardForm
 			// 
@@ -567,6 +569,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(644, 399);
+			ControlBox = false;
 			Controls.Add(toolStripContainer);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
@@ -578,7 +581,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterScreen;
 			Text = "Copy data to clipboard";
 			toolTip.SetToolTip(this, "Copy data to clipboard");
-			FormClosed += CopyDataToClipboardForm_FormClosed;
 			Load += CopyDataToClipboardForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/CopyDataToClipboardForm.cs
+++ b/Forms/CopyDataToClipboardForm.cs
@@ -121,17 +121,6 @@ public partial class CopyDataToClipboardForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>
-	/// Fired when the CopyDataToClipboardForm is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void CopyDataToClipboardForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/CopyDerivedDataToClipboardForm.Designer.cs
+++ b/Forms/CopyDerivedDataToClipboardForm.Designer.cs
@@ -559,7 +559,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterScreen;
 			Text = "Copy derived data to clipboard";
 			toolTip.SetToolTip(this, "Copy derived data to clipboard");
-			FormClosed += CopyDerivedDataToClipboardForm_FormClosed;
 			Load += CopyDerivedDataToClipboardForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/CopyDerivedDataToClipboardForm.cs
+++ b/Forms/CopyDerivedDataToClipboardForm.cs
@@ -121,17 +121,6 @@ public partial class CopyDerivedDataToClipboardForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>
-	/// Fired when the CopyDerivedDataToClipboardForm is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void CopyDerivedDataToClipboardForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/DatabaseDifferencesForm.Designer.cs
+++ b/Forms/DatabaseDifferencesForm.Designer.cs
@@ -742,6 +742,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// DatabaseDifferencesForm
 			// 
@@ -751,6 +753,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(981, 545);
+			ControlBox = false;
 			Controls.Add(toolStripContainer);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
@@ -763,7 +766,6 @@ namespace Planetoid_DB
 			Text = "Database Differences";
 			toolTip.SetToolTip(this, "Database Differences");
 			UseWaitCursor = true;
-			FormClosed += DatabaseDifferencesForm_FormClosed;
 			Load += DatabaseDifferencesForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -108,16 +108,6 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 		ClearStatusBar();
 	}
 
-	/// <summary>
-	/// Handles the FormClosed event of the DatabaseDifferencesForm control.
-	/// </summary>
-	/// <param name="sender">The source of the event.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance containing the event data.</param>
-	/// <remarks>
-	/// This event is used to clean up resources when the form is closed.
-	/// </remarks>
-	private void DatabaseDifferencesForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region BackgroundWorker event handlers

--- a/Forms/DatabaseInformationForm.Designer.cs
+++ b/Forms/DatabaseInformationForm.Designer.cs
@@ -507,7 +507,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Database information";
 			toolTip.SetToolTip(this, "Database Information");
-			FormClosed += DatabaseInformationForm_FormClosed;
 			Load += DatabaseInformationForm_Load;
 			contextMenuCopyToClipboard.ResumeLayout(false);
 			tableLayoutPanel.ResumeLayout(false);

--- a/Forms/DatabaseInformationForm.cs
+++ b/Forms/DatabaseInformationForm.cs
@@ -134,18 +134,6 @@ public partial class DatabaseInformationForm : BaseKryptonForm
 		labelAttributesValue.Text = $"{fileInfo.Attributes}";
 	}
 
-	/// <summary>
-	/// Fired when the database information form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the database information form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </remarks>
-	private void DatabaseInformationForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/DerivedOrbitElementsForm.Designer.cs
+++ b/Forms/DerivedOrbitElementsForm.Designer.cs
@@ -1215,6 +1215,7 @@ namespace Planetoid_DB
 			contextMenuFullCopyToClipboardDerivedOrbitalElements.Font = new Font("Segoe UI", 9F);
 			contextMenuFullCopyToClipboardDerivedOrbitalElements.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardLinearEccentricity, menuitemCopyToClipboardSemiMinorAxis, menuitemCopyToClipboardMajorAxis, menuitemCopyToClipboardMinorAxis, menuitemCopyToClipboardEccentricAnomaly, menuitemCopyToClipboardTrueAnomaly, menuitemCopyToClipboardPerihelionDistance, menuitemCopyToClipboardAphelionDistance, menuitemCopyToClipboardLongitudeDescendingNode, menuitemCopyToClipboardArgumentAphelion, menuitemCopyToClipboardFocalParameter, menuitemCopyToClipboardSemiLatusRectum, menuitemCopyToClipboardLatusRectum, menuitemCopyToClipboardOrbitalPeriod, menuitemCopyToClipboardOrbitalArea, menuitemCopyToClipboardSemiMeanAxis, menuitemCopyToClipboardMeanAxis, menuitemCopyToClipboardStandardGravitationalParameter });
 			contextMenuFullCopyToClipboardDerivedOrbitalElements.Name = resources.GetString("contextMenuFullCopyToClipboardDerivedOrbitalElements.Name");
+			contextMenuFullCopyToClipboardDerivedOrbitalElements.OwnerItem = splitbuttonCopyToClipboard;
 			contextMenuFullCopyToClipboardDerivedOrbitalElements.Size = new Size(257, 400);
 			contextMenuFullCopyToClipboardDerivedOrbitalElements.Text = "Copy to clipboard";
 			toolTip.SetToolTip(contextMenuFullCopyToClipboardDerivedOrbitalElements, "Copy to clipboard");
@@ -1499,7 +1500,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Derived orbit elements";
 			toolTip.SetToolTip(this, "Derived orbit elements");
-			FormClosed += DerivedOrbitElementsForm_FormClosed;
 			Load += DerivedOrbitElementsForm_Load;
 			contextMenuOpenTerminology.ResumeLayout(false);
 			contextMenuCopyToClipboard.ResumeLayout(false);

--- a/Forms/DerivedOrbitElementsForm.cs
+++ b/Forms/DerivedOrbitElementsForm.cs
@@ -327,17 +327,6 @@ public partial class DerivedOrbitElementsForm : BaseKryptonForm
 		labelStandardGravitationalParameterData.Text = derivedOrbitElements[index: 18]?.ToString();
 	}
 
-	/// <summary>
-	/// Fired when the derived orbit elements form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the form is closed.
-	/// </remarks>
-	private void DerivedOrbitElementsForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/EphemerisForm.Designer.cs
+++ b/Forms/EphemerisForm.Designer.cs
@@ -316,6 +316,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// EphemerisForm
 			// 
@@ -325,6 +327,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(406, 453);
+			ControlBox = false;
 			Controls.Add(toolStripContainer);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
@@ -335,7 +338,6 @@ namespace Planetoid_DB
 			ShowInTaskbar = false;
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Ephemerides";
-			FormClosed += EphemerisForm_FormClosed;
 			Load += EphemerisForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();

--- a/Forms/EphemerisForm.cs
+++ b/Forms/EphemerisForm.cs
@@ -87,16 +87,6 @@ public partial class EphemerisForm : BaseKryptonForm
 	/// </remarks>
 	private void EphemerisForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Handles the form closed event.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to handle the form closed event.
-	/// </remarks>
-	private void EphemerisForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region BackgroundWorker event handlers

--- a/Forms/ExportDataSheetForm.Designer.cs
+++ b/Forms/ExportDataSheetForm.Designer.cs
@@ -328,7 +328,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterScreen;
 			Text = "Export data sheet";
 			toolTip.SetToolTip(this, "Export data sheet");
-			FormClosed += ExportDataSheetForm_FormClosed;
 			Load += ExportDataSheetForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();

--- a/Forms/ExportDataSheetForm.cs
+++ b/Forms/ExportDataSheetForm.cs
@@ -165,17 +165,6 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 		MarkAll(); // Mark all items in the list
 	}
 
-	/// <summary>
-	/// Fired when the export form is closed.
-	/// Releases managed resources and disposes the form instance.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to release any resources held by the form.
-	/// </remarks>
-	private void ExportDataSheetForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/FilterForm.Designer.cs
+++ b/Forms/FilterForm.Designer.cs
@@ -1490,7 +1490,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Filter";
 			toolTip.SetToolTip(this, "Filter");
-			FormClosed += FilterForm_FormClosed;
 			Load += FilterForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/FilterForm.cs
+++ b/Forms/FilterForm.cs
@@ -87,17 +87,6 @@ public partial class FilterForm : BaseKryptonForm
 	/// </remarks>
 	private void FilterForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Fired when the filter form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to release any resources held by the form.
-	/// </remarks>
-	private void FilterForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/LicenseForm.Designer.cs
+++ b/Forms/LicenseForm.Designer.cs
@@ -222,7 +222,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "License: GPL-3.0";
 			toolTip.SetToolTip(this, "License information");
-			FormClosed += LicenseForm_FormClosed;
 			Load += LicenseForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/LicenseForm.cs
+++ b/Forms/LicenseForm.cs
@@ -123,17 +123,6 @@ public partial class LicenseForm : BaseKryptonForm
 	/// </remarks>
 	private void LicenseForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Fired when the license form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to release any resources held by the form.
-	/// </remarks>
-	private void LicenseForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -543,7 +543,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "List of readable designations";
 			toolTip.SetToolTip(this, "List of readable designations ");
-			FormClosed += ListReadableDesignationsForm_FormClosed;
 			Load += ListReadableDesignationsForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -331,20 +331,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		numericUpDownMaximum.Value = planetoidsDatabase.Count;
 	}
 
-	/// <summary>
-	/// Fired when the form is closed. Releases list view resources and disposes the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	///	<remarks>
-	///	This method is used to release resources and perform cleanup when the form is closed.
-	/// </remarks>
-	private void ListReadableDesignationsForm_FormClosed(object? sender, FormClosedEventArgs? e)
-	{
-		listView.Dispose();
-		Dispose();
-	}
-
 	#endregion
 
 	#region click event handlers

--- a/Forms/PreloadForm.Designer.cs
+++ b/Forms/PreloadForm.Designer.cs
@@ -229,7 +229,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterScreen;
 			Text = "Planetoid-DB Preloader";
 			toolTip.SetToolTip(this, "Preloader");
-			FormClosed += PreloadForm_FormClosed;
 			Load += PreloadForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();

--- a/Forms/PreloadForm.cs
+++ b/Forms/PreloadForm.cs
@@ -148,17 +148,6 @@ public partial class PreloadForm : BaseKryptonForm
 	/// </remarks>
 	private void PreloadForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Fired when the preload form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the preload form is closed.
-	/// </remarks>
-	private void PreloadForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/PrintDataSheetForm.Designer.cs
+++ b/Forms/PrintDataSheetForm.Designer.cs
@@ -58,9 +58,10 @@ namespace Planetoid_DB
 			checkedListBoxOrbitalElements.FormattingEnabled = true;
 			checkedListBoxOrbitalElements.HorizontalScrollbar = true;
 			checkedListBoxOrbitalElements.Items.AddRange(new object[] { "Index No.", "Readable designation", "Epoch (in packed form, .0 TT)", "Mean anomaly at the epoch, in degrees", "Argument of perihelion, J2000.0 (degrees)", "Longitude of the ascending node, J2000.0", "Inclination to the ecliptic, J2000.0 (degrees)", "Orbital eccentricity", "Mean daily motion (degrees per day)", "Semimajor axis (AU)", "Absolute magnitude, H", "Slope parameter, G", "Reference", "Number of oppositions", "Number of observations", "Observation span", "r.m.s. residual (\")", "Computer name", "4-hexdigit flags", "Date of last observation", "Linear eccentricity", "Semi-minor axis", "Major axis", "Minor axis", "Eccenctric anomaly", "True anomaly", "Perihelion distance", "Aphelion distance", "Longitude of Descending node", "Argument of aphelion", "Focal parameter", "Semi-latus rectum", "Latus rectum", "Period", "Orbital area", "Orbital perimeter", "Semi-mean axis", "Mean axis", "Standard gravitational parameter" });
-			checkedListBoxOrbitalElements.Location = new Point(12, 12);
+			checkedListBoxOrbitalElements.Location = new Point(14, 14);
+			checkedListBoxOrbitalElements.Margin = new Padding(4, 3, 4, 3);
 			checkedListBoxOrbitalElements.Name = "checkedListBoxOrbitalElements";
-			checkedListBoxOrbitalElements.Size = new Size(280, 220);
+			checkedListBoxOrbitalElements.Size = new Size(327, 254);
 			checkedListBoxOrbitalElements.TabIndex = 0;
 			toolTip.SetToolTip(checkedListBoxOrbitalElements, "Checks some orbital elements to print on a data sheet");
 			checkedListBoxOrbitalElements.Enter += SetStatusBar_Enter;
@@ -73,9 +74,10 @@ namespace Planetoid_DB
 			buttonPrintDataSheet.AccessibleDescription = "Prints a data sheet with some orbit elements";
 			buttonPrintDataSheet.AccessibleName = "Print data sheet";
 			buttonPrintDataSheet.AccessibleRole = AccessibleRole.PushButton;
-			buttonPrintDataSheet.Location = new Point(12, 238);
+			buttonPrintDataSheet.Location = new Point(14, 275);
+			buttonPrintDataSheet.Margin = new Padding(4, 3, 4, 3);
 			buttonPrintDataSheet.Name = "buttonPrintDataSheet";
-			buttonPrintDataSheet.Size = new Size(132, 36);
+			buttonPrintDataSheet.Size = new Size(154, 42);
 			buttonPrintDataSheet.TabIndex = 1;
 			toolTip.SetToolTip(buttonPrintDataSheet, "Print a data sheet with some orbit elements");
 			buttonPrintDataSheet.Values.DropDownArrowColor = Color.Empty;
@@ -92,9 +94,10 @@ namespace Planetoid_DB
 			buttonCancelPrint.AccessibleDescription = "Cancels the print";
 			buttonCancelPrint.AccessibleName = "Cancel print";
 			buttonCancelPrint.AccessibleRole = AccessibleRole.PushButton;
-			buttonCancelPrint.Location = new Point(164, 238);
+			buttonCancelPrint.Location = new Point(191, 275);
+			buttonCancelPrint.Margin = new Padding(4, 3, 4, 3);
 			buttonCancelPrint.Name = "buttonCancelPrint";
-			buttonCancelPrint.Size = new Size(128, 36);
+			buttonCancelPrint.Size = new Size(149, 42);
 			buttonCancelPrint.TabIndex = 2;
 			toolTip.SetToolTip(buttonCancelPrint, "Cancel the print");
 			buttonCancelPrint.Values.DropDownArrowColor = Color.Empty;
@@ -117,9 +120,10 @@ namespace Planetoid_DB
 			panel.Controls.Add(buttonCancelPrint);
 			panel.Dock = DockStyle.Fill;
 			panel.Location = new Point(0, 0);
+			panel.Margin = new Padding(4, 3, 4, 3);
 			panel.Name = "panel";
 			panel.PanelBackStyle = PaletteBackStyle.FormMain;
-			panel.Size = new Size(306, 308);
+			panel.Size = new Size(357, 355);
 			panel.TabIndex = 0;
 			panel.TabStop = true;
 			// 
@@ -130,11 +134,12 @@ namespace Planetoid_DB
 			statusStrip.AccessibleRole = AccessibleRole.StatusBar;
 			statusStrip.Font = new Font("Segoe UI", 9F);
 			statusStrip.Items.AddRange(new ToolStripItem[] { labelInformation });
-			statusStrip.Location = new Point(0, 286);
+			statusStrip.Location = new Point(0, 333);
 			statusStrip.Name = "statusStrip";
+			statusStrip.Padding = new Padding(1, 0, 16, 0);
 			statusStrip.ProgressBars = null;
 			statusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
-			statusStrip.Size = new Size(306, 22);
+			statusStrip.Size = new Size(357, 22);
 			statusStrip.SizingGrip = false;
 			statusStrip.TabIndex = 3;
 			statusStrip.Text = "status bar";
@@ -155,19 +160,22 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// PrintDataSheetForm
 			// 
 			AccessibleDescription = "Prints a data sheet with some orbit elements";
 			AccessibleName = "Print data sheet";
 			AccessibleRole = AccessibleRole.Dialog;
-			AutoScaleDimensions = new SizeF(6F, 13F);
+			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
-			ClientSize = new Size(306, 308);
+			ClientSize = new Size(357, 355);
+			ControlBox = false;
 			Controls.Add(panel);
-			Font = new Font("Segoe UI", 8.5F);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
+			Margin = new Padding(4, 3, 4, 3);
 			MaximizeBox = false;
 			MinimizeBox = false;
 			Name = "PrintDataSheetForm";
@@ -175,7 +183,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Print data sheet";
 			toolTip.SetToolTip(this, "Print data sheet");
-			FormClosed += PrintDataSheetForm_FormClosed;
 			Load += PrintDataSheetForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/PrintDataSheetForm.cs
+++ b/Forms/PrintDataSheetForm.cs
@@ -123,17 +123,6 @@ public partial class PrintDataSheetForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>
-	/// Handles the FormClosed event of the form.
-	/// Disposes the form when it is closed.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the form is closed.
-	/// </remarks>
-	private void PrintDataSheetForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/RecordsMainForm.Designer.cs
+++ b/Forms/RecordsMainForm.Designer.cs
@@ -1207,6 +1207,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// RecordsMainForm
 			// 
@@ -1216,6 +1218,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(517, 532);
+			ControlBox = false;
 			Controls.Add(statusStrip);
 			Controls.Add(panel);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
@@ -1228,7 +1231,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Top ten records";
 			toolTip.SetToolTip(this, "Top ten records");
-			FormClosed += RecordsMainForm_FormClosed;
 			Load += RecordsMainForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/RecordsMainForm.cs
+++ b/Forms/RecordsMainForm.cs
@@ -104,17 +104,6 @@ public partial class RecordsMainForm : BaseKryptonForm
 	/// </remarks>
 	private void RecordsMainForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Handles the FormClosed event of the RecordsMainForm.
-	/// Disposes the form when it is closed.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the RecordsMainForm is closed.
-	/// </remarks>
-	private void RecordsMainForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/RecordsSelectionForm.Designer.cs
+++ b/Forms/RecordsSelectionForm.Designer.cs
@@ -469,6 +469,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// RecordsSelectionForm
 			// 
@@ -478,6 +480,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(649, 329);
+			ControlBox = false;
 			Controls.Add(panel);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
@@ -489,7 +492,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Top ten records";
 			toolTip.SetToolTip(this, "Top ten records");
-			FormClosed += RecordsSelectionForm_FormClosed;
 			Load += RecordsSelectionForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/RecordsSelectionForm.cs
+++ b/Forms/RecordsSelectionForm.cs
@@ -100,17 +100,6 @@ public partial class RecordsSelectionForm : BaseKryptonForm
 	/// </remarks>
 	private void RecordsSelectionForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Handles the FormClosed event of the RecordsSelectionForm.
-	/// Disposes the form when it is closed.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the RecordsSelectionForm is closed.
-	/// </remarks>
-	private void RecordsSelectionForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/SearchForm.Designer.cs
+++ b/Forms/SearchForm.Designer.cs
@@ -390,6 +390,8 @@ namespace Planetoid_DB
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// SearchForm
 			// 
@@ -399,6 +401,7 @@ namespace Planetoid_DB
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(387, 525);
+			ControlBox = false;
 			Controls.Add(panel);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
@@ -410,7 +413,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Search";
 			toolTip.SetToolTip(this, "Search");
-			FormClosed += SearchForm_FormClosed;
 			Load += SearchForm_Load;
 			((ISupportInitialize)panel).EndInit();
 			panel.ResumeLayout(false);

--- a/Forms/SearchForm.cs
+++ b/Forms/SearchForm.cs
@@ -398,13 +398,6 @@ public partial class SearchForm : BaseKryptonForm
 		ClearStatusBar();
 	}
 
-	/// <summary>
-	/// 
-	/// </summary>
-	/// <param name="sender"></param>
-	/// <param name="e"></param>
-	private void SearchForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region BackgroundWorker event handlers

--- a/Forms/SettingsForm.Designer.cs
+++ b/Forms/SettingsForm.Designer.cs
@@ -164,7 +164,7 @@ namespace Planetoid_DB
 			tabPageNavigator.Margin = new Padding(4, 3, 4, 3);
 			tabPageNavigator.Name = "tabPageNavigator";
 			tabPageNavigator.Padding = new Padding(4, 3, 4, 3);
-			tabPageNavigator.Size = new Size(495, 232);
+			tabPageNavigator.Size = new Size(495, 235);
 			tabPageNavigator.TabIndex = 0;
 			tabPageNavigator.Text = "Navigator";
 			tabPageNavigator.UseVisualStyleBackColor = true;
@@ -230,7 +230,7 @@ namespace Planetoid_DB
 			tabPageUpdate.Margin = new Padding(4, 3, 4, 3);
 			tabPageUpdate.Name = "tabPageUpdate";
 			tabPageUpdate.Padding = new Padding(4, 3, 4, 3);
-			tabPageUpdate.Size = new Size(495, 232);
+			tabPageUpdate.Size = new Size(495, 235);
 			tabPageUpdate.TabIndex = 1;
 			tabPageUpdate.Text = "MPCORB.DAT Update";
 			tabPageUpdate.UseVisualStyleBackColor = true;
@@ -261,7 +261,7 @@ namespace Planetoid_DB
 			tabPageLookAndFeel.Margin = new Padding(4, 3, 4, 3);
 			tabPageLookAndFeel.Name = "tabPageLookAndFeel";
 			tabPageLookAndFeel.Padding = new Padding(4, 3, 4, 3);
-			tabPageLookAndFeel.Size = new Size(495, 232);
+			tabPageLookAndFeel.Size = new Size(495, 235);
 			tabPageLookAndFeel.TabIndex = 2;
 			tabPageLookAndFeel.Text = "Look and feel";
 			tabPageLookAndFeel.UseVisualStyleBackColor = true;
@@ -504,7 +504,6 @@ namespace Planetoid_DB
 			ShowInTaskbar = false;
 			StartPosition = FormStartPosition.CenterScreen;
 			Text = "Settings";
-			FormClosed += SettingsForm_FormClosed;
 			Load += SettingsForm_Load;
 			tabControlSettings.ResumeLayout(false);
 			tabPageGeneral.ResumeLayout(false);

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -86,16 +86,6 @@ public partial class SettingsForm : BaseKryptonForm
 	/// </remarks>
 	private void SettingsForm_Load(object sender, EventArgs e) => ClearStatusBar();
 
-	/// <summary>
-	/// Event handler for closing the form.
-	/// </summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the SettingsForm is closed.
-	/// </remarks>
-	private void SettingsForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
-
 	#endregion
 
 	#region Enter event handlers

--- a/Forms/SplashScreenForm.Designer.cs
+++ b/Forms/SplashScreenForm.Designer.cs
@@ -35,11 +35,11 @@ namespace Planetoid_DB
 			ComponentResourceManager resources = new ComponentResourceManager(typeof(SplashScreenForm));
 			progressBarSplash = new KryptonProgressBar();
 			labelTitle = new Label();
+			contextMenuStripCopyToClipboard = new ContextMenuStrip(components);
+			ToolStripMenuItemCpyToClipboard = new ToolStripMenuItem();
 			labelVersion = new Label();
 			toolTip = new ToolTip(components);
 			kryptonManager = new KryptonManager(components);
-			contextMenuStripCopyToClipboard = new ContextMenuStrip(components);
-			ToolStripMenuItemCpyToClipboard = new ToolStripMenuItem();
 			contextMenuStripCopyToClipboard.SuspendLayout();
 			SuspendLayout();
 			// 
@@ -82,33 +82,6 @@ namespace Planetoid_DB
 			labelTitle.DoubleClick += CopyToClipboard_DoubleClick;
 			labelTitle.MouseDown += Control_MouseDown;
 			// 
-			// labelVersion
-			// 
-			labelVersion.AccessibleDescription = "Shows the version number";
-			labelVersion.AccessibleName = "Version";
-			labelVersion.AccessibleRole = AccessibleRole.Text;
-			labelVersion.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-			labelVersion.BackColor = Color.Transparent;
-			labelVersion.ContextMenuStrip = contextMenuStripCopyToClipboard;
-			labelVersion.Font = new Font("Segoe UI", 8.5F);
-			labelVersion.ForeColor = Color.White;
-			labelVersion.Location = new Point(223, 77);
-			labelVersion.Margin = new Padding(4, 0, 4, 0);
-			labelVersion.Name = "labelVersion";
-			labelVersion.Size = new Size(221, 25);
-			labelVersion.TabIndex = 1;
-			labelVersion.Text = "Version: X.X.X.X";
-			labelVersion.TextAlign = ContentAlignment.MiddleCenter;
-			toolTip.SetToolTip(labelVersion, "Version number");
-			labelVersion.DoubleClick += CopyToClipboard_DoubleClick;
-			labelVersion.MouseDown += Control_MouseDown;
-			// 
-			// kryptonManager
-			// 
-			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
-			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
-			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
-			// 
 			// contextMenuStripCopyToClipboard
 			// 
 			contextMenuStripCopyToClipboard.AccessibleDescription = "Shows context menu for some options";
@@ -141,6 +114,33 @@ namespace Planetoid_DB
 			ToolStripMenuItemCpyToClipboard.MouseEnter += SplashScreenForm_Load;
 			ToolStripMenuItemCpyToClipboard.MouseLeave += CopyToClipboard_DoubleClick;
 			// 
+			// labelVersion
+			// 
+			labelVersion.AccessibleDescription = "Shows the version number";
+			labelVersion.AccessibleName = "Version";
+			labelVersion.AccessibleRole = AccessibleRole.Text;
+			labelVersion.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+			labelVersion.BackColor = Color.Transparent;
+			labelVersion.ContextMenuStrip = contextMenuStripCopyToClipboard;
+			labelVersion.Font = new Font("Segoe UI", 8.5F);
+			labelVersion.ForeColor = Color.White;
+			labelVersion.Location = new Point(223, 77);
+			labelVersion.Margin = new Padding(4, 0, 4, 0);
+			labelVersion.Name = "labelVersion";
+			labelVersion.Size = new Size(221, 25);
+			labelVersion.TabIndex = 1;
+			labelVersion.Text = "Version: X.X.X.X";
+			labelVersion.TextAlign = ContentAlignment.MiddleCenter;
+			toolTip.SetToolTip(labelVersion, "Version number");
+			labelVersion.DoubleClick += CopyToClipboard_DoubleClick;
+			labelVersion.MouseDown += Control_MouseDown;
+			// 
+			// kryptonManager
+			// 
+			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+			// 
 			// SplashScreenForm
 			// 
 			AccessibleDescription = "Shows the splash screen and the loading progress of the data";
@@ -165,7 +165,6 @@ namespace Planetoid_DB
 			Text = "Splash Screen";
 			toolTip.SetToolTip(this, "splash screen");
 			TopMost = true;
-			FormClosed += SplashScreenForm_FormClosed;
 			Load += SplashScreenForm_Load;
 			contextMenuStripCopyToClipboard.ResumeLayout(false);
 			ResumeLayout(false);

--- a/Forms/SplashScreenForm.cs
+++ b/Forms/SplashScreenForm.cs
@@ -99,17 +99,6 @@ public partial class SplashScreenForm : BaseKryptonForm
 		// Set the version label text to the assembly version
 		labelVersion.Text = string.Format(format: I10nStrings.VersionTemplate, arg0: AssemblyInfo.AssemblyVersion);
 	}
-
-	/// <summary>
-	/// Fired when the splash screen form is closed.
-	/// Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the splash screen form is closed.
-	/// </remarks>
-	private void SplashScreenForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
 	#endregion
 
 	#region MouseDown event handlers

--- a/Forms/TableModeForm.Designer.cs
+++ b/Forms/TableModeForm.Designer.cs
@@ -43,9 +43,9 @@ namespace Planetoid_DB
 			labelMaximum = new KryptonLabel();
 			buttonList = new KryptonButton();
 			labelWarning = new Label();
-			buttonCancel = new KryptonButton();
 			contextMenuCopyToClipboard = new ContextMenuStrip(components);
 			ToolStripMenuItemCpyToClipboard = new ToolStripMenuItem();
+			buttonCancel = new KryptonButton();
 			listView = new ListView();
 			columnHeaderIndex = new ColumnHeader();
 			columnHeaderReadableDesignation = new ColumnHeader();
@@ -214,26 +214,6 @@ namespace Planetoid_DB
 			labelWarning.MouseEnter += SetStatusBar_Enter;
 			labelWarning.MouseLeave += ClearStatusBar_Leave;
 			// 
-			// buttonCancel
-			// 
-			buttonCancel.AccessibleDescription = "Cancels the progress";
-			buttonCancel.AccessibleName = "Cancel";
-			buttonCancel.AccessibleRole = AccessibleRole.PushButton;
-			buttonCancel.Location = new Point(408, 16);
-			buttonCancel.Margin = new Padding(4, 3, 4, 3);
-			buttonCancel.Name = "buttonCancel";
-			buttonCancel.Size = new Size(80, 36);
-			buttonCancel.TabIndex = 5;
-			toolTip.SetToolTip(buttonCancel, "Cancel the progress");
-			buttonCancel.Values.DropDownArrowColor = Color.Empty;
-			buttonCancel.Values.Image = FatcowIcons16px.fatcow_cancel_16px;
-			buttonCancel.Values.Text = "&Cancel";
-			buttonCancel.Click += ButtonCancel_Click;
-			buttonCancel.Enter += SetStatusBar_Enter;
-			buttonCancel.Leave += ClearStatusBar_Leave;
-			buttonCancel.MouseEnter += SetStatusBar_Enter;
-			buttonCancel.MouseLeave += ClearStatusBar_Leave;
-			// 
 			// contextMenuCopyToClipboard
 			// 
 			contextMenuCopyToClipboard.AccessibleDescription = "Shows context menu for some options";
@@ -265,6 +245,26 @@ namespace Planetoid_DB
 			ToolStripMenuItemCpyToClipboard.Click += CopyToClipboard_DoubleClick;
 			ToolStripMenuItemCpyToClipboard.MouseEnter += SetStatusBar_Enter;
 			ToolStripMenuItemCpyToClipboard.MouseLeave += ClearStatusBar_Leave;
+			// 
+			// buttonCancel
+			// 
+			buttonCancel.AccessibleDescription = "Cancels the progress";
+			buttonCancel.AccessibleName = "Cancel";
+			buttonCancel.AccessibleRole = AccessibleRole.PushButton;
+			buttonCancel.Location = new Point(408, 16);
+			buttonCancel.Margin = new Padding(4, 3, 4, 3);
+			buttonCancel.Name = "buttonCancel";
+			buttonCancel.Size = new Size(80, 36);
+			buttonCancel.TabIndex = 5;
+			toolTip.SetToolTip(buttonCancel, "Cancel the progress");
+			buttonCancel.Values.DropDownArrowColor = Color.Empty;
+			buttonCancel.Values.Image = FatcowIcons16px.fatcow_cancel_16px;
+			buttonCancel.Values.Text = "&Cancel";
+			buttonCancel.Click += ButtonCancel_Click;
+			buttonCancel.Enter += SetStatusBar_Enter;
+			buttonCancel.Leave += ClearStatusBar_Leave;
+			buttonCancel.MouseEnter += SetStatusBar_Enter;
+			buttonCancel.MouseLeave += ClearStatusBar_Leave;
 			// 
 			// listView
 			// 
@@ -488,7 +488,6 @@ namespace Planetoid_DB
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Table Mode";
 			toolTip.SetToolTip(this, "Table Mode");
-			FormClosed += TableModeForm_FormClosed;
 			Load += TableModeForm_Load;
 			contextMenuCopyToClipboard.ResumeLayout(false);
 			((ISupportInitialize)panel).EndInit();

--- a/Forms/TableModeForm.cs
+++ b/Forms/TableModeForm.cs
@@ -399,20 +399,6 @@ public partial class TableModeForm : BaseKryptonForm
 		numericUpDownMaximum.Value = planetoidsDatabase.Count;
 	}
 
-	/// <summary>
-	/// Fired when the form is closed. Releases list view resources and disposes the form.
-	/// </summary>
-	/// <param name="sender">Event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is called when the form is closed.
-	/// </remarks>
-	private void TableModeForm_FormClosed(object sender, FormClosedEventArgs e)
-	{
-		listView.Dispose();
-		Dispose();
-	}
-
 	#endregion
 
 	#region BackgroundWorker

--- a/Forms/TerminologyForm.Designer.cs
+++ b/Forms/TerminologyForm.Designer.cs
@@ -67,11 +67,13 @@ namespace Planetoid_DB
 			// toolStripContainer.ContentPanel
 			// 
 			toolStripContainer.ContentPanel.Controls.Add(splitContainer);
-			toolStripContainer.ContentPanel.Size = new Size(609, 503);
+			toolStripContainer.ContentPanel.Margin = new Padding(4, 3, 4, 3);
+			toolStripContainer.ContentPanel.Size = new Size(710, 584);
 			toolStripContainer.Dock = DockStyle.Fill;
 			toolStripContainer.Location = new Point(0, 0);
+			toolStripContainer.Margin = new Padding(4, 3, 4, 3);
 			toolStripContainer.Name = "toolStripContainer";
-			toolStripContainer.Size = new Size(609, 525);
+			toolStripContainer.Size = new Size(710, 606);
 			toolStripContainer.TabIndex = 5;
 			toolStripContainer.Text = "toolStripContainer";
 			toolTip.SetToolTip(toolStripContainer, "Container to arrange the toolbars");
@@ -90,7 +92,7 @@ namespace Planetoid_DB
 			statusStrip.ProgressBars = null;
 			statusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
 			statusStrip.ShowItemToolTips = true;
-			statusStrip.Size = new Size(609, 22);
+			statusStrip.Size = new Size(710, 22);
 			statusStrip.TabIndex = 4;
 			statusStrip.Text = "status bar";
 			// 
@@ -115,6 +117,7 @@ namespace Planetoid_DB
 			splitContainer.ContainerBackStyle = PaletteBackStyle.FormMain;
 			splitContainer.Dock = DockStyle.Fill;
 			splitContainer.Location = new Point(0, 0);
+			splitContainer.Margin = new Padding(4, 3, 4, 3);
 			// 
 			// 
 			// 
@@ -124,8 +127,8 @@ namespace Planetoid_DB
 			// 
 			splitContainer.Panel2.Controls.Add(webBrowser);
 			splitContainer.SeparatorStyle = SeparatorStyle.HighProfile;
-			splitContainer.Size = new Size(609, 503);
-			splitContainer.SplitterDistance = 263;
+			splitContainer.Size = new Size(710, 584);
+			splitContainer.SplitterDistance = 306;
 			splitContainer.TabIndex = 8;
 			toolTip.SetToolTip(splitContainer, "Splits the pane in half with the list of terms you can look up and in the other half with the web browser");
 			// 
@@ -138,8 +141,9 @@ namespace Planetoid_DB
 			listBox.Dock = DockStyle.Fill;
 			listBox.Items.AddRange(new object[] { "Index No.", "Readable designation", "Epoch (in packed form, .0 TT)", "Mean anomaly at the epoch", "Argument of perihelion, J2000.0", "Longitude of the ascending node, J2000.0", "Inclination to the ecliptic, J2000.0", "Orbital eccentricity", "Mean daily motion", "Semi-major axis", "Absolute magnitude, H", "Slope parameter, G", "Reference", "Number of oppositions", "Number of observations", "Observation span", "r.m.s. residual", "Computer name", "4-hexdigit flags", "Date of last observation", "Linear eccentricity", "Semi-minor axis", "Major axis", "Minor axis", "Eccenctric anomaly", "True anomaly", "Perihelion distance", "Aphelion distance", "Longitude of the descending node", "Argument of aphelion", "Focal parameter", "Semi-latus rectum", "Latus rectum", "Orbital period", "Orbital area", "Orbital perimeter", "Semi-mean axis", "Mean axis", "Standard gravitational parameter" });
 			listBox.Location = new Point(0, 0);
+			listBox.Margin = new Padding(4, 3, 4, 3);
 			listBox.Name = "listBox";
-			listBox.Size = new Size(263, 503);
+			listBox.Size = new Size(306, 584);
 			listBox.TabIndex = 7;
 			toolTip.SetToolTip(listBox, "Terms that can be looked up");
 			listBox.SelectedValueChanged += ListBox_SelectedValueChanged;
@@ -155,34 +159,37 @@ namespace Planetoid_DB
 			webBrowser.AccessibleRole = AccessibleRole.Document;
 			webBrowser.Dock = DockStyle.Fill;
 			webBrowser.Location = new Point(0, 0);
+			webBrowser.Margin = new Padding(4, 3, 4, 3);
 			webBrowser.Name = "webBrowser";
-			webBrowser.Size = new Size(341, 503);
+			webBrowser.Size = new Size(399, 584);
 			webBrowser.TabIndex = 1;
 			toolTip.SetToolTip(webBrowser, "Webbrowser");
 			// 
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 			// 
 			// TerminologyForm
 			// 
 			AccessibleDescription = "Informs about some definitions";
 			AccessibleName = "Terminology";
 			AccessibleRole = AccessibleRole.Window;
-			AutoScaleDimensions = new SizeF(6F, 13F);
+			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
-			ClientSize = new Size(609, 525);
+			ClientSize = new Size(710, 606);
+			ControlBox = false;
 			Controls.Add(toolStripContainer);
-			Font = new Font("Segoe UI", 8.5F);
 			FormBorderStyle = FormBorderStyle.SizableToolWindow;
 			Icon = (Icon)resources.GetObject("$this.Icon");
+			Margin = new Padding(4, 3, 4, 3);
 			MaximizeBox = false;
 			MinimizeBox = false;
 			Name = "TerminologyForm";
 			ShowInTaskbar = false;
 			StartPosition = FormStartPosition.CenterParent;
 			Text = "Terminology";
-			FormClosed += TerminologyForm_FormClosed;
 			Load += TerminologyForm_Load;
 			toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
 			toolStripContainer.BottomToolStripPanel.PerformLayout();

--- a/Forms/TerminologyForm.cs
+++ b/Forms/TerminologyForm.cs
@@ -468,15 +468,6 @@ public partial class TerminologyForm : BaseKryptonForm
 		ClearStatusBar();
 	}
 
-	/// <summary>
-	/// Fired when the form is closed. Disposes managed resources associated with the form.
-	/// </summary>
-	/// <param name="sender">The event source (the form).</param>
-	/// <param name="e">The <see cref="FormClosedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This event is triggered when the form is closed.
-	/// </remarks>
-	private void TerminologyForm_FormClosed(object sender, FormClosedEventArgs e) => Dispose();
 	#endregion
 
 	#region Enter event handlers


### PR DESCRIPTION
## Pull request overview

Removes redundant `FormClosed` handlers that explicitly disposed forms/controls, and updates multiple WinForms designer files (layout/scale tweaks and some form property changes).

**Changes:**
- Deleted `FormClosed` event handlers that called `Dispose()` (and in a few cases disposed child controls) across many forms.
- Removed `FormClosed += ...` wire-ups in designer files and applied various designer-driven layout/scale updates.
- Added/updated several form-level properties in designers (e.g., `ControlBox = false`) and Krypton `MessageBoxStrings` in some forms.

### Reviewed changes

Copilot reviewed 22 out of 44 changed files in this pull request and generated 2 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| Forms/TerminologyForm.cs | Removes `FormClosed` disposal handler. |
| Forms/TerminologyForm.Designer.cs | Removes `FormClosed` subscription; designer layout/property updates. |
| Forms/TableModeForm.cs | Removes `FormClosed` disposal handler (incl. `listView.Dispose()`). |
| Forms/TableModeForm.Designer.cs | Removes `FormClosed` subscription; minor designer reordering. |
| Forms/SplashScreenForm.cs | Removes `FormClosed` disposal handler. |
| Forms/SplashScreenForm.Designer.cs | Removes `FormClosed` subscription; designer reordering. |
| Forms/SettingsForm.cs | Removes `FormClosed` disposal handler. |
| Forms/SettingsForm.Designer.cs | Removes `FormClosed` subscription; minor layout size adjustments. |
| Forms/SearchForm.cs | Removes `FormClosed` disposal handler. |
| Forms/SearchForm.Designer.cs | Removes `FormClosed` subscription; adds Krypton strings + form property updates. |
| Forms/RecordsSelectionForm.cs | Removes `FormClosed` disposal handler. |
| Forms/RecordsSelectionForm.Designer.cs | Removes `FormClosed` subscription; adds Krypton strings + form property updates. |
| Forms/RecordsMainForm.cs | Removes `FormClosed` disposal handler. |
| Forms/RecordsMainForm.Designer.cs | Removes `FormClosed` subscription; adds Krypton strings + form property updates. |
| Forms/PrintDataSheetForm.cs | Removes `FormClosed` disposal handler. |
| Forms/PrintDataSheetForm.Designer.cs | Removes `FormClosed` subscription; designer layout/scale/property updates. |
| Forms/PreloadForm.cs | Removes `FormClosed` disposal handler. |
| Forms/PreloadForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/ListReadableDesignationsForm.cs | Removes `FormClosed` disposal handler (incl. `listView.Dispose()`). |
| Forms/ListReadableDesignationsForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/LicenseForm.cs | Removes `FormClosed` disposal handler. |
| Forms/LicenseForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/FilterForm.cs | Removes `FormClosed` disposal handler. |
| Forms/FilterForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/ExportDataSheetForm.cs | Removes `FormClosed` disposal handler. |
| Forms/ExportDataSheetForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/EphemerisForm.cs | Removes `FormClosed` disposal handler. |
| Forms/EphemerisForm.Designer.cs | Removes `FormClosed` subscription; adds Krypton strings + form property updates. |
| Forms/DerivedOrbitElementsForm.cs | Removes `FormClosed` disposal handler. |
| Forms/DerivedOrbitElementsForm.Designer.cs | Removes `FormClosed` subscription; sets context menu `OwnerItem`. |
| Forms/DatabaseInformationForm.cs | Removes `FormClosed` disposal handler. |
| Forms/DatabaseInformationForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/DatabaseDifferencesForm.cs | Removes `FormClosed` disposal handler. |
| Forms/DatabaseDifferencesForm.Designer.cs | Removes `FormClosed` subscription; adds Krypton strings + form property updates. |
| Forms/CopyDerivedDataToClipboardForm.cs | Removes `FormClosed` disposal handler. |
| Forms/CopyDerivedDataToClipboardForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/CopyDataToClipboardForm.cs | Removes `FormClosed` disposal handler. |
| Forms/CopyDataToClipboardForm.Designer.cs | Removes `FormClosed` subscription; fixes control `Name`; adds Krypton strings + form property updates. |
| Forms/CheckMpcorbDatForm.cs | Removes `FormClosed` disposal handler. |
| Forms/CheckMpcorbDatForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/CheckAstorbDatForm.cs | Removes `FormClosed` disposal handler. |
| Forms/CheckAstorbDatForm.Designer.cs | Removes `FormClosed` subscription. |
| Forms/AppInfoForm.cs | Removes `FormClosed` disposal handler. |
| Forms/AppInfoForm.Designer.cs | Removes `FormClosed` subscription; designer reordering for context menu/init calls. |
</details>


<details>
<summary>Files not reviewed (22)</summary>

* **Forms/AppInfoForm.Designer.cs**: Language not supported
* **Forms/CheckAstorbDatForm.Designer.cs**: Language not supported
* **Forms/CheckMpcorbDatForm.Designer.cs**: Language not supported
* **Forms/CopyDataToClipboardForm.Designer.cs**: Language not supported
* **Forms/CopyDerivedDataToClipboardForm.Designer.cs**: Language not supported
* **Forms/DatabaseDifferencesForm.Designer.cs**: Language not supported
* **Forms/DatabaseInformationForm.Designer.cs**: Language not supported
* **Forms/DerivedOrbitElementsForm.Designer.cs**: Language not supported
* **Forms/EphemerisForm.Designer.cs**: Language not supported
* **Forms/ExportDataSheetForm.Designer.cs**: Language not supported
* **Forms/FilterForm.Designer.cs**: Language not supported
* **Forms/LicenseForm.Designer.cs**: Language not supported
* **Forms/ListReadableDesignationsForm.Designer.cs**: Language not supported
* **Forms/PreloadForm.Designer.cs**: Language not supported
* **Forms/PrintDataSheetForm.Designer.cs**: Language not supported
* **Forms/RecordsMainForm.Designer.cs**: Language not supported
* **Forms/RecordsSelectionForm.Designer.cs**: Language not supported
* **Forms/SearchForm.Designer.cs**: Language not supported
* **Forms/SettingsForm.Designer.cs**: Language not supported
* **Forms/SplashScreenForm.Designer.cs**: Language not supported
* **Forms/TableModeForm.Designer.cs**: Language not supported
* **Forms/TerminologyForm.Designer.cs**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (11)</summary>

**Forms/CheckAstorbDatForm.cs:123**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			var response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckAstorbDatForm.cs:152**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckMpcorbDatForm.cs:123**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/CheckMpcorbDatForm.cs:152**
* Disposable 'HttpRequestMessage' is created but not disposed.
```
			HttpResponseMessage response = await Client.SendAsync(request: new HttpRequestMessage(method: HttpMethod.Head, requestUri: uri)).ConfigureAwait(continueOnCapturedContext: false);
```
**Forms/ListReadableDesignationsForm.cs:354**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderIndex = new()
		{
			Text = I10nStrings.Index,
			TextAlign = HorizontalAlignment.Right,
			Width = 100
		};
```
**Forms/ListReadableDesignationsForm.cs:361**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderReadableDesignation = new()
		{
			Text = "Readable Designation",
			TextAlign = HorizontalAlignment.Left,
			Width = 300
		};
```
**Forms/PrintDataSheetForm.cs:284**
* Disposable 'Font' is created but not disposed.
```
		Font printFont = new(familyName: "Arial", emSize: 12);
```
**Forms/ListReadableDesignationsForm.cs:349**
* Local scope variable 'columnHeaderIndex' shadows [ListReadableDesignationsForm.columnHeaderIndex](1).
```
		ColumnHeader columnHeaderIndex = new()
```
**Forms/ListReadableDesignationsForm.cs:356**
* Local scope variable 'columnHeaderReadableDesignation' shadows [ListReadableDesignationsForm.columnHeaderReadableDesignation](1).
```
		ColumnHeader columnHeaderReadableDesignation = new()
```
**Forms/TableModeForm.cs:537**
* Local scope variable 'listView' shadows [TableModeForm.listView](1).
**Forms/ListReadableDesignationsForm.cs:82**
* This variable is manually [disposed](1) in a [finally block](2) - consider a C# using statement as a preferable resource management technique.
```
	private CancellationTokenSource? _cancellationTokenSource;
```
</details>