### PR TITLE
Added list export as pdf and PostScript file in the ListReadableDesignationForm class

### DIFF
--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -56,6 +56,8 @@ namespace Planetoid_DB
 			toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
 			toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
 			toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
 			dropButtonSaveList = new KryptonDropButton();
 			panel = new KryptonPanel();
 			listView = new ListView();
@@ -71,6 +73,8 @@ namespace Planetoid_DB
 			saveFileDialogSql = new SaveFileDialog();
 			saveFileDialogTsv = new SaveFileDialog();
 			saveFileDialogLatex = new SaveFileDialog();
+			saveFileDialogPostScript = new SaveFileDialog();
+			saveFileDialogPdf = new SaveFileDialog();
 			statusStrip.SuspendLayout();
 			contextMenuCopyToClipboard.SuspendLayout();
 			contextMenuSaveList.SuspendLayout();
@@ -257,9 +261,9 @@ namespace Planetoid_DB
 			contextMenuSaveList.AccessibleName = "Save list";
 			contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql });
+			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript });
 			contextMenuSaveList.Name = "contextMenuStrip1";
-			contextMenuSaveList.Size = new Size(193, 202);
+			contextMenuSaveList.Size = new Size(193, 246);
 			contextMenuSaveList.TabStop = true;
 			contextMenuSaveList.Text = "&Save List";
 			toolTip.SetToolTip(contextMenuSaveList, "Save List");
@@ -409,6 +413,38 @@ namespace Planetoid_DB
 			toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 			toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
 			// 
+			// toolStripMenuItemSaveAsPdf
+			// 
+			toolStripMenuItemSaveAsPdf.AccessibleDescription = "Save the list as PDF";
+			toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+			toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+			toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+			toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "Strg+F";
+			toolStripMenuItemSaveAsPdf.ShortcutKeys = Keys.Control | Keys.F;
+			toolStripMenuItemSaveAsPdf.Size = new Size(192, 22);
+			toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
+			toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+			toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsPostScript
+			// 
+			toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Save the list as PostScript";
+			toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
+			toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+			toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+			toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "Strg+P";
+			toolStripMenuItemSaveAsPostScript.ShortcutKeys = Keys.Control | Keys.P;
+			toolStripMenuItemSaveAsPostScript.Size = new Size(192, 22);
+			toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
+			toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+			toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+			// 
 			// dropButtonSaveList
 			// 
 			dropButtonSaveList.AccessibleDescription = "Saves the list as file";
@@ -542,7 +578,17 @@ namespace Planetoid_DB
 			// saveFileDialogLatex
 			// 
 			saveFileDialogLatex.DefaultExt = "tex";
-			saveFileDialogLatex.Filter = "Latex files|*.tex|all files|*.*";
+			saveFileDialogLatex.Filter = "LaTex files|*.tex|all files|*.*";
+			// 
+			// saveFileDialogPostScript
+			// 
+			saveFileDialogPostScript.DefaultExt = "ps";
+			saveFileDialogPostScript.Filter = "PostScript files|*.ps|all files|*.*";
+			// 
+			// saveFileDialogPdf
+			// 
+			saveFileDialogPdf.DefaultExt = "pdf";
+			saveFileDialogPdf.Filter = "PDF files|*.pdf|all files|*.*";
 			// 
 			// ListReadableDesignationsForm
 			// 
@@ -615,5 +661,9 @@ namespace Planetoid_DB
 		private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
 		private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
 		private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+		private SaveFileDialog saveFileDialogPostScript;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+		private SaveFileDialog saveFileDialogPdf;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
 	}
 }

--- a/Forms/ListReadableDesignationsForm.resx
+++ b/Forms/ListReadableDesignationsForm.resx
@@ -118,16 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>642, 55</value>
+    <value>781, 54</value>
   </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>543, 54</value>
+    <value>690, 54</value>
   </metadata>
   <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>326, 54</value>
+    <value>473, 54</value>
   </metadata>
   <metadata name="contextMenuSaveList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>159, 54</value>
+    <value>306, 54</value>
   </metadata>
   <metadata name="saveFileDialogCsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -142,7 +142,7 @@
     <value>321, 17</value>
   </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 54</value>
+    <value>164, 54</value>
   </metadata>
   <metadata name="saveFileDialogMarkdown.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>768, 17</value>
