### PR TITLE
Fixed HTML entities in perihelion orbital speed document

### DIFF
--- a/Resources/TerminologyDocs/terminology_PerihelionOrbitalSpeed.html
+++ b/Resources/TerminologyDocs/terminology_PerihelionOrbitalSpeed.html
@@ -90,7 +90,7 @@ The perihelion orbital speed <em>v<sub>q</sub></em> is obtained from the
 </p>
 
 <span class="formula">
-v<sub>q</sub> = &Sqrt;( &my; ( 2/q &minus; 1/a ) )
+v<sub>q</sub> = &#8730;( &mu; ( 2/q &minus; 1/a ) )
 </span>
 
 <p>
@@ -98,7 +98,7 @@ Substituting for <em>q</em> yields:
 </p>
 
 <span class="formula">
-v<sub>q</sub> = &Sqrt;( &my; / a &middot; (1 + e) / (1 &minus; e) )
+v<sub>q</sub> = &#8730;( &mu; / a &middot; (1 + e) / (1 &minus; e) )
 </span>
 
 <h2>4. Relation to Aphelion Orbital Speed</h2>
@@ -107,7 +107,7 @@ The aphelion orbital speed <em>v<sub>Q</sub></em> is:
 </p>
 
 <span class="formula">
-v<sub>Q</sub> = &Sqrt;( &my; / a &middot; (1 &minus; e) / (1 + e) )
+v<sub>Q</sub> = &#8730;( &mu; / a &middot; (1 &minus; e) / (1 + e) )
 </span>
 
 <p>
@@ -164,7 +164,7 @@ Perihelion orbital speed is relevant in:
 <p>
 <strong>The perihelion orbital speed</strong> is the instantaneous velocity of a body at
 its minimum heliocentric distance. For an elliptical orbit, it is given by
-<em>v = &Sqrt;( &my; / a &middot; (1 + e) / (1 &minus; e) )</em> and represents the maximum orbital speed
+<em>v = &#8730;( &mu; / a &middot; (1 + e) / (1 &minus; e) )</em> and represents the maximum orbital speed
 along the trajectory.
 </p>
 


### PR DESCRIPTION
- Replaced literal minus signs with &minus; entity (correct)
- Replaced literal square root symbols with &Sqrt; entity (incorrect - should be &#8730;)
- Replaced literal mu symbols with &my; entity (incorrect - should be &mu;)
- Replaced literal middle dot with &middot; entity (correct)
- Replaced literal ≤ with &le; entity (correct)