### PR TITLE
Moved save dialogs from designer file to code file

### DIFF
--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -71,19 +71,7 @@ namespace Planetoid_DB
 			listView = new ListView();
 			columnHeaderIndex = new ColumnHeader();
 			columnHeaderReadableDesignation = new ColumnHeader();
-			saveFileDialogCsv = new SaveFileDialog();
-			saveFileDialogJson = new SaveFileDialog();
-			saveFileDialogHtml = new SaveFileDialog();
-			saveFileDialogXml = new SaveFileDialog();
 			kryptonManager = new KryptonManager(components);
-			saveFileDialogMarkdown = new SaveFileDialog();
-			saveFileDialogYaml = new SaveFileDialog();
-			saveFileDialogSql = new SaveFileDialog();
-			saveFileDialogTsv = new SaveFileDialog();
-			saveFileDialogLatex = new SaveFileDialog();
-			saveFileDialogPostScript = new SaveFileDialog();
-			saveFileDialogPdf = new SaveFileDialog();
-			saveFileDialogPsv = new SaveFileDialog();
 			statusStrip.SuspendLayout();
 			contextMenuCopyToClipboard.SuspendLayout();
 			contextMenuSaveList.SuspendLayout();
@@ -289,7 +277,7 @@ namespace Planetoid_DB
 			contextMenuSaveList.Font = new Font("Segoe UI", 9F);
 			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsMobi });
 			contextMenuSaveList.Name = "contextMenuStrip1";
-			contextMenuSaveList.Size = new Size(216, 466);
+			contextMenuSaveList.Size = new Size(216, 444);
 			contextMenuSaveList.TabStop = true;
 			contextMenuSaveList.Text = "&Save List";
 			contextMenuSaveList.MouseEnter += Control_Enter;
@@ -702,71 +690,11 @@ namespace Planetoid_DB
 			columnHeaderReadableDesignation.Text = "Readable designation";
 			columnHeaderReadableDesignation.Width = 180;
 			// 
-			// saveFileDialogCsv
-			// 
-			saveFileDialogCsv.DefaultExt = "csv";
-			saveFileDialogCsv.Filter = "CSV files|*.csv|all files|*.*";
-			// 
-			// saveFileDialogJson
-			// 
-			saveFileDialogJson.DefaultExt = "json";
-			saveFileDialogJson.Filter = "JSON files|*.json|all files|*.*";
-			// 
-			// saveFileDialogHtml
-			// 
-			saveFileDialogHtml.DefaultExt = "html";
-			saveFileDialogHtml.Filter = "HTML files|*.html|all files|*.*";
-			// 
-			// saveFileDialogXml
-			// 
-			saveFileDialogXml.DefaultExt = "xml";
-			saveFileDialogXml.Filter = "XML files|*.xml|all files|*.*";
-			// 
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
-			// 
-			// saveFileDialogMarkdown
-			// 
-			saveFileDialogMarkdown.DefaultExt = "md";
-			saveFileDialogMarkdown.Filter = "Markdown files|*.md|all files|*.*";
-			// 
-			// saveFileDialogYaml
-			// 
-			saveFileDialogYaml.DefaultExt = "yaml";
-			saveFileDialogYaml.Filter = "YAML files|*.yaml|all files|*.*";
-			// 
-			// saveFileDialogSql
-			// 
-			saveFileDialogSql.DefaultExt = "sql";
-			saveFileDialogSql.Filter = "SQL script|*.sql|all files|*.*";
-			// 
-			// saveFileDialogTsv
-			// 
-			saveFileDialogTsv.DefaultExt = "tsv";
-			saveFileDialogTsv.Filter = "TSV files|*.tsv|all files|*.*";
-			// 
-			// saveFileDialogLatex
-			// 
-			saveFileDialogLatex.DefaultExt = "tex";
-			saveFileDialogLatex.Filter = "LaTex files|*.tex|all files|*.*";
-			// 
-			// saveFileDialogPostScript
-			// 
-			saveFileDialogPostScript.DefaultExt = "ps";
-			saveFileDialogPostScript.Filter = "PostScript files|*.ps|all files|*.*";
-			// 
-			// saveFileDialogPdf
-			// 
-			saveFileDialogPdf.DefaultExt = "pdf";
-			saveFileDialogPdf.Filter = "PDF files|*.pdf|all files|*.*";
-			// 
-			// saveFileDialogPsv
-			// 
-			saveFileDialogPsv.DefaultExt = "psv";
-			saveFileDialogPsv.Filter = "PSV files|*.psv|all files|*.*";
 			// 
 			// ListReadableDesignationsForm
 			// 
@@ -820,28 +748,16 @@ namespace Planetoid_DB
 		private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
 		private ToolStripMenuItem toolStripMenuItemSaveAsXml;
 		private ToolStripMenuItem toolStripMenuItemSaveAsJson;
-		private SaveFileDialog saveFileDialogCsv;
-		private SaveFileDialog saveFileDialogJson;
-		private SaveFileDialog saveFileDialogHtml;
-		private SaveFileDialog saveFileDialogXml;
 		private KryptonManager kryptonManager;
 		private ContextMenuStrip contextMenuCopyToClipboard;
 		private ToolStripMenuItem ToolStripMenuItemCopyToClipboard;
