### PR TITLE
Added list export as PSV file

### DIFF
--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -74,6 +74,8 @@ namespace Planetoid_DB
 			saveFileDialogLatex = new SaveFileDialog();
 			saveFileDialogPostScript = new SaveFileDialog();
 			saveFileDialogPdf = new SaveFileDialog();
+			saveFileDialogPsv = new SaveFileDialog();
+			toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
 			statusStrip.SuspendLayout();
 			contextMenuCopyToClipboard.SuspendLayout();
 			contextMenuSaveList.SuspendLayout();
@@ -277,9 +279,9 @@ namespace Planetoid_DB
 			contextMenuSaveList.AccessibleName = "Save list";
 			contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript });
+			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript });
 			contextMenuSaveList.Name = "contextMenuStrip1";
-			contextMenuSaveList.Size = new Size(193, 246);
+			contextMenuSaveList.Size = new Size(193, 268);
 			contextMenuSaveList.TabStop = true;
 			contextMenuSaveList.Text = "&Save List";
 			contextMenuSaveList.MouseEnter += Control_Enter;
@@ -342,6 +344,7 @@ namespace Planetoid_DB
 			toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 			toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
 			toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "Strg+T";
+			toolStripMenuItemSaveAsTsv.ShortcutKeys = Keys.Control | Keys.T;
 			toolStripMenuItemSaveAsTsv.Size = new Size(192, 22);
 			toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
 			toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
@@ -420,10 +423,10 @@ namespace Planetoid_DB
 			toolStripMenuItemSaveAsSql.AutoToolTip = true;
 			toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
 			toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
-			toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+S";
-			toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.S;
+			toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+Q";
+			toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.Q;
 			toolStripMenuItemSaveAsSql.Size = new Size(192, 22);
-			toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
+			toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
 			toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
 			toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 			toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
@@ -608,6 +611,28 @@ namespace Planetoid_DB
 			saveFileDialogPdf.DefaultExt = "pdf";
 			saveFileDialogPdf.Filter = "PDF files|*.pdf|all files|*.*";
 			// 
+			// saveFileDialogPsv
+			// 
+			saveFileDialogPsv.DefaultExt = "psv";
+			saveFileDialogPsv.Filter = "PSV files|*.psv|all files|*.*";
+			// 
+			// toolStripMenuItemSaveAsPsv
+			// 
+			toolStripMenuItemSaveAsPsv.AccessibleDescription = "Save the list as PSV file";
+			toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+			toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+			toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+			toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "Strg+V";
+			toolStripMenuItemSaveAsPsv.ShortcutKeys = Keys.Control | Keys.V;
+			toolStripMenuItemSaveAsPsv.Size = new Size(192, 22);
+			toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
+			toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+			toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+
+			// 
 			// ListReadableDesignationsForm
 			// 
 			AccessibleDescription = "List readable designations";
@@ -681,5 +706,7 @@ namespace Planetoid_DB
 		private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
 		private SaveFileDialog saveFileDialogPdf;
 		private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+		private SaveFileDialog saveFileDialogPsv;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
 	}
 }

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -849,6 +849,34 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	}
 
 	/// <summary>
+	/// Saves the list as a PSV (Pipe-Separated Values) file.
+	/// Ideal for spreadsheet applications.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>
+	/// This method is invoked when the user selects the "Save As PSV" menu item.
+	/// </remarks>
+	private void ToolStripMenuItemSaveAsPsv_Click(object? sender, EventArgs? e)
+	{
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogPsv, ext: "psv"))
+		{
+			return;
+		}
+		// Write the data to the PSV file
+		using StreamWriter streamWriter = new(path: saveFileDialogPsv.FileName, append: false, encoding: Encoding.UTF8);
+		// Write PSV header
+		streamWriter.WriteLine(value: "Index|Designation");
+		// Write each item
+		foreach ((string? index, string? name) in GetExportData())
+		{
+			streamWriter.WriteLine(value: $"{index}|{name}");
+		}
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
 	/// Saves the list as a LaTeX document.
 	/// </summary>
 	/// <param name="sender">Event source (the menu item).</param>

--- a/Forms/ListReadableDesignationsForm.resx
+++ b/Forms/ListReadableDesignationsForm.resx
@@ -127,7 +127,7 @@
     <value>306, 54</value>
   </metadata>
   <metadata name="saveFileDialogCsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>22, 18</value>
   </metadata>
   <metadata name="saveFileDialogJson.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>616, 17</value>
@@ -161,6 +161,9 @@
   </metadata>
   <metadata name="saveFileDialogPdf.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 54</value>
+  </metadata>
+  <metadata name="saveFileDialogPsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>199, 91</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>118</value>


### PR DESCRIPTION
- Added PSV export method with Ctrl+V shortcut, header row, and pipe delimiter
- Fixed TSV menu item to properly register Ctrl+T shortcut (previously only had display string)
- Changed SQL shortcut from Ctrl+S to Ctrl+Q and updated mnemonic from &SQL to S&QL