### PR TITLE
Added some code improvements

### DIFF
--- a/Forms/DerivedOrbitElementsForm.cs
+++ b/Forms/DerivedOrbitElementsForm.cs
@@ -5,6 +5,8 @@ using Planetoid_DB.Forms;
 using System.Collections;
 using System.Diagnostics;
 
+using static Planetoid_DB.TerminologyForm;
+
 namespace Planetoid_DB;
 
 /// <summary>
@@ -169,53 +171,49 @@ public partial class DerivedOrbitElementsForm : BaseKryptonForm
 		// Create a new instance of the TerminologyForm and set the active terminology based on the index
 		using TerminologyForm formTerminology = new();
 		// Set the active terminology based on the index
-		switch (index)
+		formTerminology.SelectedElement = index switch
 		{
-			// Set the active terminology based on the index
-			// Each case corresponds to a specific terminology
-			// and calls the appropriate method in the TerminologyForm
-			case 0: formTerminology.SetIndexNumberActive(); break;
-			case 1: formTerminology.SetReadableDesignationActive(); break;
-			case 2: formTerminology.SetEpochActive(); break;
-			case 3: formTerminology.SetMeanAnomalyAtTheEpochActive(); break;
-			case 4: formTerminology.SetArgumentOfPerihelionActive(); break;
-			case 5: formTerminology.SetLongitudeOfTheAscendingNodeActive(); break;
-			case 6: formTerminology.SetInclinationToTheEclipticActive(); break;
-			case 7: formTerminology.SetOrbitalEccentricityActive(); break;
-			case 8: formTerminology.SetMeanDailyMotionActive(); break;
-			case 9: formTerminology.SetSemiMajorAxisActive(); break;
-			case 10: formTerminology.SetAbsoluteMagnitudeActive(); break;
-			case 11: formTerminology.SetSlopeParamActive(); break;
-			case 12: formTerminology.SetReferenceActive(); break;
-			case 13: formTerminology.SetNumberOfOppositionsActive(); break;
-			case 14: formTerminology.SetNumberOfObservationsActive(); break;
-			case 15: formTerminology.SetObservationSpanActive(); break;
-			case 16: formTerminology.SetRmsResidualActive(); break;
-			case 17: formTerminology.SetComputerNameActive(); break;
-			case 18: formTerminology.SetFlagsActive(); break;
-			case 19: formTerminology.SetDateOfTheLastObservationActive(); break;
-			case 20: formTerminology.SetLinearEccentricityActive(); break;
-			case 21: formTerminology.SetSemiMinorAxisActive(); break;
-			case 22: formTerminology.SetMajorAxisActive(); break;
-			case 23: formTerminology.SetMinorAxisActive(); break;
-			case 24: formTerminology.SetEccentricAnomalyActive(); break;
-			case 25: formTerminology.SetTrueAnomalyActive(); break;
-			case 26: formTerminology.SetPerihelionDistanceActive(); break;
-			case 27: formTerminology.SetAphelionDistanceActive(); break;
-			case 28: formTerminology.SetLongitudeOfTheDescendingNodeActive(); break;
-			case 29: formTerminology.SetArgumentOfTheAphelionActive(); break;
-			case 30: formTerminology.SetFocalParameterActive(); break;
-			case 31: formTerminology.SetSemiLatusRectumActive(); break;
-			case 32: formTerminology.SetLatusRectumActive(); break;
-			case 33: formTerminology.SetOrbitalPeriodActive(); break;
-			case 34: formTerminology.SetOrbitalAreaActive(); break;
-			case 35: formTerminology.SetOrbitalPerimeterActive(); break;
-			case 36: formTerminology.SetSemiMeanAxisActive(); break;
-			case 37: formTerminology.SetMeanAxisActive(); break;
-			case 38: formTerminology.SetStandardGravitationalParameterActive(); break;
-			// Default case to handle unexpected values
-			default: formTerminology.SetIndexNumberActive(); break;
-		}
+			0 => TerminologyElement.IndexNumber,
+			1 => TerminologyElement.ReadableDesignation,
+			2 => TerminologyElement.Epoch,
+			3 => TerminologyElement.MeanAnomalyAtTheEpoch,
+			4 => TerminologyElement.ArgumentOfThePerihelion,
+			5 => TerminologyElement.LongitudeOfTheAscendingNode,
+			6 => TerminologyElement.InclinationToTheEcliptic,
+			7 => TerminologyElement.OrbitalEccentricity,
+			8 => TerminologyElement.MeanDailyMotion,
+			9 => TerminologyElement.SemiMajorAxis,
+			10 => TerminologyElement.AbsoluteMagnitude,
+			11 => TerminologyElement.SlopeParameter,
+			12 => TerminologyElement.Reference,
+			13 => TerminologyElement.NumberOfOppositions,
+			14 => TerminologyElement.NumberOfObservations,
+			15 => TerminologyElement.ObservationSpan,
+			16 => TerminologyElement.RmsResidual,
+			17 => TerminologyElement.ComputerName,
+			18 => TerminologyElement.Flags,
+			19 => TerminologyElement.DateOfLastObservation,
+			20 => TerminologyElement.LinearEccentricity,
+			21 => TerminologyElement.SemiMinorAxis,
+			22 => TerminologyElement.MajorAxis,
+			23 => TerminologyElement.MinorAxis,
+			24 => TerminologyElement.EccentricAnomaly,
+			25 => TerminologyElement.TrueAnomaly,
+			26 => TerminologyElement.PerihelionDistance,
+			27 => TerminologyElement.AphelionDistance,
+			28 => TerminologyElement.LongitudeOfTheDescendingNode,
+			29 => TerminologyElement.ArgumentOfTheAphelion,
+			30 => TerminologyElement.FocalParameter,
+			31 => TerminologyElement.SemiLatusRectum,
+			32 => TerminologyElement.LatusRectum,
+			33 => TerminologyElement.OrbitalPeriod,
+			34 => TerminologyElement.OrbitalArea,
+			35 => TerminologyElement.OrbitalPerimeter,
+			36 => TerminologyElement.SemiMeanAxis,
+			37 => TerminologyElement.MeanAxis,
+			38 => TerminologyElement.StandardGravitationalParameter,
+			_ => TerminologyElement.IndexNumber,
+		};
 		// Set the form to be topmost if the main form is topmost
 		formTerminology.TopMost = TopMost;
 		// Show the terminology form as a dialog

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -15,6 +15,8 @@ using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Reflection;
 
