### PR TITLE
Added list export as sql script in the ListReadableDesignationForm class

### DIFF
--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -69,6 +69,7 @@ namespace Planetoid_DB
 			saveFileDialogSql = new SaveFileDialog();
 			saveFileDialogTsv = new SaveFileDialog();
 			saveFileDialogLatex = new SaveFileDialog();
+			toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
 			statusStrip.SuspendLayout();
 			contextMenuCopyToClipboard.SuspendLayout();
 			contextMenuSaveList.SuspendLayout();
@@ -314,9 +315,9 @@ namespace Planetoid_DB
 			contextMenuSaveList.AccessibleName = "Save list";
 			contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson });
+			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsSql });
 			contextMenuSaveList.Name = "contextMenuStrip1";
-			contextMenuSaveList.Size = new Size(193, 92);
+			contextMenuSaveList.Size = new Size(193, 114);
 			contextMenuSaveList.TabStop = true;
 			contextMenuSaveList.Text = "&Save List";
 			toolTip.SetToolTip(contextMenuSaveList, "Save List");
@@ -523,6 +524,22 @@ namespace Planetoid_DB
 			saveFileDialogLatex.DefaultExt = "tex";
 			saveFileDialogLatex.Filter = "Latex files|*.tex|all files|*.*";
 			// 
+			// toolStripMenuItemSaveAsSql
+			// 
+			toolStripMenuItemSaveAsSql.AccessibleDescription = "Save the list as SQL script";
+			toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+			toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsSql.AutoToolTip = true;
+			toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_script_16px;
+			toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+			toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+S";
+			toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.S;
+			toolStripMenuItemSaveAsSql.Size = new Size(192, 22);
+			toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
+			toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+			toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+			// 
 			// ListReadableDesignationsForm
 			// 
 			AccessibleDescription = "List readable designations";
@@ -593,5 +610,6 @@ namespace Planetoid_DB
 		private SaveFileDialog saveFileDialogSql;
 		private SaveFileDialog saveFileDialogTsv;
 		private SaveFileDialog saveFileDialogLatex;
+		private ToolStripMenuItem toolStripMenuItemSaveAsSql;
 	}
 }

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -516,11 +516,9 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Set taskbar progress to normal state
 		try
 		{
-			/*
 			// Start loading items asynchronously
 			token.ThrowIfCancellationRequested();
 			TaskbarProgress.SetState(windowHandle: Handle, taskbarState: TaskbarProgress.TaskbarStates.Normal);
-			*/
 			// Load items in a background task
 			List<ListViewItem> itemsToAdd = await Task.Run(function: () =>
 			{


### PR DESCRIPTION
## Pull request overview

This pull request adds SQL export functionality to the ListReadableDesignationsForm, allowing users to save the list of readable designations as a SQL script file. However, the PR also includes an unrelated change where code comments are removed.

**Changes:**
- Added a new menu item "Save as SQL" with Ctrl+S keyboard shortcut to the context menu for saving lists
- Implemented SQL export functionality that generates INSERT statements with proper SQL escaping
- Uncommented taskbar progress-related code (unrelated to SQL export feature)

### Reviewed changes

Copilot reviewed 1 out of 2 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| Forms/ListReadableDesignationsForm.cs | Uncommented taskbar progress code (unrelated to SQL export) |
| Forms/ListReadableDesignationsForm.Designer.cs | Added SQL export menu item with dialog and event handler wiring |

<details>
<summary>Files not reviewed (1)</summary>

* **Forms/ListReadableDesignationsForm.Designer.cs**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (5)</summary>

**Forms/ListReadableDesignationsForm.cs:483**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderIndex = new()
		{
			Text = I10nStrings.Index,
			TextAlign = HorizontalAlignment.Right,
			Width = 100
		};
```
**Forms/ListReadableDesignationsForm.cs:490**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderReadableDesignation = new()
		{
			Text = "Readable Designation",
			TextAlign = HorizontalAlignment.Left,
			Width = 300
		};
```
**Forms/ListReadableDesignationsForm.cs:478**
* Local scope variable 'columnHeaderIndex' shadows [ListReadableDesignationsForm.columnHeaderIndex](1).
```
		ColumnHeader columnHeaderIndex = new()
```
**Forms/ListReadableDesignationsForm.cs:485**
* Local scope variable 'columnHeaderReadableDesignation' shadows [ListReadableDesignationsForm.columnHeaderReadableDesignation](1).
```
		ColumnHeader columnHeaderReadableDesignation = new()
```
**Forms/ListReadableDesignationsForm.cs:81**
* This variable is manually [disposed](1) in a [finally block](2) - consider a C# using statement as a preferable resource management technique.
```
	private CancellationTokenSource? cancellationTokenSource;
```
</details>