### PR TITLE
Updated CHANGELOG for version 0.7.20.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Planetoid-DB 0.7.20.47
+
+* Updated screenshot in README.md by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/293
+* Updated CHANGELOG for version 0.7.19.46 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/294
+* Fix CHANGELOG grammar and remove WIP marker for v0.7.19.46 by @Copilot in https://github.com/mjohne/Planetoid-DB/pull/295
+* Added FormClosed event handler to ListReadableDesignationsForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/296
+* Added list export as sql script in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/297
+* Added list export as markdown in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/298
+* Added list export as yaml file in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/299
+* Added list export as TSV file in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/300
+* Added list export as Latex file in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/301
+* Added message box after list export in the ListReadableForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/302
+* Updated I10N resources for list exports by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/303
+* Improved listview in the ListReadableDesignationsForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/304
+* Added list export as pdf and PostScript file in the ListReadableDesignationForm class by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/305
+* Some improvements by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/306
+* Some improvements by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/307
+* Updated terms of the terminology by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/308
+* Updated NLog to version 6.1.0 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/309
+* Added WebView2 1.0.3719.77 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/310
+* Removed WebView2 1.0.3719.77 (just testing) by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/311
+* Updated to version 0.7.20.47 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/312
+
+**Full Changelog**: https://github.com/mjohne/Planetoid-DB/compare/0.7.19.46.291.1142...0.7.20.47.312.1185
+
+
 ## Planetoid-DB 0.7.19.46
 
 * Updated version number by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/254


### PR DESCRIPTION
## Pull request overview

This pull request updates the CHANGELOG to document version 0.7.20.47 of Planetoid-DB, adding a new release section with references to 20 merged pull requests.

**Changes:**
- Added new version section (0.7.20.47) with changelog entries for PRs #293-312
- Documented new features including list export functionality for multiple formats (SQL, Markdown, YAML, TSV, LaTeX, PDF, PostScript)
- Included dependency updates (NLog 6.1.0) and version updates