@@ -154,10 +154,19 @@
     <value>471, 17</value>
   </metadata>
   <metadata name="saveFileDialogTsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>751, 55</value>
+    <value>890, 54</value>
   </metadata>
   <metadata name="saveFileDialogLatex.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>886, 55</value>
+    <value>1035, 54</value>
+  </metadata>
+  <metadata name="saveFileDialogPostScript.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 91</value>
+  </metadata>
+  <metadata name="saveFileDialogPdf.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 54</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>118</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Forms/TableModeForm.cs
+++ b/Forms/TableModeForm.cs
@@ -97,8 +97,6 @@ public partial class TableModeForm : BaseKryptonForm
 		InitializeComponent();
 		// Enable virtual mode for the ListView
 		listView.VirtualMode = true;
-		// Set up the ListView for virtual mode
-		listView.RetrieveVirtualItem += ListView_RetrieveVirtualItem;
 		// Handle column click events for sorting
 		listView.ColumnClick += ListView_ColumnClick;
 	}


### PR DESCRIPTION
## Pull request overview

This PR adds PDF and PostScript export functionality to the ListReadableDesignationsForm class, allowing users to save planetoid designation lists in these additional formats alongside the existing export options (CSV, HTML, XML, JSON, YAML, SQL, Markdown, LaTeX).

**Changes:**
- Added two new export methods: PDF and PostScript file generation with manual format implementation
- Added new menu items and keyboard shortcuts (Ctrl+F for PDF, Ctrl+P for PostScript)
- Cleaned up unused code (removed stopwatch field, reorganized virtualListOffset field)
- Fixed LaTeX capitalization in file dialog filter

### Reviewed changes

Copilot reviewed 3 out of 4 changed files in this pull request and generated 15 comments.

| File | Description |
| ---- | ----------- |
| Forms/TableModeForm.cs | Removed ListView_RetrieveVirtualItem event handler registration (appears to be unintentional - breaks virtual mode) |
| Forms/ListReadableDesignationsForm.resx | Auto-generated position adjustments for designer controls to accommodate new save dialogs |
| Forms/ListReadableDesignationsForm.cs | Added PDF and PostScript export methods with helper functions for escaping special characters; removed unused stopwatch field; reorganized field declarations |
| Forms/ListReadableDesignationsForm.Designer.cs | Added two new menu items (Save as PDF, Save as PS) with keyboard shortcuts and corresponding SaveFileDialog components; fixed LaTeX capitalization |

<details>
<summary>Files not reviewed (1)</summary>

* **Forms/ListReadableDesignationsForm.Designer.cs**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (7)</summary>

**Forms/ListReadableDesignationsForm.cs:565**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderIndex = new()
		{
			Text = I10nStrings.Index,
			TextAlign = HorizontalAlignment.Right,
			Width = 100
		};
```
**Forms/ListReadableDesignationsForm.cs:571**
* Disposable 'ColumnHeader' is created but not disposed.
```
		ColumnHeader columnHeaderReadableDesignation = new()
		{
			Text = "Readable Designation",
			TextAlign = HorizontalAlignment.Left,
			Width = 300
		};
```
**Forms/ListReadableDesignationsForm.cs:560**
* Local scope variable 'columnHeaderIndex' shadows [ListReadableDesignationsForm.columnHeaderIndex](1).
```
		ColumnHeader columnHeaderIndex = new()
```
**Forms/ListReadableDesignationsForm.cs:566**
* Local scope variable 'columnHeaderReadableDesignation' shadows [ListReadableDesignationsForm.columnHeaderReadableDesignation](1).
```
		ColumnHeader columnHeaderReadableDesignation = new()
```
**Forms/TableModeForm.cs:467**
* Local scope variable 'listView' shadows [TableModeForm.listView](1).
```
		if (sender is not ListView listView)
```
**Forms/TableModeForm.cs:573**
* This assignment to [progress](1) is useless, since its value is never read.
```
		Progress<int> progress = new(handler: percent =>
		{
			progressBar.Value = percent;
			int taskbarPercent = count > 0 ? percent * 100 / count : 0;
			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: taskbarPercent, progressMax: 100);
		});
```
**Forms/TableModeForm.cs:41**
* This variable is manually [disposed](1) in a [finally block](2) - consider a C# using statement as a preferable resource management technique.
```
	private CancellationTokenSource? cancellationTokenSource;
```
</details>