### PR TITLE
Changed listview in virtual mode in TableModeForm() class

### DIFF
--- a/Forms/TableModeForm.Designer.cs
+++ b/Forms/TableModeForm.Designer.cs
@@ -286,6 +286,7 @@ namespace Planetoid_DB
 			listView.TabIndex = 8;
 			listView.UseCompatibleStateImageBehavior = false;
 			listView.View = View.Details;
+			listView.VirtualMode = true;
 			listView.SelectedIndexChanged += ListViewTableMode_SelectedIndexChanged;
 			listView.Enter += Control_Enter;
 			listView.Leave += Control_Leave;


### PR DESCRIPTION
## Pull request overview

This pull request converts the ListView in the TableModeForm class from standard mode to virtual mode, a performance optimization for displaying large datasets. Virtual mode allows the ListView to request items on-demand rather than storing all items in memory.

**Changes:**
- Added virtual mode support to ListView with on-demand item retrieval
- Replaced ListViewItem collection with a PlanetoidRecord cache for better memory efficiency
- Updated background processing to parse data into records instead of creating ListViewItems upfront

### Reviewed changes

Copilot reviewed 1 out of 2 changed files in this pull request and generated 7 comments.

| File | Description |
| ---- | ----------- |
| Forms/TableModeForm.cs | Implements virtual mode ListView with RetrieveVirtualItem handler, adds displayCache field, refactors ButtonList_ClickAsync to populate cache instead of ListView.Items, removes listView.Visible toggle from SetUiState |
| Forms/TableModeForm.Designer.cs | Enables VirtualMode property on ListView control |

<details>
<summary>Files not reviewed (1)</summary>

* **Forms/TableModeForm.Designer.cs**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (2)</summary>

**Forms/TableModeForm.cs:355**
* Local scope variable 'listView' shadows [TableModeForm.listView](1).
```
		if (sender is not ListView listView)
```
**Forms/TableModeForm.cs:460**
* This assignment to [progress](1) is useless, since its value is never read.
```
		Progress<int> progress = new(handler: percent =>
		{
			progressBar.Value = percent;
			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: percent, progressMax: 100);
		});
```
</details>

