### PR TITLE
Updated HTML entities for argument of aphelion

### DIFF
--- a/Resources/TerminologyDocs/terminology_ArgumentOfTheAphelion.html
+++ b/Resources/TerminologyDocs/terminology_ArgumentOfTheAphelion.html
@@ -84,21 +84,21 @@ The argument of aphelion is defined as the angle:
 </ul>
 
 <p>
-It is usually denoted by <strong>ω<sub>a</sub></strong>.
+It is usually denoted by <strong>&omega;<sub>a</sub></strong>.
 </p>
 
 <span class="formula">
-0° ≤ ω<sub>a</sub> &lt; 360°
+0&deg; &le; &omega;<sub>a</sub> &lt; 360&deg;
 </span>
 
 <h2>4. Relation to the Argument of Perihelion</h2>
 <p>
-The argument of perihelion (<em>ω</em>) is one of the six classical Keplerian orbital elements. Since perihelion
+The argument of perihelion (<em>&omega;</em>) is one of the six classical Keplerian orbital elements. Since perihelion
 and aphelion are separated by 180 degrees along the orbit, the argument of aphelion is given by:
 </p>
 
 <span class="formula">
-ω<sub>a</sub> = ω + 180°  (mod 360°)
+&omega;<sub>a</sub> = &omega; + 180&deg;  (mod 360&deg;)
 </span>
 
 <p>
@@ -110,16 +110,16 @@ Thus, the argument of aphelion contains no independent information once the argu
 Let:
 </p>
 <ul>
-    <li><em>Ω</em> be the longitude of the ascending node</li>
-    <li><em>ω</em> be the argument of perihelion</li>
+    <li><em>&Omega;</em> be the longitude of the ascending node</li>
+    <li><em>&omega;</em> be the argument of perihelion</li>
 </ul>
 
 <p>
-Then the longitude of aphelion <em>ϖ<sub>a</sub></em> is:
+Then the longitude of aphelion <em>&piv;<sub>a</sub></em> is:
 </p>
 
 <span class="formula">
-ϖ<sub>a</sub> = Ω + ω + 180°
+&piv;<sub>a</sub> = &Omega; + &omega; + 180&deg;
 </span>
 
 <p>
@@ -149,7 +149,7 @@ as the latter is trivially derived.
         <td>Circular orbit; aphelion and perihelion undefined</td>
     </tr>
     <tr>
-        <td>i = 0°</td>
+        <td>i = 0&deg;</td>
         <td>Coplanar orbit; node undefined, argument loses meaning</td>
     </tr>
     <tr>


### PR DESCRIPTION
- Replaced literal Greek characters (ω, Ω, ϖ) with named HTML entities (ω, Ω, ϖ).
- Normalized degree notation to use &deg; and related entities (e.g., &le;) in formulas and table entries.