+using static Planetoid_DB.TerminologyForm;
+
 namespace Planetoid_DB;
 
 /// <summary>
@@ -709,49 +711,49 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		// Create a new instance of the TerminologyForm
 		using TerminologyForm formTerminology = new();
 		// Set the active terminology based on the index
-		switch (index)
+		formTerminology.SelectedElement = index switch
 		{
-			case 0: formTerminology.SetIndexNumberActive(); break; // Index number
-			case 1: formTerminology.SetReadableDesignationActive(); break; // Readable designation
-			case 2: formTerminology.SetEpochActive(); break; // Epoch
-			case 3: formTerminology.SetMeanAnomalyAtTheEpochActive(); break; // Mean anomaly at the epoch
-			case 4: formTerminology.SetArgumentOfPerihelionActive(); break; // Argument of perihelion
-			case 5: formTerminology.SetLongitudeOfTheAscendingNodeActive(); break; // Longitude of the ascending node
-			case 6: formTerminology.SetInclinationToTheEclipticActive(); break; // Inclination to the ecliptic
-			case 7: formTerminology.SetOrbitalEccentricityActive(); break; // Orbital eccentricity
-			case 8: formTerminology.SetMeanDailyMotionActive(); break; // Mean daily motion
-			case 9: formTerminology.SetSemiMajorAxisActive(); break; // Semi-major axis
-			case 10: formTerminology.SetAbsoluteMagnitudeActive(); break; // Absolute magnitude
-			case 11: formTerminology.SetSlopeParamActive(); break; // Slope parameter
-			case 12: formTerminology.SetReferenceActive(); break; // Reference
-			case 13: formTerminology.SetNumberOfOppositionsActive(); break; // Number of oppositions
-			case 14: formTerminology.SetNumberOfObservationsActive(); break; // Number of observations
-			case 15: formTerminology.SetObservationSpanActive(); break; // Observation span
-			case 16: formTerminology.SetRmsResidualActive(); break; // r.m.s. residual
-			case 17: formTerminology.SetComputerNameActive(); break; // Computer name
-			case 18: formTerminology.SetFlagsActive(); break; // 4-hexdigit flags
-			case 19: formTerminology.SetDateOfTheLastObservationActive(); break; // Date of last observation
-			case 20: formTerminology.SetLinearEccentricityActive(); break; // Linear eccentricity
-			case 21: formTerminology.SetSemiMinorAxisActive(); break; // Semi-minor axis
-			case 22: formTerminology.SetMajorAxisActive(); break; // Major axis
-			case 23: formTerminology.SetMinorAxisActive(); break; // Minor axis
-			case 24: formTerminology.SetEccentricAnomalyActive(); break; // Eccentric anomaly
-			case 25: formTerminology.SetTrueAnomalyActive(); break; // True anomaly
-			case 26: formTerminology.SetPerihelionDistanceActive(); break; // Perihelion distance
-			case 27: formTerminology.SetAphelionDistanceActive(); break; // Aphelion distance
-			case 28: formTerminology.SetLongitudeOfTheDescendingNodeActive(); break; // Longitude of the descending node
-			case 29: formTerminology.SetArgumentOfTheAphelionActive(); break; // Argument of the aphelion
-			case 30: formTerminology.SetFocalParameterActive(); break; // Focal parameter
-			case 31: formTerminology.SetSemiLatusRectumActive(); break; // Semi-latus rectum
-			case 32: formTerminology.SetLatusRectumActive(); break; // Latus rectum
-			case 33: formTerminology.SetOrbitalPeriodActive(); break; // Orbital period
-			case 34: formTerminology.SetOrbitalAreaActive(); break; // Orbital area
-			case 35: formTerminology.SetOrbitalPerimeterActive(); break; // Orbital perimeter
-			case 36: formTerminology.SetSemiMeanAxisActive(); break; // Semi-mean axis
-			case 37: formTerminology.SetMeanAxisActive(); break; // Mean axis
-			case 38: formTerminology.SetStandardGravitationalParameterActive(); break; // Standard gravitational parameter
-			default: formTerminology.SetIndexNumberActive(); break; // Default to index number
-		}
+			0 => TerminologyElement.IndexNumber,
+			1 => TerminologyElement.ReadableDesignation,
+			2 => TerminologyElement.Epoch,
+			3 => TerminologyElement.MeanAnomalyAtTheEpoch,
+			4 => TerminologyElement.ArgumentOfThePerihelion,
+			5 => TerminologyElement.LongitudeOfTheAscendingNode,
+			6 => TerminologyElement.InclinationToTheEcliptic,
+			7 => TerminologyElement.OrbitalEccentricity,
+			8 => TerminologyElement.MeanDailyMotion,
+			9 => TerminologyElement.SemiMajorAxis,
+			10 => TerminologyElement.AbsoluteMagnitude,
+			11 => TerminologyElement.SlopeParameter,
+			12 => TerminologyElement.Reference,
+			13 => TerminologyElement.NumberOfOppositions,
+			14 => TerminologyElement.NumberOfObservations,
+			15 => TerminologyElement.ObservationSpan,
+			16 => TerminologyElement.RmsResidual,
+			17 => TerminologyElement.ComputerName,
+			18 => TerminologyElement.Flags,
+			19 => TerminologyElement.DateOfLastObservation,
+			20 => TerminologyElement.LinearEccentricity,
+			21 => TerminologyElement.SemiMinorAxis,
+			22 => TerminologyElement.MajorAxis,
+			23 => TerminologyElement.MinorAxis,
+			24 => TerminologyElement.EccentricAnomaly,
+			25 => TerminologyElement.TrueAnomaly,
+			26 => TerminologyElement.PerihelionDistance,
+			27 => TerminologyElement.AphelionDistance,
+			28 => TerminologyElement.LongitudeOfTheDescendingNode,
+			29 => TerminologyElement.ArgumentOfTheAphelion,
+			30 => TerminologyElement.FocalParameter,
+			31 => TerminologyElement.SemiLatusRectum,
+			32 => TerminologyElement.LatusRectum,
+			33 => TerminologyElement.OrbitalPeriod,
+			34 => TerminologyElement.OrbitalArea,
+			35 => TerminologyElement.OrbitalPerimeter,
+			36 => TerminologyElement.SemiMeanAxis,
+			37 => TerminologyElement.MeanAxis,
+			38 => TerminologyElement.StandardGravitationalParameter,
+			_ => TerminologyElement.IndexNumber,
+		};
 		// Set the TopMost property to true to keep the form on top of other windows
 		formTerminology.TopMost = TopMost;
 		// Show the terminology form as a modal dialog