-		private SaveFileDialog saveFileDialogMarkdown;
-		private SaveFileDialog saveFileDialogYaml;
-		private SaveFileDialog saveFileDialogSql;
-		private SaveFileDialog saveFileDialogTsv;
-		private SaveFileDialog saveFileDialogLatex;
 		private ToolStripMenuItem toolStripMenuItemSaveAsSql;
 		private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
 		private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
 		private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
 		private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
-		private SaveFileDialog saveFileDialogPostScript;
 		private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
-		private SaveFileDialog saveFileDialogPdf;
 		private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
-		private SaveFileDialog saveFileDialogPsv;
 		private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
 		private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
 		private ToolStripMenuItem toolStripMenuItemSaveAsWord;

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -659,8 +659,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsCsv_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogCsv = new()
+		{
+			Filter = "Comma-separated values files (*.csv)|*.csv|All files (*.*)|*.*",
+			DefaultExt = "csv",
+			Title = "Save list as CSV"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogCsv, ext: "csv"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogCsv, ext: saveFileDialogCsv.DefaultExt))
 		{
 			return;
 		}
@@ -683,8 +690,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsHtml_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogHtml = new()
+		{
+			Filter = "HTML files (*.html)|*.html|All files (*.*)|*.*",
+			DefaultExt = "html",
+			Title = "Save list as HTML"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogHtml, ext: "html"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogHtml, ext: saveFileDialogHtml.DefaultExt))
 		{
 			return;
 		}
@@ -713,8 +727,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsXml_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogXml = new()
+		{
+			Filter = "XML files (*.xml)|*.xml|All files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save list as XML"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogXml, ext: "xml"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogXml, ext: saveFileDialogXml.DefaultExt))
 		{
 			return;
 		}
@@ -748,8 +769,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsJson_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogJson = new()
+		{
+			Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+			DefaultExt = "json",
+			Title = "Save list as JSON"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogJson, ext: "json"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogJson, ext: saveFileDialogJson.DefaultExt))
 		{
 			return;
 		}
@@ -772,8 +800,16 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsSql_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogSql = new()
+		{
+			Filter = "SQL files (*.sql)|*.sql|All files (*.*)|*.*",
+			DefaultExt = "sql",
+			Title = "Save list as SQL"
+		};
+
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogSql, ext: "sql"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogSql, ext: saveFileDialogSql.DefaultExt))
 		{
 			return;
 		}
@@ -817,8 +853,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsMarkdown_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogMarkdown = new()
+		{
+			Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+			DefaultExt = "md",
+			Title = "Save list as Markdown"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogMarkdown, ext: "md"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogMarkdown, ext: saveFileDialogMarkdown.DefaultExt))
 		{
 			return;
 		}
@@ -847,8 +890,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsYaml_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogYaml = new()
+		{
+			Filter = "YAML files (*.yaml)|*.yaml|All files (*.*)|*.*",
+			DefaultExt = "yaml",
+			Title = "Save list as YAML"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogYaml, ext: "yaml"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogYaml, ext: saveFileDialogYaml.DefaultExt))
 		{
 			return;
 		}
@@ -882,8 +932,16 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsTsv_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogTsv = new()
+		{
+			Filter = "Tab-separated values files (*.tsv)|*.tsv|All files (*.*)|*.*",
+			DefaultExt = "tsv",
+			Title = "Save list as TSV"
+		};
+
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogTsv, ext: "tsv"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogTsv, ext: saveFileDialogTsv.DefaultExt))
 		{
 			return;
 		}
@@ -910,8 +968,16 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsPsv_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogPsv = new()
+		{
+			Filter = "Pipe-separated values files (*.psv)|*.psv|All files (*.*)|*.*",
+			DefaultExt = "psv",
+			Title = "Save list as PSV"
+		};
+
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogPsv, ext: "psv"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogPsv, ext: saveFileDialogPsv.DefaultExt))
 		{
 			return;
 		}
@@ -937,7 +1003,14 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsLatex_Click(object? sender, EventArgs? e)
 	{
-		if (!PrepareSaveDialog(dialog: saveFileDialogLatex, ext: "tex"))
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogLatex = new()
+		{
+			Filter = "LaTeX files (*.tex)|*.tex|All files (*.*)|*.*",
+			DefaultExt = "tex",
+			Title = "Save list as LaTeX"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialogLatex, ext: saveFileDialogLatex.DefaultExt))
 		{
 			return;
 		}
@@ -981,8 +1054,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsPostScript_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogPostScript = new()
+		{
+			Filter = "PostScript files (*.ps)|*.ps|All files (*.*)|*.*",
+			DefaultExt = "ps",
+			Title = "Save list as PostScript"
+		};
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogPostScript, ext: "ps"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogPostScript, ext: saveFileDialogPostScript.DefaultExt))
 		{
 			return;
 		}
@@ -1062,8 +1142,16 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsPdf_Click(object? sender, EventArgs? e)
 	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogPdf = new()