--- a/Forms/TerminologyForm.TerminologyElement.cs
+++ b/Forms/TerminologyForm.TerminologyElement.cs
@@ -44,7 +44,7 @@ public partial class TerminologyForm
 		/// <remarks>
 		/// This field stores the argument of perihelion of the element.
 		/// </remarks>
-		ArgumentOfPerihelion,
+		ArgumentOfThePerihelion,
 		/// <summary>
 		/// Longitude of the ascending node of the element.
 		/// </summary>
@@ -219,7 +219,7 @@ public partial class TerminologyForm
 		/// <remarks>
 		/// This field stores the argument of aphelion of the element.
 		/// </remarks>
-		ArgumentOfAphelion,
+		ArgumentOfTheAphelion,
 		/// <summary>
 		/// Focal parameter of the element.
 		/// </summary>

--- a/Forms/TerminologyForm.cs
+++ b/Forms/TerminologyForm.cs
@@ -13,14 +13,6 @@ namespace Planetoid_DB;
 [DebuggerDisplay(value: "{" + nameof(GetDebuggerDisplay) + "(),nq}")]
 public partial class TerminologyForm : BaseKryptonForm
 {
-	/// <summary>
-	/// The currently selected terminology element.
-	/// </summary>
-	/// <remarks>
-	/// This field stores the currently selected terminology element.
-	/// </remarks>
-	private TerminologyElement selectedElement = TerminologyElement.IndexNumber;
-
 	#region constructor
 
 	/// <summary>
@@ -45,6 +37,51 @@ public partial class TerminologyForm : BaseKryptonForm
 	/// This method is used to provide a visual representation of the object in the debugger.
 	/// </remarks>
 	private string GetDebuggerDisplay() => ToString();
+
+	/// <summary>
+	/// Updates the content displayed in the web browser control.
+	/// </summary>
+	/// <remarks>
+	/// This method is used to update the web browser content based on the selected terminology element.
+	/// </remarks>
+	private void UpdateBrowserContent()
+	{
+		// Dynamically generate the resource name based on the selected element.
+		string resourceKey = $"terminology_{SelectedElement}";
+		// Try to load the text. Fallback to IndexNumber if not found.
+		// This is a trick to avoid a large switch statement.
+		string? text = I10nStrings.ResourceManager.GetString(name: resourceKey);
+		webBrowser.DocumentText = text ?? I10nStrings.terminology_IndexNumber;
+	}
+
+	/// <summary>
+	/// Retrieves or sets the currently selected terminology element.
+	/// Automatically updates the display when set.
+	/// </summary>
+	/// <value>The currently selected terminology element.</value>
+	/// <remarks>
+	/// This property is configured for code serialization.
+	/// </remarks>
+	[System.ComponentModel.DesignerSerializationVisibility(visibility: System.ComponentModel.DesignerSerializationVisibility.Visible)]
+	public TerminologyElement SelectedElement
+	{
+		get;
+		set
+		{
+			// Check if the value is different from the current field
+			if (field != value)
+			{
+				// Update the field and refresh the browser content
+				field = value;
+				UpdateBrowserContent();
+				// Update the list box selection if needed
+				if (listBox.SelectedIndex != (int)value)
+				{
+					listBox.SelectedIndex = (int)value;
+				}
+			}
+		}
+	} = TerminologyElement.IndexNumber;
 
 	/// <summary>
 	/// Sets the status bar text and enables the information label when text is provided.
@@ -89,13 +126,13 @@ public partial class TerminologyForm : BaseKryptonForm
 	private void SetActiveElement()
 	{
 		// Set the selected element in the list box
-		webBrowser.DocumentText = selectedElement switch
+		webBrowser.DocumentText = SelectedElement switch
 		{
 			TerminologyElement.IndexNumber => I10nStrings.terminology_IndexNumber,
-			TerminologyElement.ReadableDesignation => I10nStrings.terminology_ReadableDesignaton,
+			TerminologyElement.ReadableDesignation => I10nStrings.terminology_ReadableDesignation,
 			TerminologyElement.Epoch => I10nStrings.terminology_Epoch,
 			TerminologyElement.MeanAnomalyAtTheEpoch => I10nStrings.terminology_MeanAnomalyAtTheEpoch,
-			TerminologyElement.ArgumentOfPerihelion => I10nStrings.terminology_ArgumentOfPerihelion,
+			TerminologyElement.ArgumentOfThePerihelion => I10nStrings.terminology_ArgumentOfThePerihelion,
 			TerminologyElement.LongitudeOfTheAscendingNode => I10nStrings.terminology_LongitudeOfTheAscendingNode,
 			TerminologyElement.InclinationToTheEcliptic => I10nStrings.terminology_InclinationToTheEcliptic,
 			TerminologyElement.OrbitalEccentricity => I10nStrings.terminology_OrbitalEccentricity,
@@ -120,7 +157,7 @@ public partial class TerminologyForm : BaseKryptonForm
 			TerminologyElement.PerihelionDistance => I10nStrings.terminology_PerihelionDistance,
 			TerminologyElement.AphelionDistance => I10nStrings.terminology_AphelionDistance,
 			TerminologyElement.LongitudeOfTheDescendingNode => I10nStrings.terminology_LongitudeOfTheDescendingNode,
-			TerminologyElement.ArgumentOfAphelion => I10nStrings.terminology_ArgumentOfAphelion,
+			TerminologyElement.ArgumentOfTheAphelion => I10nStrings.terminology_ArgumentOfTheAphelion,
 			TerminologyElement.FocalParameter => I10nStrings.terminology_FocalParameter,
 			TerminologyElement.SemiLatusRectum => I10nStrings.terminology_SemiLatusRectum,
 			TerminologyElement.LatusRectum => I10nStrings.terminology_LatusRectum,
@@ -134,318 +171,6 @@ public partial class TerminologyForm : BaseKryptonForm
 			_ => I10nStrings.terminology_IndexNumber,
 		};
 	}
-
-	/// <summary>
-	/// Sets the selected element to IndexNumber.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to IndexNumber.
-	/// </remarks>
-	public void SetIndexNumberActive() => selectedElement = TerminologyElement.IndexNumber;
-
-	/// <summary>
-	/// Sets the selected element to ReadableDesignation.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to ReadableDesignation.
-	/// </remarks>
-	public void SetReadableDesignationActive() => selectedElement = TerminologyElement.ReadableDesignation;
-
-	/// <summary>
-	/// Sets the selected element to Epoch.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to Epoch.
-	/// </remarks>
-	public void SetEpochActive() => selectedElement = TerminologyElement.Epoch;
-
-	/// <summary>
-	/// Sets the selected element to MeanAnomalyAtTheEpoch.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to MeanAnomalyAtTheEpoch.
-	/// </remarks>
-	public void SetMeanAnomalyAtTheEpochActive() => selectedElement = TerminologyElement.MeanAnomalyAtTheEpoch;
-
-	/// <summary>
-	/// Sets the selected element to ArgumentOfPerihelion.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to ArgumentOfPerihelion.
-	/// </remarks>
-	public void SetArgumentOfPerihelionActive() => selectedElement = TerminologyElement.ArgumentOfPerihelion;
-
-	/// <summary>
-	/// Sets the selected element to LongitudeOfTheAscendingNode.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to LongitudeOfTheAscendingNode.
-	/// </remarks>
-	public void SetLongitudeOfTheAscendingNodeActive() => selectedElement = TerminologyElement.LongitudeOfTheAscendingNode;
-
-	/// <summary>
-	/// Sets the selected element to InclinationToTheEcliptic.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to InclinationToTheEcliptic.
-	/// </remarks>
-	public void SetInclinationToTheEclipticActive() => selectedElement = TerminologyElement.InclinationToTheEcliptic;
-
-	/// <summary>
-	/// Sets the selected element to OrbitalEccentricity.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to OrbitalEccentricity.
-	/// </remarks>
-	public void SetOrbitalEccentricityActive() => selectedElement = TerminologyElement.OrbitalEccentricity;
-
-	/// <summary>
-	/// Sets the selected element to MeanDailyMotion.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to MeanDailyMotion.
-	/// </remarks>
-	public void SetMeanDailyMotionActive() => selectedElement = TerminologyElement.MeanDailyMotion;
-
-	/// <summary>
-	/// Sets the selected element to SemiMajorAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to SemiMajorAxis.
-	/// </remarks>
-	public void SetSemiMajorAxisActive() => selectedElement = TerminologyElement.SemiMajorAxis;
-
-	/// <summary>
-	/// Sets the selected element to AbsoluteMagnitude.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to AbsoluteMagnitude.
-	/// </remarks>
-	public void SetAbsoluteMagnitudeActive() => selectedElement = TerminologyElement.AbsoluteMagnitude;
-
-	/// <summary>
-	/// Sets the selected element to SlopeParameter.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to SlopeParameter.
-	/// </remarks>
-	public void SetSlopeParamActive() => selectedElement = TerminologyElement.SlopeParameter;
-
-	/// <summary>
-	/// Sets the selected element to Reference.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to Reference.
-	/// </remarks>
-	public void SetReferenceActive() => selectedElement = TerminologyElement.Reference;
-
-	/// <summary>
-	/// Sets the selected element to NumberOfOppositions.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to NumberOfOppositions.
-	/// </remarks>
-	public void SetNumberOfOppositionsActive() => selectedElement = TerminologyElement.NumberOfOppositions;
-
-	/// <summary>
-	/// Sets the selected element to NumberOfObservations.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to NumberOfObservations.
-	/// </remarks>
-	public void SetNumberOfObservationsActive() => selectedElement = TerminologyElement.NumberOfObservations;
-
-	/// <summary>
-	/// Sets the selected element to ObservationSpan.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to ObservationSpan.
-	/// </remarks>
-	public void SetObservationSpanActive() => selectedElement = TerminologyElement.ObservationSpan;
-
-	/// <summary>
-	/// Sets the selected element to RmsResidual.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to RmsResidual.
-	/// </remarks>
-	public void SetRmsResidualActive() => selectedElement = TerminologyElement.RmsResidual;
-
-	/// <summary>
-	/// Sets the selected element to ComputerName.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to ComputerName.
-	/// </remarks>
-	public void SetComputerNameActive() => selectedElement = TerminologyElement.ComputerName;
-
-	/// <summary>
-	/// Sets the selected element to Flags.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to Flags.
-	/// </remarks>
-	public void SetFlagsActive() => selectedElement = TerminologyElement.Flags;
-
-	/// <summary>
-	/// Sets the selected element to DateOfLastObservation.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to DateOfLastObservation.
-	/// </remarks>
-	public void SetDateOfTheLastObservationActive() => selectedElement = TerminologyElement.DateOfLastObservation;
-
-	/// <summary>
-	/// Sets the selected element to LinearEccentricity.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to LinearEccentricity.
-	/// </remarks>
-	public void SetLinearEccentricityActive() => selectedElement = TerminologyElement.LinearEccentricity;
-
-	/// <summary>
-	/// Sets the selected element to SemiMinorAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to SemiMinorAxis.
-	/// </remarks>
-	public void SetSemiMinorAxisActive() => selectedElement = TerminologyElement.SemiMinorAxis;
-
-	/// <summary>
-	/// Sets the selected element to MajorAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to MajorAxis.
-	/// </remarks>
-	public void SetMajorAxisActive() => selectedElement = TerminologyElement.MajorAxis;
-
-	/// <summary>
-	/// Sets the selected element to MinorAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to MinorAxis.
-	/// </remarks>
-	public void SetMinorAxisActive() => selectedElement = TerminologyElement.MinorAxis;
-
-	/// <summary>
-	/// Sets the selected element to EccentricAnomaly.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to EccentricAnomaly.
-	/// </remarks>
-	public void SetEccentricAnomalyActive() => selectedElement = TerminologyElement.EccentricAnomaly;
-
-	/// <summary>
-	/// Sets the selected element to TrueAnomaly.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to TrueAnomaly.
-	/// </remarks>
-	public void SetTrueAnomalyActive() => selectedElement = TerminologyElement.TrueAnomaly;
-
-	/// <summary>
-	/// Sets the selected element to PerihelionDistance.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to PerihelionDistance.
-	/// </remarks>
-	public void SetPerihelionDistanceActive() => selectedElement = TerminologyElement.PerihelionDistance;
-
-	/// <summary>
-	/// Sets the selected element to AphelionDistance.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to AphelionDistance.
-	/// </remarks>
-	public void SetAphelionDistanceActive() => selectedElement = TerminologyElement.AphelionDistance;
-
-	/// <summary>
-	/// Sets the selected element to LongitudeOfTheDescendingNode.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to LongitudeOfTheDescendingNode.
-	/// </remarks>
-	public void SetLongitudeOfTheDescendingNodeActive() => selectedElement = TerminologyElement.LongitudeOfTheDescendingNode;
-
-	/// <summary>
-	/// Sets the selected element to ArgumentOfAphelion.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to ArgumentOfAphelion.
-	/// </remarks>
-	public void SetArgumentOfTheAphelionActive() => selectedElement = TerminologyElement.ArgumentOfAphelion;
-
-	/// <summary>
-	/// Sets the selected element to FocalParameter.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to FocalParameter.
-	/// </remarks>
-	public void SetFocalParameterActive() => selectedElement = TerminologyElement.FocalParameter;
-
-	/// <summary>
-	/// Sets the selected element to SemiLatusRectum.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to SemiLatusRectum.
-	/// </remarks>
-	public void SetSemiLatusRectumActive() => selectedElement = TerminologyElement.SemiLatusRectum;
-
-	/// <summary>
-	/// Sets the selected element to LatusRectum.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to LatusRectum.
-	/// </remarks>
-	public void SetLatusRectumActive() => selectedElement = TerminologyElement.LatusRectum;
-
-	/// <summary>
-	/// Sets the selected element to OrbitalPeriod.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to OrbitalPeriod.
-	/// </remarks>
-	public void SetOrbitalPeriodActive() => selectedElement = TerminologyElement.OrbitalPeriod;
-
-	/// <summary>
-	/// Sets the selected element to OrbitalArea.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to OrbitalArea.
-	/// </remarks>
-	public void SetOrbitalAreaActive() => selectedElement = TerminologyElement.OrbitalArea;
-
-	/// <summary>
-	/// Sets the selected element to OrbitalPerimeter.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to OrbitalPerimeter.
-	/// </remarks>
-	public void SetOrbitalPerimeterActive() => selectedElement = TerminologyElement.OrbitalPerimeter;
-
-	/// <summary>
-	/// Sets the selected element to SemiMeanAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to SemiMeanAxis.
-	/// </remarks>
-	public void SetSemiMeanAxisActive() => selectedElement = TerminologyElement.SemiMeanAxis;
-
-	/// <summary>
-	/// Sets the selected element to MeanAxis.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to MeanAxis.
-	/// </remarks>
-	public void SetMeanAxisActive() => selectedElement = TerminologyElement.MeanAxis;
-
-	/// <summary>
-	/// Sets the selected element to StandardGravitationalParameter.
-	/// </summary>
-	/// <remarks>
-	/// This method sets the selected element to StandardGravitationalParameter.
-	/// </remarks>
-	public void SetStandardGravitationalParameterActive() => selectedElement = TerminologyElement.StandardGravitationalParameter;
 
 	#endregion
 
@@ -531,9 +256,7 @@ public partial class TerminologyForm : BaseKryptonForm
 	private void ListBox_SelectedValueChanged(object sender, EventArgs e)
 	{
 		// Get the selected element from the list box
-		selectedElement = (TerminologyElement)listBox.SelectedIndex;
-		// Set the active element based on the selected value
-		SetActiveElement();
+		SelectedElement = (TerminologyElement)listBox.SelectedIndex;
 	}
 
 	#endregion

--- a/I10nStrings.Designer.cs
+++ b/I10nStrings.Designer.cs
@@ -416,61 +416,61 @@ namespace Planetoid_DB {
         ///		&lt;h1&gt;Argument of aphelion&lt;/h1&gt;
         ///		&lt;p&gt;The &lt;span class=&quot;bold&quot;&gt;argument of aphelion&lt;/span&gt; is the  [Rest der Zeichenfolge wurde abgeschnitten]&quot;; ähnelt.
         /// </summary>
-        internal static string terminology_ArgumentOfAphelion {
+        internal static string terminology_ArgumentOfTheAphelion {
             get {
-                return ResourceManager.GetString("terminology_ArgumentOfAphelion", resourceCulture);
+                return ResourceManager.GetString("terminology_ArgumentOfTheAphelion", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die &lt;!DOCTYPE html&gt;
-        ///&lt;html lang=&quot;en&quot;&gt;
-        ///	&lt;head&gt;
-        ///		&lt;meta charset=&quot;utf-8&quot;&gt;
-        ///		&lt;meta name=&quot;description&quot; content=&quot;&quot;&gt;
-        ///		&lt;meta name=&quot;keywords&quot; content=&quot;&quot;&gt;
-        ///		&lt;title&gt;Argument of perihelion, J2000.0 (degrees)&lt;/title&gt;
-        ///		&lt;style&gt;
-        ///			* {font-family:sans-serif;}
-        ///			.bold {font-weight: bold;}
-        ///			.italic {font-variant: italic;}
-        ///			.sup {vertical-align: super; font-size: smaller;}
-        ///			.sub {vertical-align: sub; font-size: smaller;}
-        ///		&lt;/style&gt;
-        ///	&lt;/head&gt;
-        ///	&lt;body&gt;
-        ///		&lt;h1&gt;Argument of perihelion, J2000.0 (degrees)&lt;/h1&gt;
-        ///		&lt;p&gt;The &lt;span class= [Rest der Zeichenfolge wurde abgeschnitten]&quot;; ähnelt.
-        /// </summary>
-        internal static string terminology_ArgumentOfPerihelion {
-            get {
-                return ResourceManager.GetString("terminology_ArgumentOfPerihelion", resourceCulture);
+
+		/// <summary>
+		///   Sucht eine lokalisierte Zeichenfolge, die &lt;!DOCTYPE html&gt;
+		///&lt;html lang=&quot;en&quot;&gt;
+		///	&lt;head&gt;
+		///		&lt;meta charset=&quot;utf-8&quot;&gt;
+		///		&lt;meta name=&quot;description&quot; content=&quot;&quot;&gt;
+		///		&lt;meta name=&quot;keywords&quot; content=&quot;&quot;&gt;
+		///		&lt;title&gt;Argument of perihelion, J2000.0 (degrees)&lt;/title&gt;
+		///		&lt;style&gt;
+		///			* {font-family:sans-serif;}
+		///			.bold {font-weight: bold;}
+		///			.italic {font-variant: italic;}
+		///			.sup {vertical-align: super; font-size: smaller;}
+		///			.sub {vertical-align: sub; font-size: smaller;}
+		///		&lt;/style&gt;
+		///	&lt;/head&gt;
+		///	&lt;body&gt;
+		///		&lt;h1&gt;Argument of perihelion, J2000.0 (degrees)&lt;/h1&gt;
+		///		&lt;p&gt;The &lt;span class= [Rest der Zeichenfolge wurde abgeschnitten]&quot;; ähnelt.
+		/// </summary>
+		internal static string terminology_ArgumentOfThePerihelion{
+			get {
+                return ResourceManager.GetString("terminology_ArgumentOfThePerihelion", resourceCulture);
             }
-        }
-        
-        /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die &lt;!DOCTYPE html&gt;
-        ///&lt;html lang=&quot;en&quot;&gt;
-        ///	&lt;head&gt;
-        ///		&lt;meta charset=&quot;utf-8&quot;&gt;
-        ///		&lt;meta name=&quot;description&quot; content=&quot;&quot;&gt;
-        ///		&lt;meta name=&quot;keywords&quot; content=&quot;&quot;&gt;
-        ///		&lt;title&gt;Computer name&lt;/title&gt;
-        ///		&lt;style&gt;
-        ///			* {font-family:sans-serif;}
-        ///			.bold {font-weight: bold;}
-        ///			.italic {font-variant: italic;}
-        ///			.sup {vertical-align: super; font-size: smaller;}
-        ///			.sub {vertical-align: sub; font-size: smaller;}
-        ///		&lt;/style&gt;
-        ///	&lt;/head&gt;
-        ///	&lt;body&gt;
-        ///		&lt;h1&gt;Computer name&lt;/h1&gt;
-        ///		&lt;p&gt;This is the computer name.&lt;/p&gt;
-        ///	&lt;/body&gt;
-        ///&lt;/html&gt; ähnelt.
-        /// </summary>
-        internal static string terminology_ComputerName {
+		}
+
+		/// <summary>
+		///   Sucht eine lokalisierte Zeichenfolge, die &lt;!DOCTYPE html&gt;
+		///&lt;html lang=&quot;en&quot;&gt;
+		///	&lt;head&gt;
+		///		&lt;meta charset=&quot;utf-8&quot;&gt;
+		///		&lt;meta name=&quot;description&quot; content=&quot;&quot;&gt;
+		///		&lt;meta name=&quot;keywords&quot; content=&quot;&quot;&gt;
+		///		&lt;title&gt;Computer name&lt;/title&gt;
+		///		&lt;style&gt;
+		///			* {font-family:sans-serif;}
+		///			.bold {font-weight: bold;}
+		///			.italic {font-variant: italic;}
+		///			.sup {vertical-align: super; font-size: smaller;}
+		///			.sub {vertical-align: sub; font-size: smaller;}
+		///		&lt;/style&gt;
+		///	&lt;/head&gt;
+		///	&lt;body&gt;
+		///		&lt;h1&gt;Computer name&lt;/h1&gt;
+		///		&lt;p&gt;This is the computer name.&lt;/p&gt;
+		///	&lt;/body&gt;
+		///&lt;/html&gt; ähnelt.
+		/// </summary>
+		internal static string terminology_ComputerName {
             get {
                 return ResourceManager.GetString("terminology_ComputerName", resourceCulture);
             }
@@ -1127,9 +1127,9 @@ namespace Planetoid_DB {
         ///		&lt;p&gt;This is the readable designation.&lt;/p&gt;
         ///  &lt;/bod [Rest der Zeichenfolge wurde abgeschnitten]&quot;; ähnelt.
         /// </summary>
-        internal static string terminology_ReadableDesignaton {
+        internal static string terminology_ReadableDesignation {
             get {
-                return ResourceManager.GetString("terminology_ReadableDesignaton", resourceCulture);
+                return ResourceManager.GetString("terminology_ReadableDesignation", resourceCulture);
             }
         }
         

--- a/I10nStrings.resx
+++ b/I10nStrings.resx
@@ -220,8 +220,8 @@
   <data name="terminology_ComputerName" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\TerminologyDocs\terminology_ComputerName.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
-  <data name="terminology_ReadableDesignaton" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\TerminologyDocs\terminology_ReadableDesignaton.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  <data name="terminology_ReadableDesignation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\TerminologyDocs\terminology_ReadableDesignation.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="terminology_Epoch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\TerminologyDocs\terminology_Epoch.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>

--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -902,6 +902,9 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resources\FatcowIcons16px.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>FatcowIcons16px.Designer.cs</LastGenOutput>


### PR DESCRIPTION
## Pull request overview

This PR improves code quality by fixing spelling errors in resource names, refactoring code to use modern C# patterns, and removing code duplication.

**Changes:**
- Fixed spelling: "ReadableDesignaton" → "ReadableDesignation", "ArgumentOfPerihelion/ArgumentOfAphelion" → "ArgumentOfThePerihelion/ArgumentOfTheAphelion"
- Refactored TerminologyForm to use a property with auto-notification instead of multiple setter methods and a private field
- Converted switch statements to switch expressions in PlanetoidDBForm and DerivedOrbitElementsForm

### Reviewed changes

Copilot reviewed 6 out of 7 changed files in this pull request and generated 4 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| Planetoid-DB.csproj | Disabled auto-code generation for Properties\Resources.resx |
| I10nStrings.resx | Corrected spelling of resource name and changed encoding to utf-8 |
| I10nStrings.Designer.cs | Updated property names to match corrected resource names |
| Forms/TerminologyForm.cs | Replaced private field and 40+ setter methods with a single property and UpdateBrowserContent method |
| Forms/TerminologyForm.TerminologyElement.cs | Renamed enum values to fix spelling |
| Forms/PlanetoidDBForm.cs | Converted switch statement to switch expression for terminology selection |
| Forms/DerivedOrbitElementsForm.cs | Converted switch statement to switch expression for terminology selection |
</details>


<details>
<summary>Files not reviewed (1)</summary>

* **I10nStrings.Designer.cs**: Language not supported
</details>