+		{
+			Filter = "PDF files (*.pdf)|*.pdf|All files (*.*)|*.*",
+			DefaultExt = "pdf",
+			Title = "Save list as PDF"
+		};
+
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogPdf, ext: "pdf"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogPdf, ext: saveFileDialogPdf.DefaultExt))
 		{
 			return;
 		}
@@ -1233,7 +1321,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsEpub_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogEpub = new()
 		{
 			Filter = "EPUB files (*.epub)|*.epub|All files (*.*)|*.*",
@@ -1242,7 +1330,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogEpub, ext: "epub"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogEpub, ext: saveFileDialogEpub.DefaultExt))
 		{
 			return;
 		}
@@ -1364,7 +1452,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsWord_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogWord = new()
 		{
 			Filter = "Word documents (*.docx)|*.docx|All files (*.*)|*.*",
@@ -1373,7 +1461,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogWord, ext: "docx"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogWord, ext: saveFileDialogWord.DefaultExt))
 		{
 			return;
 		}
@@ -1462,7 +1550,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsExcel_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogExcel = new()
 		{
 			Filter = "Excel files (*.xlsx)|*.xlsx|All files (*.*)|*.*",
@@ -1471,7 +1559,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogExcel, ext: "xlsx"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogExcel, ext: saveFileDialogExcel.DefaultExt))
 		{
 			return;
 		}
@@ -1568,7 +1656,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsOdt_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogOdt = new()
 		{
 			Filter = "OpenDocument Text (*.odt)|*.odt|All files (*.*)|*.*",
@@ -1577,7 +1665,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogOdt, ext: "odt"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogOdt, ext: saveFileDialogOdt.DefaultExt))
 		{
 			return;
 		}
@@ -1660,7 +1748,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsOds_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogOds = new()
 		{
 			Filter = "OpenDocument Spreadsheet (*.ods)|*.ods|All files (*.*)|*.*",
@@ -1669,7 +1757,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogOds, ext: "ods"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogOds, ext: saveFileDialogOds.DefaultExt))
 		{
 			return;
 		}
@@ -1745,7 +1833,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsMobi_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogMobi = new()
 		{
 			Filter = "Mobi files (*.mobi)|*.mobi|All files (*.*)|*.*",
@@ -1754,7 +1842,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogMobi, ext: "mobi"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogMobi, ext: saveFileDialogMobi.DefaultExt))
 		{
 			return;
 		}
@@ -1920,7 +2008,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsRtf_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogRtf = new()
 		{
 			Filter = "Rich Text Format (*.rtf)|*.rtf|All files (*.*)|*.*",
@@ -1929,7 +2017,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogRtf, ext: "rtf"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogRtf, ext: saveFileDialogRtf.DefaultExt))
 		{
 			return;
 		}
@@ -1983,7 +2071,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// </remarks>
 	private void ToolStripMenuItemSaveAsText_Click(object? sender, EventArgs? e)
 	{
-		// Create a SaveFileDialog manually since it's not in the designer
+		// Create a SaveFileDialog manually
 		using SaveFileDialog saveFileDialogText = new()
 		{
 			Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
@@ -1992,7 +2080,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		};
 
 		// Prepare the save dialog
-		if (!PrepareSaveDialog(dialog: saveFileDialogText, ext: "txt"))
+		if (!PrepareSaveDialog(dialog: saveFileDialogText, ext: saveFileDialogText.DefaultExt))
 		{
 			return;
 		}

--- a/Forms/ListReadableDesignationsForm.resx
+++ b/Forms/ListReadableDesignationsForm.resx
@@ -118,55 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>690, 54</value>
+    <value>543, 17</value>
   </metadata>
   <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>473, 54</value>
+    <value>326, 17</value>
   </metadata>
   <metadata name="contextMenuSaveList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>306, 54</value>
-  </metadata>
-  <metadata name="saveFileDialogCsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>22, 18</value>
-  </metadata>
-  <metadata name="saveFileDialogJson.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>616, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogHtml.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>165, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogXml.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>321, 17</value>
+    <value>159, 17</value>
   </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>164, 54</value>
-  </metadata>
-  <metadata name="saveFileDialogMarkdown.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>768, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogYaml.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>954, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogSql.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>471, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogTsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>799, 54</value>
-  </metadata>
-  <metadata name="saveFileDialogLatex.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>944, 54</value>
-  </metadata>
-  <metadata name="saveFileDialogPostScript.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1101, 56</value>
-  </metadata>
-  <metadata name="saveFileDialogPdf.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 54</value>
-  </metadata>
-  <metadata name="saveFileDialogPsv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1101, 13</value>
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>93</value>
+    <value>55</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
is PR moves `SaveFileDialog` configuration out of the WinForms designer artifacts and into the `ListReadableDesignationsForm` code-behind, aligning all export actions to create dialogs programmatically.

**Changes:**
- Removed designer-managed `SaveFileDialog` components and their `.resx` tray metadata.
- Added per-export local `SaveFileDialog` creation (Filter/DefaultExt/Title) in the corresponding menu click handlers.
- Updated `PrepareSaveDialog(...)` calls to derive the extension from `SaveFileDialog.DefaultExt`.