### PR TITLE
Added information export in DatabaseInformationForm

### DIFF
--- a/Forms/DatabaseInformationForm.Designer.cs
+++ b/Forms/DatabaseInformationForm.Designer.cs
@@ -37,7 +37,7 @@ namespace Planetoid_DB
 			components = new Container();
 			ComponentResourceManager resources = new ComponentResourceManager(typeof(DatabaseInformationForm));
 			labelName = new KryptonLabel();
-			labelDirectory = new KryptonLabel();
+			labelPath = new KryptonLabel();
 			labelSize = new KryptonLabel();
 			labelDateCreated = new KryptonLabel();
 			labelDateAccessed = new KryptonLabel();
@@ -45,8 +45,8 @@ namespace Planetoid_DB
 			labelAttributes = new KryptonLabel();
 			labelNameValue = new KryptonLabel();
 			contextMenuCopyToClipboard = new ContextMenuStrip(components);
-			ToolStripMenuItemCopyToClipboard = new ToolStripMenuItem();
-			labelDirectoryValue = new KryptonLabel();
+			toolStripMenuItemCopyToClipboard = new ToolStripMenuItem();
+			labelPathValue = new KryptonLabel();
 			labelSizeValue = new KryptonLabel();
 			labelDateCreatedValue = new KryptonLabel();
 			labelDateAccessedValue = new KryptonLabel();
@@ -56,13 +56,49 @@ namespace Planetoid_DB
 			toolStripContainer = new ToolStripContainer();
 			statusStrip = new KryptonStatusStrip();
 			labelInformation = new ToolStripStatusLabel();
+			toolStripIcons = new KryptonToolStrip();
+			toolStripButtonSaveToFile = new ToolStripButton();
+			toolStripButtonCopyToClipboard = new ToolStripButton();
 			kryptonManager = new KryptonManager(components);
+			contextMenuFullCopyToClipboard = new ContextMenuStrip(components);
+			menuitemCopyToClipboardName = new ToolStripMenuItem();
+			menuitemCopyToClipboardPath = new ToolStripMenuItem();
+			menuitemCopyToClipboardSize = new ToolStripMenuItem();
+			menuitemCopyToClipboardCreationDate = new ToolStripMenuItem();
+			menuitemCopyToClipboardLastAccessDate = new ToolStripMenuItem();
+			menuitemCopyToClipboardLastWriteDate = new ToolStripMenuItem();
+			menuitemCopyToClipboardAttributes = new ToolStripMenuItem();
+			contextMenuSaveToFile = new ContextMenuStrip(components);
+			toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+			toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
 			contextMenuCopyToClipboard.SuspendLayout();
 			tableLayoutPanel.SuspendLayout();
 			toolStripContainer.BottomToolStripPanel.SuspendLayout();
 			toolStripContainer.ContentPanel.SuspendLayout();
+			toolStripContainer.TopToolStripPanel.SuspendLayout();
 			toolStripContainer.SuspendLayout();
 			statusStrip.SuspendLayout();
+			toolStripIcons.SuspendLayout();
+			contextMenuFullCopyToClipboard.SuspendLayout();
+			contextMenuSaveToFile.SuspendLayout();
 			SuspendLayout();
 			// 
 			// labelName
@@ -88,28 +124,28 @@ namespace Planetoid_DB
 			labelName.MouseEnter += Control_Enter;
 			labelName.MouseLeave += Control_Leave;
 			// 
-			// labelDirectory
+			// labelPath
 			// 
-			labelDirectory.AccessibleDescription = "Shows the directory of the database";
-			labelDirectory.AccessibleName = "Directory";
-			labelDirectory.AccessibleRole = AccessibleRole.Text;
-			labelDirectory.Dock = DockStyle.Fill;
-			labelDirectory.LabelStyle = LabelStyle.BoldPanel;
-			labelDirectory.Location = new Point(4, 29);
-			labelDirectory.Margin = new Padding(4, 3, 4, 3);
-			labelDirectory.Name = "labelDirectory";
-			labelDirectory.Size = new Size(102, 20);
-			labelDirectory.TabIndex = 2;
-			labelDirectory.ToolTipValues.Description = "Shows the directory of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
-			labelDirectory.ToolTipValues.EnableToolTips = true;
-			labelDirectory.ToolTipValues.Heading = "Directory";
-			labelDirectory.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			labelDirectory.Values.Text = "Directory";
-			labelDirectory.DoubleClick += CopyToClipboard_DoubleClick;
-			labelDirectory.Enter += Control_Enter;
-			labelDirectory.Leave += Control_Leave;
-			labelDirectory.MouseEnter += Control_Enter;
-			labelDirectory.MouseLeave += Control_Leave;
+			labelPath.AccessibleDescription = "Shows the path of the database";
+			labelPath.AccessibleName = "Path";
+			labelPath.AccessibleRole = AccessibleRole.Text;
+			labelPath.Dock = DockStyle.Fill;
+			labelPath.LabelStyle = LabelStyle.BoldPanel;
+			labelPath.Location = new Point(4, 29);
+			labelPath.Margin = new Padding(4, 3, 4, 3);
+			labelPath.Name = "labelPath";
+			labelPath.Size = new Size(102, 20);
+			labelPath.TabIndex = 2;
+			labelPath.ToolTipValues.Description = "Shows the path of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
+			labelPath.ToolTipValues.EnableToolTips = true;
+			labelPath.ToolTipValues.Heading = "Path";
+			labelPath.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+			labelPath.Values.Text = "Path";
+			labelPath.DoubleClick += CopyToClipboard_DoubleClick;
+			labelPath.Enter += Control_Enter;
+			labelPath.Leave += Control_Leave;
+			labelPath.MouseEnter += Control_Enter;
+			labelPath.MouseLeave += Control_Leave;
 			// 
 			// labelSize
 			// 
@@ -236,7 +272,7 @@ namespace Planetoid_DB
 			labelNameValue.Location = new Point(114, 3);
 			labelNameValue.Margin = new Padding(4, 3, 4, 3);
 			labelNameValue.Name = "labelNameValue";
-			labelNameValue.Size = new Size(252, 20);
+			labelNameValue.Size = new Size(290, 20);
 			labelNameValue.TabIndex = 1;
 			labelNameValue.ToolTipValues.Description = "Shows the name of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelNameValue.ToolTipValues.EnableToolTips = true;
@@ -257,7 +293,7 @@ namespace Planetoid_DB
 			contextMenuCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuCopyToClipboard.AllowClickThrough = true;
 			contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
-			contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCopyToClipboard });
+			contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { toolStripMenuItemCopyToClipboard });
 			contextMenuCopyToClipboard.Name = "contextMenuStrip";
 			contextMenuCopyToClipboard.Size = new Size(214, 26);
 			contextMenuCopyToClipboard.TabStop = true;
@@ -265,45 +301,45 @@ namespace Planetoid_DB
 			contextMenuCopyToClipboard.MouseEnter += Control_Enter;
 			contextMenuCopyToClipboard.MouseLeave += Control_Leave;
 			// 
-			// ToolStripMenuItemCopyToClipboard
+			// toolStripMenuItemCopyToClipboard
 			// 
-			ToolStripMenuItemCopyToClipboard.AccessibleDescription = "Copies the text/value to the clipboard";
-			ToolStripMenuItemCopyToClipboard.AccessibleName = "Copy to clipboard";
-			ToolStripMenuItemCopyToClipboard.AccessibleRole = AccessibleRole.MenuItem;
-			ToolStripMenuItemCopyToClipboard.AutoToolTip = true;
-			ToolStripMenuItemCopyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
-			ToolStripMenuItemCopyToClipboard.Name = "ToolStripMenuItemCopyToClipboard";
-			ToolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Strg+C";
-			ToolStripMenuItemCopyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
-			ToolStripMenuItemCopyToClipboard.Size = new Size(213, 22);
-			ToolStripMenuItemCopyToClipboard.Text = "&Copy to clipboard";
-			ToolStripMenuItemCopyToClipboard.Click += CopyToClipboard_DoubleClick;
-			ToolStripMenuItemCopyToClipboard.MouseEnter += Control_Enter;
-			ToolStripMenuItemCopyToClipboard.MouseLeave += Control_Leave;
+			toolStripMenuItemCopyToClipboard.AccessibleDescription = "Copies the text/value to the clipboard";
+			toolStripMenuItemCopyToClipboard.AccessibleName = "Copy to clipboard";
+			toolStripMenuItemCopyToClipboard.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemCopyToClipboard.AutoToolTip = true;
+			toolStripMenuItemCopyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
+			toolStripMenuItemCopyToClipboard.Name = "toolStripMenuItemCopyToClipboard";
+			toolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Strg+C";
+			toolStripMenuItemCopyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
+			toolStripMenuItemCopyToClipboard.Size = new Size(213, 22);
+			toolStripMenuItemCopyToClipboard.Text = "&Copy to clipboard";
+			toolStripMenuItemCopyToClipboard.Click += CopyToClipboard_DoubleClick;
+			toolStripMenuItemCopyToClipboard.MouseEnter += Control_Enter;
+			toolStripMenuItemCopyToClipboard.MouseLeave += Control_Leave;
 			// 
-			// labelDirectoryValue
+			// labelPathValue
 			// 
-			labelDirectoryValue.AccessibleDescription = "Shows the directory of the database";
-			labelDirectoryValue.AccessibleName = "Directory value";
-			labelDirectoryValue.AccessibleRole = AccessibleRole.Text;
-			labelDirectoryValue.ContextMenuStrip = contextMenuCopyToClipboard;
-			labelDirectoryValue.Dock = DockStyle.Fill;
-			labelDirectoryValue.Location = new Point(114, 29);
-			labelDirectoryValue.Margin = new Padding(4, 3, 4, 3);
-			labelDirectoryValue.Name = "labelDirectoryValue";
-			labelDirectoryValue.Size = new Size(252, 20);
-			labelDirectoryValue.TabIndex = 3;
-			labelDirectoryValue.ToolTipValues.Description = "Shows the directory of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
-			labelDirectoryValue.ToolTipValues.EnableToolTips = true;
-			labelDirectoryValue.ToolTipValues.Heading = "Directory value";
-			labelDirectoryValue.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			labelDirectoryValue.Values.Text = "..........";
-			labelDirectoryValue.DoubleClick += CopyToClipboard_DoubleClick;
-			labelDirectoryValue.Enter += Control_Enter;
-			labelDirectoryValue.Leave += Control_Leave;
-			labelDirectoryValue.MouseDown += Control_MouseDown;
-			labelDirectoryValue.MouseEnter += Control_Enter;
-			labelDirectoryValue.MouseLeave += Control_Leave;
+			labelPathValue.AccessibleDescription = "Shows the path of the database";
+			labelPathValue.AccessibleName = "Path value";
+			labelPathValue.AccessibleRole = AccessibleRole.Text;
+			labelPathValue.ContextMenuStrip = contextMenuCopyToClipboard;
+			labelPathValue.Dock = DockStyle.Fill;
+			labelPathValue.Location = new Point(114, 29);
+			labelPathValue.Margin = new Padding(4, 3, 4, 3);
+			labelPathValue.Name = "labelPathValue";
+			labelPathValue.Size = new Size(290, 20);
+			labelPathValue.TabIndex = 3;
+			labelPathValue.ToolTipValues.Description = "Shows the path of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
+			labelPathValue.ToolTipValues.EnableToolTips = true;
+			labelPathValue.ToolTipValues.Heading = "Path value";
+			labelPathValue.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+			labelPathValue.Values.Text = "..........";
+			labelPathValue.DoubleClick += CopyToClipboard_DoubleClick;
+			labelPathValue.Enter += Control_Enter;
+			labelPathValue.Leave += Control_Leave;
+			labelPathValue.MouseDown += Control_MouseDown;
+			labelPathValue.MouseEnter += Control_Enter;
+			labelPathValue.MouseLeave += Control_Leave;
 			// 
 			// labelSizeValue
 			// 
@@ -315,7 +351,7 @@ namespace Planetoid_DB
 			labelSizeValue.Location = new Point(114, 55);
 			labelSizeValue.Margin = new Padding(4, 3, 4, 3);
 			labelSizeValue.Name = "labelSizeValue";
-			labelSizeValue.Size = new Size(252, 20);
+			labelSizeValue.Size = new Size(290, 20);
 			labelSizeValue.TabIndex = 5;
 			labelSizeValue.ToolTipValues.Description = "Shows the size of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelSizeValue.ToolTipValues.EnableToolTips = true;
@@ -339,7 +375,7 @@ namespace Planetoid_DB
 			labelDateCreatedValue.Location = new Point(114, 81);
 			labelDateCreatedValue.Margin = new Padding(4, 3, 4, 3);
 			labelDateCreatedValue.Name = "labelDateCreatedValue";
-			labelDateCreatedValue.Size = new Size(252, 20);
+			labelDateCreatedValue.Size = new Size(290, 20);
 			labelDateCreatedValue.TabIndex = 7;
 			labelDateCreatedValue.ToolTipValues.Description = "Shows the creation date of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelDateCreatedValue.ToolTipValues.EnableToolTips = true;
@@ -363,7 +399,7 @@ namespace Planetoid_DB
 			labelDateAccessedValue.Location = new Point(114, 107);
 			labelDateAccessedValue.Margin = new Padding(4, 3, 4, 3);
 			labelDateAccessedValue.Name = "labelDateAccessedValue";
-			labelDateAccessedValue.Size = new Size(252, 20);
+			labelDateAccessedValue.Size = new Size(290, 20);
 			labelDateAccessedValue.TabIndex = 9;
 			labelDateAccessedValue.ToolTipValues.Description = "Shows the last access date of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelDateAccessedValue.ToolTipValues.EnableToolTips = true;
@@ -387,7 +423,7 @@ namespace Planetoid_DB
 			labelDateWritedValue.Location = new Point(114, 133);
 			labelDateWritedValue.Margin = new Padding(4, 3, 4, 3);
 			labelDateWritedValue.Name = "labelDateWritedValue";
-			labelDateWritedValue.Size = new Size(252, 20);
+			labelDateWritedValue.Size = new Size(290, 20);
 			labelDateWritedValue.TabIndex = 11;
 			labelDateWritedValue.ToolTipValues.Description = "Shows the last write date of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelDateWritedValue.ToolTipValues.EnableToolTips = true;
@@ -411,14 +447,14 @@ namespace Planetoid_DB
 			tableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
 			tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
 			tableLayoutPanel.Controls.Add(labelName, 0, 0);
-			tableLayoutPanel.Controls.Add(labelDirectory, 0, 1);
+			tableLayoutPanel.Controls.Add(labelPath, 0, 1);
 			tableLayoutPanel.Controls.Add(labelSize, 0, 2);
 			tableLayoutPanel.Controls.Add(labelDateCreated, 0, 3);
 			tableLayoutPanel.Controls.Add(labelDateAccessed, 0, 4);
 			tableLayoutPanel.Controls.Add(labelDateWrited, 0, 5);
 			tableLayoutPanel.Controls.Add(labelAttributes, 0, 6);
 			tableLayoutPanel.Controls.Add(labelNameValue, 1, 0);
-			tableLayoutPanel.Controls.Add(labelDirectoryValue, 1, 1);
+			tableLayoutPanel.Controls.Add(labelPathValue, 1, 1);
 			tableLayoutPanel.Controls.Add(labelSizeValue, 1, 2);
 			tableLayoutPanel.Controls.Add(labelDateCreatedValue, 1, 3);
 			tableLayoutPanel.Controls.Add(labelDateAccessedValue, 1, 4);
@@ -437,7 +473,7 @@ namespace Planetoid_DB
 			tableLayoutPanel.RowStyles.Add(new RowStyle());
 			tableLayoutPanel.RowStyles.Add(new RowStyle());
 			tableLayoutPanel.RowStyles.Add(new RowStyle());
-			tableLayoutPanel.Size = new Size(370, 187);
+			tableLayoutPanel.Size = new Size(408, 187);
 			tableLayoutPanel.TabIndex = 0;
 			tableLayoutPanel.TabStop = true;
 			// 
@@ -451,7 +487,7 @@ namespace Planetoid_DB
 			labelAttributesValue.Location = new Point(114, 159);
 			labelAttributesValue.Margin = new Padding(4, 3, 4, 3);
 			labelAttributesValue.Name = "labelAttributesValue";
-			labelAttributesValue.Size = new Size(252, 25);
+			labelAttributesValue.Size = new Size(290, 25);
 			labelAttributesValue.TabIndex = 13;
 			labelAttributesValue.ToolTipValues.Description = "Shows the attributes of the database.\r\nDouble-click or right-click to copy the information to the clipboard.";
 			labelAttributesValue.ToolTipValues.EnableToolTips = true;
@@ -479,15 +515,18 @@ namespace Planetoid_DB
 			// 
 			toolStripContainer.ContentPanel.Controls.Add(tableLayoutPanel);
 			toolStripContainer.ContentPanel.Margin = new Padding(4, 3, 4, 3);
-			toolStripContainer.ContentPanel.Size = new Size(370, 187);
+			toolStripContainer.ContentPanel.Size = new Size(408, 187);
 			toolStripContainer.Dock = DockStyle.Fill;
 			toolStripContainer.Location = new Point(0, 0);
 			toolStripContainer.Margin = new Padding(4, 3, 4, 3);
 			toolStripContainer.Name = "toolStripContainer";
-			toolStripContainer.Size = new Size(370, 209);
+			toolStripContainer.Size = new Size(408, 234);
 			toolStripContainer.TabIndex = 3;
 			toolStripContainer.Text = "toolStripContainer";
-			toolStripContainer.TopToolStripPanelVisible = false;
+			// 
+			// toolStripContainer.TopToolStripPanel
+			// 
+			toolStripContainer.TopToolStripPanel.Controls.Add(toolStripIcons);
 			// 
 			// statusStrip
 			// 
@@ -501,7 +540,7 @@ namespace Planetoid_DB
 			statusStrip.Name = "statusStrip";
 			statusStrip.ProgressBars = null;
 			statusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
-			statusStrip.Size = new Size(370, 22);
+			statusStrip.Size = new Size(408, 22);
 			statusStrip.TabIndex = 2;
 			statusStrip.Text = "status bar";
 			// 
@@ -518,11 +557,499 @@ namespace Planetoid_DB
 			labelInformation.Text = "some information here";
 			labelInformation.ToolTipText = "Shows some information";
 			// 
+			// toolStripIcons
+			// 
+			toolStripIcons.AccessibleDescription = "Toolbar of copying information";
+			toolStripIcons.AccessibleName = "Toolbar of copying information";
+			toolStripIcons.Dock = DockStyle.None;
+			toolStripIcons.Font = new Font("Segoe UI", 9F);
+			toolStripIcons.Items.AddRange(new ToolStripItem[] { toolStripButtonSaveToFile, toolStripButtonCopyToClipboard });
+			toolStripIcons.Location = new Point(0, 0);
+			toolStripIcons.Name = "toolStripIcons";
+			toolStripIcons.Size = new Size(408, 25);
+			toolStripIcons.Stretch = true;
+			toolStripIcons.TabIndex = 0;
+			toolStripIcons.TabStop = true;
+			toolStripIcons.Text = "Toolbar of copying information";
+			toolStripIcons.MouseEnter += Control_Enter;
+			toolStripIcons.MouseLeave += Control_Leave;
+			// 
+			// toolStripButtonSaveToFile
+			// 
+			toolStripButtonSaveToFile.AccessibleDescription = "Saves to file";
+			toolStripButtonSaveToFile.AccessibleName = "Save to file";
+			toolStripButtonSaveToFile.AccessibleRole = AccessibleRole.PushButton;
+			toolStripButtonSaveToFile.Image = FatcowIcons16px.fatcow_diskette_16px;
+			toolStripButtonSaveToFile.ImageTransparentColor = Color.Magenta;
+			toolStripButtonSaveToFile.Name = "toolStripButtonSaveToFile";
+			toolStripButtonSaveToFile.Size = new Size(84, 22);
+			toolStripButtonSaveToFile.Text = "&Save to file";
+			toolStripButtonSaveToFile.Click += ToolStripButtonSaveToFile_Click;
+			toolStripButtonSaveToFile.MouseEnter += Control_Enter;
+			toolStripButtonSaveToFile.MouseLeave += Control_Leave;
+			// 
+			// toolStripButtonCopyToClipboard
+			// 
+			toolStripButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
+			toolStripButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
+			toolStripButtonCopyToClipboard.AccessibleRole = AccessibleRole.PushButton;
+			toolStripButtonCopyToClipboard.Image = FugueIcons16px.fugue_blue_document_copy_16px;
+			toolStripButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
+			toolStripButtonCopyToClipboard.Name = "toolStripButtonCopyToClipboard";
+			toolStripButtonCopyToClipboard.Size = new Size(122, 22);
+			toolStripButtonCopyToClipboard.Text = "&Copy to clipboard";
+			toolStripButtonCopyToClipboard.Click += ToolStripButtonCopyToClipboard_Click;
+			toolStripButtonCopyToClipboard.MouseEnter += Control_Enter;
+			toolStripButtonCopyToClipboard.MouseLeave += Control_Leave;
+			// 
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+			// 
+			// contextMenuFullCopyToClipboard
+			// 
+			contextMenuFullCopyToClipboard.AccessibleDescription = "Shows the context menu of the derived orbital elements to copy to clipboard";
+			contextMenuFullCopyToClipboard.AccessibleName = "context menu of the derived orbital elements to copy to clipboard";
+			contextMenuFullCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
+			contextMenuFullCopyToClipboard.Font = new Font("Segoe UI", 9F);
+			contextMenuFullCopyToClipboard.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardName, menuitemCopyToClipboardPath, menuitemCopyToClipboardSize, menuitemCopyToClipboardCreationDate, menuitemCopyToClipboardLastAccessDate, menuitemCopyToClipboardLastWriteDate, menuitemCopyToClipboardAttributes });
+			contextMenuFullCopyToClipboard.Name = "Context menu of copying to clipboard of derived orbital elements";
+			contextMenuFullCopyToClipboard.Size = new Size(159, 158);
+			contextMenuFullCopyToClipboard.Text = "Copy to clipboard";
+			contextMenuFullCopyToClipboard.MouseEnter += Control_Enter;
+			contextMenuFullCopyToClipboard.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardName
+			// 
+			menuitemCopyToClipboardName.AccessibleDescription = "Copy to clipboard: Name";
+			menuitemCopyToClipboardName.AccessibleName = "Copy to clipboard: Name";
+			menuitemCopyToClipboardName.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardName.AutoToolTip = true;
+			menuitemCopyToClipboardName.Image = (Image)resources.GetObject("menuitemCopyToClipboardName.Image");
+			menuitemCopyToClipboardName.Name = "menuitemCopyToClipboardName";
+			menuitemCopyToClipboardName.Size = new Size(158, 22);
+			menuitemCopyToClipboardName.Text = "Name";
+			menuitemCopyToClipboardName.Click += MenuitemCopyToClipboardName_Click;
+			menuitemCopyToClipboardName.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardName.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardPath
+			// 
+			menuitemCopyToClipboardPath.AccessibleDescription = "Copy to clipboard: Path";
+			menuitemCopyToClipboardPath.AccessibleName = "Copy to clipboard: Path";
+			menuitemCopyToClipboardPath.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardPath.AutoToolTip = true;
+			menuitemCopyToClipboardPath.Image = (Image)resources.GetObject("menuitemCopyToClipboardPath.Image");
+			menuitemCopyToClipboardPath.Name = "menuitemCopyToClipboardPath";
+			menuitemCopyToClipboardPath.Size = new Size(158, 22);
+			menuitemCopyToClipboardPath.Text = "Path";
+			menuitemCopyToClipboardPath.Click += MenuitemCopyToClipboardPath_Click;
+			menuitemCopyToClipboardPath.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardPath.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardSize
+			// 
+			menuitemCopyToClipboardSize.AccessibleDescription = "Copy to clipboard: Size";
+			menuitemCopyToClipboardSize.AccessibleName = "Copy to clipboard: Size";
+			menuitemCopyToClipboardSize.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardSize.AutoToolTip = true;
+			menuitemCopyToClipboardSize.Image = (Image)resources.GetObject("menuitemCopyToClipboardSize.Image");
+			menuitemCopyToClipboardSize.Name = "menuitemCopyToClipboardSize";
+			menuitemCopyToClipboardSize.Size = new Size(158, 22);
+			menuitemCopyToClipboardSize.Text = "Size";
+			menuitemCopyToClipboardSize.Click += MenuitemCopyToClipboardSize_Click;
+			menuitemCopyToClipboardSize.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardSize.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardCreationDate
+			// 
+			menuitemCopyToClipboardCreationDate.AccessibleDescription = "Copy to clipboard: Creation date";
+			menuitemCopyToClipboardCreationDate.AccessibleName = "Copy to clipboard: Creation date";
+			menuitemCopyToClipboardCreationDate.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardCreationDate.AutoToolTip = true;
+			menuitemCopyToClipboardCreationDate.Image = (Image)resources.GetObject("menuitemCopyToClipboardCreationDate.Image");
+			menuitemCopyToClipboardCreationDate.Name = "menuitemCopyToClipboardCreationDate";
+			menuitemCopyToClipboardCreationDate.Size = new Size(158, 22);
+			menuitemCopyToClipboardCreationDate.Text = "Creation date";
+			menuitemCopyToClipboardCreationDate.Click += MenuitemCopyToClipboardCreationDate_Click;
+			menuitemCopyToClipboardCreationDate.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardCreationDate.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardLastAccessDate
+			// 
+			menuitemCopyToClipboardLastAccessDate.AccessibleDescription = "Copy to clipboard: Last access date";
+			menuitemCopyToClipboardLastAccessDate.AccessibleName = "Copy to clipboard: Last access date";
+			menuitemCopyToClipboardLastAccessDate.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardLastAccessDate.AutoToolTip = true;
+			menuitemCopyToClipboardLastAccessDate.Image = (Image)resources.GetObject("menuitemCopyToClipboardLastAccessDate.Image");
+			menuitemCopyToClipboardLastAccessDate.Name = "menuitemCopyToClipboardLastAccessDate";
+			menuitemCopyToClipboardLastAccessDate.Size = new Size(158, 22);
+			menuitemCopyToClipboardLastAccessDate.Text = "Last access date";
+			menuitemCopyToClipboardLastAccessDate.Click += MenuitemCopyToClipboardLastAccessDate_Click;
+			menuitemCopyToClipboardLastAccessDate.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardLastAccessDate.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardLastWriteDate
+			// 
+			menuitemCopyToClipboardLastWriteDate.AccessibleDescription = "Copy to clipboard: Last write date";
+			menuitemCopyToClipboardLastWriteDate.AccessibleName = "Copy to clipboard: Last write date";
+			menuitemCopyToClipboardLastWriteDate.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardLastWriteDate.AutoToolTip = true;
+			menuitemCopyToClipboardLastWriteDate.Image = (Image)resources.GetObject("menuitemCopyToClipboardLastWriteDate.Image");
+			menuitemCopyToClipboardLastWriteDate.Name = "menuitemCopyToClipboardLastWriteDate";
+			menuitemCopyToClipboardLastWriteDate.Size = new Size(158, 22);
+			menuitemCopyToClipboardLastWriteDate.Text = "Last write date";
+			menuitemCopyToClipboardLastWriteDate.Click += MenuitemCopyToClipboardLastWriteDate_Click;
+			menuitemCopyToClipboardLastWriteDate.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardLastWriteDate.MouseLeave += Control_Leave;
+			// 
+			// menuitemCopyToClipboardAttributes
+			// 
+			menuitemCopyToClipboardAttributes.AccessibleDescription = "Copy to clipboard: Attributes";
+			menuitemCopyToClipboardAttributes.AccessibleName = "Copy to clipboard: Attributes";
+			menuitemCopyToClipboardAttributes.AccessibleRole = AccessibleRole.MenuItem;
+			menuitemCopyToClipboardAttributes.AutoToolTip = true;
+			menuitemCopyToClipboardAttributes.Image = (Image)resources.GetObject("menuitemCopyToClipboardAttributes.Image");
+			menuitemCopyToClipboardAttributes.Name = "menuitemCopyToClipboardAttributes";
+			menuitemCopyToClipboardAttributes.Size = new Size(158, 22);
+			menuitemCopyToClipboardAttributes.Text = "Attributes";
+			menuitemCopyToClipboardAttributes.Click += MenuitemCopyToClipboardAttributes_Click;
+			menuitemCopyToClipboardAttributes.MouseEnter += Control_Enter;
+			menuitemCopyToClipboardAttributes.MouseLeave += Control_Leave;
+			// 
+			// contextMenuSaveToFile
+			// 
+			contextMenuSaveToFile.AccessibleDescription = "Save the information to file";
+			contextMenuSaveToFile.AccessibleName = "Save to file";
+			contextMenuSaveToFile.AccessibleRole = AccessibleRole.MenuPopup;
+			contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
+			contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi });
+			contextMenuSaveToFile.Name = "contextMenuSaveToFile";
+			contextMenuSaveToFile.Size = new Size(216, 444);
+			contextMenuSaveToFile.TabStop = true;
+			contextMenuSaveToFile.Text = "&Save to file";
+			contextMenuSaveToFile.MouseEnter += Control_Enter;
+			contextMenuSaveToFile.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsText
+			// 
+			toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the information as text file";
+			toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+			toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsText.AutoToolTip = true;
+			toolStripMenuItemSaveAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+			toolStripMenuItemSaveAsText.ShortcutKeyDisplayString = "Strg+X";
+			toolStripMenuItemSaveAsText.ShortcutKeys = Keys.Control | Keys.X;
+			toolStripMenuItemSaveAsText.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsText.Text = "Save as te&xt";
+			toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+			toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsLatex
+			// 
+			toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the information as Latex file";
+			toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+			toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+			toolStripMenuItemSaveAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+			toolStripMenuItemSaveAsLatex.ShortcutKeyDisplayString = "Strg+E";
+			toolStripMenuItemSaveAsLatex.ShortcutKeys = Keys.Control | Keys.E;
+			toolStripMenuItemSaveAsLatex.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsLatex.Text = "Save as Lat&ex";
+			toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+			toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsMarkdown
+			// 
+			toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the information as Markdown file";
+			toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+			toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+			toolStripMenuItemSaveAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+			toolStripMenuItemSaveAsMarkdown.ShortcutKeyDisplayString = "Strg+K";
+			toolStripMenuItemSaveAsMarkdown.ShortcutKeys = Keys.Control | Keys.K;
+			toolStripMenuItemSaveAsMarkdown.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsMarkdown.Text = "Save as Mar&kdown";
+			toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+			toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsWord
+			// 
+			toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the information as Word file";
+			toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+			toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsWord.AutoToolTip = true;
+			toolStripMenuItemSaveAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+			toolStripMenuItemSaveAsWord.ShortcutKeyDisplayString = "Strg+W";
+			toolStripMenuItemSaveAsWord.ShortcutKeys = Keys.Control | Keys.W;
+			toolStripMenuItemSaveAsWord.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsWord.Text = "Save as &Word";
+			toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+			toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsOdt
+			// 
+			toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the information as ODT file";
+			toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+			toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+			toolStripMenuItemSaveAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+			toolStripMenuItemSaveAsOdt.ShortcutKeyDisplayString = "Strg+D";
+			toolStripMenuItemSaveAsOdt.ShortcutKeys = Keys.Control | Keys.D;
+			toolStripMenuItemSaveAsOdt.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsOdt.Text = "Save as O&DT";
+			toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+			toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsRtf
+			// 
+			toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the information as RTF file";
+			toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+			toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+			toolStripMenuItemSaveAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+			toolStripMenuItemSaveAsRtf.ShortcutKeyDisplayString = "Strg+R";
+			toolStripMenuItemSaveAsRtf.ShortcutKeys = Keys.Control | Keys.R;
+			toolStripMenuItemSaveAsRtf.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsRtf.Text = "Save as &RTF";
+			toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+			// 
+			// toolStripMenuItemSaveAsExcel
+			// 
+			toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the information as Excel file";
+			toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+			toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+			toolStripMenuItemSaveAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+			toolStripMenuItemSaveAsExcel.ShortcutKeyDisplayString = "Strg+L";
+			toolStripMenuItemSaveAsExcel.ShortcutKeys = Keys.Control | Keys.L;
+			toolStripMenuItemSaveAsExcel.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsExcel.Text = "Save as Exce&l";
+			toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+			toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsOds
+			// 
+			toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the information as ODS file";
+			toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+			toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsOds.AutoToolTip = true;
+			toolStripMenuItemSaveAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+			toolStripMenuItemSaveAsOds.ShortcutKeyDisplayString = "Strg+S";
+			toolStripMenuItemSaveAsOds.ShortcutKeys = Keys.Control | Keys.S;
+			toolStripMenuItemSaveAsOds.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsOds.Text = "Save as OD&S";
+			toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+			toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsCsv
+			// 
+			toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the information as CSV file";
+			toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+			toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+			toolStripMenuItemSaveAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+			toolStripMenuItemSaveAsCsv.ShortcutKeyDisplayString = "Strg+C";
+			toolStripMenuItemSaveAsCsv.ShortcutKeys = Keys.Control | Keys.C;
+			toolStripMenuItemSaveAsCsv.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsCsv.Text = "Save as &CSV";
+			toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+			toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsTsv
+			// 
+			toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the information as TSV file";
+			toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+			toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+			toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+			toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "Strg+T";
+			toolStripMenuItemSaveAsTsv.ShortcutKeys = Keys.Control | Keys.T;
+			toolStripMenuItemSaveAsTsv.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
+			toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+			toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsPsv
+			// 
+			toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the information as PSV file";
+			toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+			toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+			toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+			toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "Strg+V";
+			toolStripMenuItemSaveAsPsv.ShortcutKeys = Keys.Control | Keys.V;
+			toolStripMenuItemSaveAsPsv.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
+			toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+			toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsHtml
+			// 
+			toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the information as HTML file";
+			toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+			toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+			toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+			toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+			toolStripMenuItemSaveAsHtml.ShortcutKeyDisplayString = "Strg+H";
+			toolStripMenuItemSaveAsHtml.ShortcutKeys = Keys.Control | Keys.H;
+			toolStripMenuItemSaveAsHtml.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+			toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+			toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsXml
+			// 
+			toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the information as XML file";
+			toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+			toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsXml.AutoToolTip = true;
+			toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+			toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+			toolStripMenuItemSaveAsXml.ShortcutKeyDisplayString = "Strg+M";
+			toolStripMenuItemSaveAsXml.ShortcutKeys = Keys.Control | Keys.M;
+			toolStripMenuItemSaveAsXml.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsXml.Text = "Save as X&ML";
+			toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+			toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsJson
+			// 
+			toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the information as JSON file";
+			toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+			toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsJson.AutoToolTip = true;
+			toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+			toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+			toolStripMenuItemSaveAsJson.ShortcutKeyDisplayString = "Strg+J";
+			toolStripMenuItemSaveAsJson.ShortcutKeys = Keys.Control | Keys.J;
+			toolStripMenuItemSaveAsJson.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+			toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+			toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsYaml
+			// 
+			toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the information as YAML file";
+			toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+			toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+			toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+			toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+			toolStripMenuItemSaveAsYaml.ShortcutKeyDisplayString = "Strg+Y";
+			toolStripMenuItemSaveAsYaml.ShortcutKeys = Keys.Control | Keys.Y;
+			toolStripMenuItemSaveAsYaml.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+			toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+			toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsSql
+			// 
+			toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the information as SQL script";
+			toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+			toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsSql.AutoToolTip = true;
+			toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+			toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+			toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+Q";
+			toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.Q;
+			toolStripMenuItemSaveAsSql.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
+			toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+			toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsPdf
+			// 
+			toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the information as PDF file";
+			toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+			toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+			toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+			toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "Strg+F";
+			toolStripMenuItemSaveAsPdf.ShortcutKeys = Keys.Control | Keys.F;
+			toolStripMenuItemSaveAsPdf.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
+			toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+			toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsPostScript
+			// 
+			toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the information as PostScript file";
+			toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
+			toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+			toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+			toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "Strg+P";
+			toolStripMenuItemSaveAsPostScript.ShortcutKeys = Keys.Control | Keys.P;
+			toolStripMenuItemSaveAsPostScript.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
+			toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+			toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsEpub
+			// 
+			toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the information as EPUB file";
+			toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+			toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+			toolStripMenuItemSaveAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+			toolStripMenuItemSaveAsEpub.ShortcutKeyDisplayString = "Strg+B";
+			toolStripMenuItemSaveAsEpub.ShortcutKeys = Keys.Control | Keys.B;
+			toolStripMenuItemSaveAsEpub.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsEpub.Text = "Save as EPU&B";
+			toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+			toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemSaveAsMobi
+			// 
+			toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the information as MOBI file";
+			toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+			toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+			toolStripMenuItemSaveAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+			toolStripMenuItemSaveAsMobi.ShortcutKeyDisplayString = "Strg+I";
+			toolStripMenuItemSaveAsMobi.ShortcutKeys = Keys.Control | Keys.I;
+			toolStripMenuItemSaveAsMobi.Size = new Size(215, 22);
+			toolStripMenuItemSaveAsMobi.Text = "Save as MOB&I";
+			toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+			toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+			toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
 			// 
 			// DatabaseInformationForm
 			// 
@@ -531,7 +1058,7 @@ namespace Planetoid_DB
 			AccessibleRole = AccessibleRole.Dialog;
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
-			ClientSize = new Size(370, 209);
+			ClientSize = new Size(408, 234);
 			ControlBox = false;
 			Controls.Add(toolStripContainer);
 			FormBorderStyle = FormBorderStyle.SizableToolWindow;
@@ -550,10 +1077,16 @@ namespace Planetoid_DB
 			toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
 			toolStripContainer.BottomToolStripPanel.PerformLayout();
 			toolStripContainer.ContentPanel.ResumeLayout(false);
+			toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+			toolStripContainer.TopToolStripPanel.PerformLayout();
 			toolStripContainer.ResumeLayout(false);
 			toolStripContainer.PerformLayout();
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();
+			toolStripIcons.ResumeLayout(false);
+			toolStripIcons.PerformLayout();
+			contextMenuFullCopyToClipboard.ResumeLayout(false);
+			contextMenuSaveToFile.ResumeLayout(false);
 			ResumeLayout(false);
 
 		}
@@ -561,14 +1094,14 @@ namespace Planetoid_DB
 		#endregion
 		private KryptonTableLayoutPanel tableLayoutPanel;
     private KryptonLabel labelName;
-    private KryptonLabel labelDirectory;
+    private KryptonLabel labelPath;
     private KryptonLabel labelSize;
     private KryptonLabel labelDateCreated;
     private KryptonLabel labelDateAccessed;
     private KryptonLabel labelDateWrited;
     private KryptonLabel labelAttributes;
     private KryptonLabel labelNameValue;
-    private KryptonLabel labelDirectoryValue;
+    private KryptonLabel labelPathValue;
     private KryptonLabel labelSizeValue;
     private KryptonLabel labelDateCreatedValue;
     private KryptonLabel labelDateAccessedValue;
@@ -579,6 +1112,38 @@ namespace Planetoid_DB
 	private ToolStripContainer toolStripContainer;
 		private KryptonManager kryptonManager;
 		private ContextMenuStrip contextMenuCopyToClipboard;
-		private ToolStripMenuItem ToolStripMenuItemCopyToClipboard;
+		private ToolStripMenuItem toolStripMenuItemCopyToClipboard;
+		private KryptonToolStrip toolStripIcons;
+		private ToolStripButton toolStripButtonCopyToClipboard;
+		private ContextMenuStrip contextMenuFullCopyToClipboard;
+		private ToolStripMenuItem menuitemCopyToClipboardName;
+		private ToolStripMenuItem menuitemCopyToClipboardPath;
+		private ToolStripMenuItem menuitemCopyToClipboardSize;
+		private ToolStripMenuItem menuitemCopyToClipboardCreationDate;
+		private ToolStripMenuItem menuitemCopyToClipboardLastAccessDate;
+		private ToolStripMenuItem menuitemCopyToClipboardLastWriteDate;
+		private ToolStripMenuItem menuitemCopyToClipboardAttributes;
+		private ToolStripButton toolStripButtonSaveToFile;
+		private ContextMenuStrip contextMenuSaveToFile;
+		private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+		private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
+		private ToolStripMenuItem toolStripMenuItemSaveAsWord;
+		private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
+		private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
+		private ToolStripMenuItem toolStripMenuItemSaveAsOds;
+		private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
+		private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
+		private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
+		private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+		private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+		private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+		private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+		private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+		private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+		private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+		private ToolStripMenuItem toolStripMenuItemSaveAsText;
+		private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
 	}
 }

--- a/Forms/DatabaseInformationForm.cs
+++ b/Forms/DatabaseInformationForm.cs
@@ -10,6 +10,7 @@ using Planetoid_DB.Properties;
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 
 namespace Planetoid_DB;
 
@@ -63,6 +64,75 @@ public partial class DatabaseInformationForm : BaseKryptonForm
 	/// </remarks>
 	private string GetDebuggerDisplay() => ToString();
 
+	/// <summary>
+	/// Prepares the save dialog for exporting data.
+	/// </summary>
+	/// <param name="dialog">The file dialog to prepare.</param>
+	/// <param name="ext">The file extension.</param>
+	/// <returns>True if the dialog was shown successfully; otherwise, false.</returns>
+	/// <remarks>
+	/// This method is used to prepare the save dialog for exporting data.
+	/// </remarks>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"Database-Information.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
+	/// <summary>
+	/// Escapes a string for use in a CSV file.
+	/// </summary>
+	/// <param name="text">The text to escape.</param>
+	/// <param name="separator">The separator used in the CSV file.</param>
+	/// <returns>The escaped text.</returns>
+	/// <remarks>
+	/// This method escapes special characters in a string for use in a CSV file.
+	/// </remarks>
+	private static string EscapeCsv(string text, string separator)
+	{
+		return text.Contains(value: separator) || text.Contains(value: '"') || text.Contains(value: '\n') || text.Contains(value: '\r')
+			? $"\"{text.Replace(oldValue: "\"", newValue: "\"\"")}\""
+			: text;
+	}
+
+	/// <summary>
+	/// Saves the content of the table layout panel to a CSV file.
+	/// </summary>
+	/// <param name="path">The path to the file to save to.</param>
+	/// <param name="separator">The separator to use in the CSV file (default is semicolon).</param>
+	/// <remarks>
+	/// This method iterates through the table layout panel controls and writes the content to a CSV file.
+	/// </remarks>
+	private void SaveTableToCsv(string path, string separator = ";")
+	{
+		// Create a string builder to build the CSV content
+		StringBuilder csvContent = new();
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the CSV content
+				_ = csvContent.AppendLine(value: $"{EscapeCsv(text: label, separator: separator)}{separator}{EscapeCsv(text: value, separator: separator)}");
+			}
+		}
+		// Write the content to the file
+		File.WriteAllText(path: path, contents: csvContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
 	#endregion
 
 	#region form event handlers
@@ -91,7 +161,7 @@ public partial class DatabaseInformationForm : BaseKryptonForm
 		// Set the file information in the labels
 		labelNameValue.Text = fileInfo.Name;
 		// Set the file name in the label
-		labelDirectoryValue.Text = fileInfo.DirectoryName;
+		labelPathValue.Text = fileInfo.DirectoryName;
 		// Set the file size in the label
 		labelSizeValue.Text = $"{fileInfo.Length:N0} {I18nStrings.BytesText}";
 		// Set the file type in the label
@@ -102,6 +172,1149 @@ public partial class DatabaseInformationForm : BaseKryptonForm
 		labelDateWritedValue.Text = fileInfo.LastWriteTime.ToString(format: "G", provider: CultureInfo.CurrentCulture);
 		// Set the file attributes in the label
 		labelAttributesValue.Text = $"{fileInfo.Attributes}";
+	}
+
+	#endregion
+
+	#region Click event handlers
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard button.
+	/// </summary>
+	/// <param name="sender">Event source (the button).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard button is clicked.
+	/// </remarks>
+	private void ToolStripButtonCopyToClipboard_Click(object sender, EventArgs e)
+	{
+		// Check if the sender is a tool strip button
+		if (sender is ToolStripButton button && button.Owner is not null)
+		{
+			// Show the context menu for copying to the clipboard
+			contextMenuFullCopyToClipboard.Show(control: button.Owner, x: button.Bounds.Left, y: button.Bounds.Bottom);
+		}
+	}
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database name.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database name is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardName_Click(object sender, EventArgs e) => CopyToClipboard(text: labelNameValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database path.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database path is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardPath_Click(object sender, EventArgs e) => CopyToClipboard(text: labelPathValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database size.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database size is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardSize_Click(object sender, EventArgs e) => CopyToClipboard(text: labelSizeValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database creation date.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database creation date is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardCreationDate_Click(object sender, EventArgs e) => CopyToClipboard(text: labelDateCreatedValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database last access date.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database last access date is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardLastAccessDate_Click(object sender, EventArgs e) => CopyToClipboard(text: labelDateAccessedValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database last write date.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database last write date is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardLastWriteDate_Click(object sender, EventArgs e) => CopyToClipboard(text: labelDateWritedValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the copy to clipboard menu item for the database attributes.
+	/// </summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the copy to clipboard menu item for the database attributes is clicked.
+	/// </remarks>
+	private void MenuitemCopyToClipboardAttributes_Click(object sender, EventArgs e) => CopyToClipboard(text: labelAttributesValue.Text);
+
+	/// <summary>
+	/// Handles the click event of the save to file button.
+	/// </summary>
+	/// <param name="sender">Event source (the button).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is called when the save to file button is clicked.
+	/// </remarks>
+	private void ToolStripButtonSaveToFile_Click(object sender, EventArgs e)
+	{
+		// Check if the sender is a tool strip button
+		if (sender is ToolStripButton button && button.Owner is not null)
+		{
+			// Show the context menu for saving to a file
+			contextMenuSaveToFile.Show(control: button.Owner, x: button.Bounds.Left, y: button.Bounds.Bottom);
+		}
+	}
+
+	/// <summary>
+	/// Handles the click event for the 'Save As Text' menu item, allowing users to export database information to a text
+	/// file.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a text file in a tab-separated format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsText_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogText = new()
+		{
+			Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
+			DefaultExt = "txt",
+			Title = "Save database information as text"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogText, ext: saveFileDialogText.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the tab-separated content
+		StringBuilder textContent = new();
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the content with a space separator
+				_ = textContent.AppendLine(value: $"{label} {value}");
+			}
+		}
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogText.FileName, contents: textContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the 'Save As LaTeX' menu item, allowing users to export database information to a LaTeX
+	/// file.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a LaTeX file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsLatex_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogLatex = new()
+		{
+			Filter = "LaTeX files (*.tex)|*.tex|All files (*.*)|*.*",
+			DefaultExt = "tex",
+			Title = "Save database information as LaTeX"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogLatex, ext: saveFileDialogLatex.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the LaTeX content
+		StringBuilder latexContent = new();
+		latexContent.AppendLine(value: @"\documentclass{article}");
+		latexContent.AppendLine(value: @"\usepackage[utf8]{inputenc}");
+		latexContent.AppendLine(value: @"\begin{document}");
+		latexContent.AppendLine(value: @"\begin{tabular}{|l|l|}");
+		latexContent.AppendLine(value: @"\hline");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the LaTeX content
+				latexContent.AppendLine(value: $"{label} & {value} \\\\ \\hline");
+			}
+		}
+		latexContent.AppendLine(value: @"\end{tabular}");
+		latexContent.AppendLine(value: @"\end{document}");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogLatex.FileName, contents: latexContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the 'Save As Markdown' menu item, allowing users to export database information to a Markdown
+	/// file.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a Markdown file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogMarkdown = new()
+		{
+			Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+			DefaultExt = "md",
+			Title = "Save database information as Markdown"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogMarkdown, ext: saveFileDialogMarkdown.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the Markdown content
+		StringBuilder markdownContent = new();
+		markdownContent.AppendLine(value: "| Label | Value |");
+		markdownContent.AppendLine(value: "|-------|-------|");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the Markdown content
+				markdownContent.AppendLine(value: $"| {label} | {value} |");
+			}
+		}
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogMarkdown.FileName, contents: markdownContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the 'Save As Word' menu item, allowing users to export database information to a Word
+	/// file.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a Word file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsWord_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogWord = new()
+		{
+			Filter = "Word files (*.doc)|*.doc|All files (*.*)|*.*",
+			DefaultExt = "doc",
+			Title = "Save database information as Word"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogWord, ext: saveFileDialogWord.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the Word content
+		StringBuilder wordContent = new();
+		wordContent.AppendLine(value: @"<html xmlns:o='urn:schemas-microsoft-com:office:office' xmlns:w='urn:schemas-microsoft-com:office:word' xmlns='http://www.w3.org/TR/REC-html40'>");
+		wordContent.AppendLine(value: @"<head><meta charset='utf-8'><title>Database Information</title></head>");
+		wordContent.AppendLine(value: @"<body>");
+		wordContent.AppendLine(value: @"<table border=""1"" style=""border-collapse: collapse; width: 100%;"">");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the Word content
+				wordContent.AppendLine(value: $"  <tr><td>{label}</td><td>{value}</td></tr>");
+			}
+		}
+		wordContent.AppendLine(value: @"</table>");
+		wordContent.AppendLine(value: @"</body>");
+		wordContent.AppendLine(value: @"</html>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogWord.FileName, contents: wordContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as ODT" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an ODT file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsOdt_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogOdt = new()
+		{
+			Filter = "OpenDocument Text files (*.odt)|*.odt|All files (*.*)|*.*",
+			DefaultExt = "odt",
+			Title = "Save database information as ODT"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogOdt, ext: saveFileDialogOdt.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the ODT content
+		StringBuilder odtContent = new();
+		odtContent.AppendLine(value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		odtContent.AppendLine(value: "<office:document xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" office:version=\"1.2\" office:mimetype=\"application/vnd.oasis.opendocument.text\">");
+		odtContent.AppendLine(value: "<office:body>");
+		odtContent.AppendLine(value: "<office:text>");
+		odtContent.AppendLine(value: "<table:table>");
+		odtContent.AppendLine(value: "<table:table-column table:number-columns-repeated=\"2\"/>");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the ODT content
+				odtContent.AppendLine(value: "<table:table-row>");
+				odtContent.AppendLine(value: $"<table:table-cell><text:p>{label}</text:p></table:table-cell>");
+				odtContent.AppendLine(value: $"<table:table-cell><text:p>{value}</text:p></table:table-cell>");
+				odtContent.AppendLine(value: "</table:table-row>");
+			}
+		}
+		odtContent.AppendLine(value: "</table:table>");
+		odtContent.AppendLine(value: "</office:text>");
+		odtContent.AppendLine(value: "</office:body>");
+		odtContent.AppendLine(value: "</office:document>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogOdt.FileName, contents: odtContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as Excel" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an Excel file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsExcel_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogExcel = new()
+		{
+			Filter = "Excel files (*.xls)|*.xls|All files (*.*)|*.*",
+			DefaultExt = "xls",
+			Title = "Save database information as Excel"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogExcel, ext: saveFileDialogExcel.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the Excel content
+		StringBuilder excelContent = new();
+		excelContent.AppendLine(value: @"<html xmlns:o='urn:schemas-microsoft-com:office:office' xmlns:x='urn:schemas-microsoft-com:office:excel' xmlns='http://www.w3.org/TR/REC-html40'>");
+		excelContent.AppendLine(value: @"<head><meta charset='utf-8'><title>Database Information</title>");
+		excelContent.AppendLine(value: @"<!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets><x:ExcelWorksheet><x:Name>Database Information</x:Name><x:WorksheetOptions><x:DisplayGridlines/></x:WorksheetOptions></x:ExcelWorksheet></x:ExcelWorksheets></x:ExcelWorkbook></xml><![endif]-->");
+		excelContent.AppendLine(value: @"</head><body>");
+		excelContent.AppendLine(value: @"<table border=""1"">");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the Excel content
+				excelContent.AppendLine(value: $"  <tr><td>{label}</td><td>{value}</td></tr>");
+			}
+		}
+		excelContent.AppendLine(value: @"</table>");
+		excelContent.AppendLine(value: @"</body>");
+		excelContent.AppendLine(value: @"</html>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogExcel.FileName, contents: excelContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as ODS" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an ODS file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsOds_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogOds = new()
+		{
+			Filter = "OpenDocument Spreadsheet files (*.ods)|*.ods|All files (*.*)|*.*",
+			DefaultExt = "ods",
+			Title = "Save database information as ODS"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogOds, ext: saveFileDialogOds.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the ODS content
+		StringBuilder odsContent = new();
+		odsContent.AppendLine(value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		odsContent.AppendLine(value: "<office:document xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" office:version=\"1.2\" office:mimetype=\"application/vnd.oasis.opendocument.spreadsheet\">");
+		odsContent.AppendLine(value: "<office:body>");
+		odsContent.AppendLine(value: "<office:spreadsheet>");
+		odsContent.AppendLine(value: "<table:table table:name=\"DatabaseInformation\">");
+		odsContent.AppendLine(value: "<table:table-column table:number-columns-repeated=\"2\"/>");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the ODS content
+				odsContent.AppendLine(value: "<table:table-row>");
+				odsContent.AppendLine(value: $"<table:table-cell office:value-type=\"string\"><text:p>{label}</text:p></table:table-cell>");
+				odsContent.AppendLine(value: $"<table:table-cell office:value-type=\"string\"><text:p>{value}</text:p></table:table-cell>");
+				odsContent.AppendLine(value: "</table:table-row>");
+			}
+		}
+		odsContent.AppendLine(value: "</table:table>");
+		odsContent.AppendLine(value: "</office:spreadsheet>");
+		odsContent.AppendLine(value: "</office:body>");
+		odsContent.AppendLine(value: "</office:document>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogOds.FileName, contents: odsContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as RTF" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an RTF file in a tabular format. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsRtf_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogRtf = new()
+		{
+			Filter = "Rich Text Format files (*.rtf)|*.rtf|All files (*.*)|*.*",
+			DefaultExt = "rtf",
+			Title = "Save database information as RTF"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogRtf, ext: saveFileDialogRtf.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the RTF content
+		StringBuilder rtfContent = new();
+		rtfContent.AppendLine(value: @"{\rtf1\ansi\deff0");
+		rtfContent.AppendLine(value: @"{\fonttbl{\f0\fnil\fcharset0 Calibri;}}");
+		rtfContent.AppendLine(value: @"\viewkind4\uc1\pard\fs20");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the RTF content
+				rtfContent.AppendLine(value: $@"\b {label}:\b0 {value}\par");
+			}
+		}
+		rtfContent.AppendLine(value: "}");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogRtf.FileName, contents: rtfContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as CSV" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a CSV file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsCsv_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogCsv = new()
+		{
+			Filter = "Comma-separated values files (*.csv)|*.csv|All files (*.*)|*.*",
+			DefaultExt = "csv",
+			Title = "Save database information as CSV"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogCsv, ext: saveFileDialogCsv.DefaultExt))
+		{
+			return;
+		}
+		SaveTableToCsv(path: saveFileDialogCsv.FileName, separator: ";");
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as TSV" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a TSV file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsTsv_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogTsv = new()
+		{
+			Filter = "Tab-separated values files (*.tsv)|*.tsv|All files (*.*)|*.*",
+			DefaultExt = "tsv",
+			Title = "Save database information as TSV"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogTsv, ext: saveFileDialogTsv.DefaultExt))
+		{
+			return;
+		}
+		SaveTableToCsv(path: saveFileDialogTsv.FileName, separator: "\t");
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as PSV" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a PSV file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsPsv_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogPsv = new()
+		{
+			Filter = "Pipe-separated values files (*.psv)|*.psv|All files (*.*)|*.*",
+			DefaultExt = "psv",
+			Title = "Save database information as PSV"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogPsv, ext: saveFileDialogPsv.DefaultExt))
+		{
+			return;
+		}
+		SaveTableToCsv(path: saveFileDialogPsv.FileName, separator: "|");
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as HTML" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an HTML file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsHtml_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogHtml = new()
+		{
+			Filter = "HTML files (*.html)|*.html|All files (*.*)|*.*",
+			DefaultExt = "html",
+			Title = "Save database information as HTML"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogHtml, ext: saveFileDialogHtml.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the HTML content
+		StringBuilder htmlContent = new();
+		htmlContent.AppendLine(value: "<html>");
+		htmlContent.AppendLine(value: "<head><title>Database Information</title></head>");
+		htmlContent.AppendLine(value: "<body>");
+		htmlContent.AppendLine(value: "<table border=\"1\">");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the HTML content
+				htmlContent.AppendLine(value: $"  <tr><td>{label}</td><td>{value}</td></tr>");
+			}
+		}
+		htmlContent.AppendLine(value: "</table>");
+		htmlContent.AppendLine(value: "</body>");
+		htmlContent.AppendLine(value: "</html>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogHtml.FileName, contents: htmlContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as XML" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an XML file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsXml_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogXml = new()
+		{
+			Filter = "XML files (*.xml)|*.xml|All files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save database information as XML"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogXml, ext: saveFileDialogXml.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the XML content
+		StringBuilder xmlContent = new();
+		xmlContent.AppendLine(value: "<DatabaseInformation>");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the XML content
+				xmlContent.AppendLine(value: $"  <{label}>{value}</{label}>");
+			}
+		}
+		xmlContent.AppendLine(value: "</DatabaseInformation>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogXml.FileName, contents: xmlContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as JSON" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a JSON file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsJson_Click(object sender, EventArgs e)
+	{
+		using SaveFileDialog saveFileDialogJson = new()
+		{
+			Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+			DefaultExt = "json",
+			Title = "Save database information as JSON"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogJson, ext: saveFileDialogJson.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the JSON content
+		StringBuilder jsonContent = new();
+		jsonContent.AppendLine(value: "{");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the JSON content
+				jsonContent.AppendLine(value: $"  \"{label}\": \"{value}\",");
+			}
+		}
+		jsonContent.AppendLine(value: "}");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogJson.FileName, contents: jsonContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as YAML" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a YAML file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsYaml_Click(object sender, EventArgs e)
+	{
+		using SaveFileDialog saveFileDialogYaml = new()
+		{
+			Filter = "YAML files (*.yaml)|*.yaml|All files (*.*)|*.*",
+			DefaultExt = "yaml",
+			Title = "Save database information as YAML"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogYaml, ext: saveFileDialogYaml.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the YAML content
+		StringBuilder yamlContent = new();
+		yamlContent.AppendLine(value: "DatabaseInformation:");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the YAML content
+				yamlContent.AppendLine(value: $"  {label}: {value}");
+			}
+		}
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogYaml.FileName, contents: yamlContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as SQL" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an SQL file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsSql_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogSql = new()
+		{
+			Filter = "SQL files (*.sql)|*.sql|All files (*.*)|*.*",
+			DefaultExt = "sql",
+			Title = "Save database information as SQL"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogSql, ext: saveFileDialogSql.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the SQL content
+		StringBuilder sqlContent = new();
+		sqlContent.AppendLine(value: "CREATE TABLE DatabaseInformation (");
+		sqlContent.AppendLine(value: "	Label NVARCHAR(255),");
+		sqlContent.AppendLine(value: "	Value NVARCHAR(MAX)");
+		sqlContent.AppendLine(value: ");");
+		sqlContent.AppendLine();
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Escape single quotes for SQL
+				label = label.Replace(oldValue: "'", newValue: "''");
+				value = value.Replace(oldValue: "'", newValue: "''");
+				// Append the line to the SQL content
+				sqlContent.AppendLine(value: $"INSERT INTO DatabaseInformation (Label, Value) VALUES ('{label}', '{value}');");
+			}
+		}
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogSql.FileName, contents: sqlContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as PDF" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a PDF file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsPdf_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogPdf = new()
+		{
+			Filter = "PDF files (*.pdf)|*.pdf|All files (*.*)|*.*",
+			DefaultExt = "pdf",
+			Title = "Save database information as PDF"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogPdf, ext: saveFileDialogPdf.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the PDF content
+		StringBuilder pdfContent = new();
+		List<long> offsets = [];
+		// Helper function to add objects and track offsets
+		void AddObject(int id, string content)
+		{
+			offsets.Add(item: pdfContent.Length);
+			pdfContent.AppendLine(value: $"{id} 0 obj");
+			pdfContent.AppendLine(value: content);
+			pdfContent.AppendLine(value: "endobj");
+		}
+		// Header
+		pdfContent.AppendLine(value: "%PDF-1.4");
+		// 1: Catalog
+		AddObject(id: 1, content: "<< /Type /Catalog /Pages 2 0 R >>");
+		// 2: Pages
+		AddObject(id: 2, content: "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+		// 3: Page
+		AddObject(id: 3, content: "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 5 0 R /Resources << /Font << /F1 4 0 R >> >> >>");
+		// 4: Font
+		AddObject(id: 4, content: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+		// Build Content Stream
+		StringBuilder streamContent = new();
+		streamContent.AppendLine(value: "BT");
+		streamContent.AppendLine(value: "/F1 12 Tf");
+		streamContent.AppendLine(value: "50 750 Td");
+		streamContent.AppendLine(value: "15 TL");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Escape special characters for PDF text strings
+				string line = $"{label}: {value}".Replace(oldValue: "\\", newValue: "\\\\").Replace(oldValue: "(", newValue: "\\(").Replace(oldValue: ")", newValue: "\\)");
+				streamContent.AppendLine(value: $"({line}) Tj");
+				streamContent.AppendLine(value: "T*");
+			}
+		}
+		streamContent.AppendLine(value: "ET");
+		// 5: Content Object
+		AddObject(id: 5, content: $"<< /Length {streamContent.Length} >>\nstream\n{streamContent}endstream");
+		// XRef Table
+		long xrefOffset = pdfContent.Length;
+		pdfContent.AppendLine(value: "xref");
+		pdfContent.AppendLine(value: $"0 {offsets.Count + 1}");
+		pdfContent.AppendLine(value: "0000000000 65535 f ");
+		foreach (long offset in offsets)
+		{
+			pdfContent.AppendLine(value: $"{offset:D10} 00000 n ");
+		}
+		// Trailer
+		pdfContent.AppendLine(value: "trailer");
+		pdfContent.AppendLine(value: $"<< /Size {offsets.Count + 1} /Root 1 0 R >>");
+		pdfContent.AppendLine(value: "startxref");
+		pdfContent.AppendLine(value: $"{xrefOffset}");
+		pdfContent.AppendLine(value: "%%EOF");
+		// Write the content to the file using Latin1 encoding to preserve byte offsets
+		File.WriteAllText(path: saveFileDialogPdf.FileName, contents: pdfContent.ToString(), encoding: Encoding.Latin1);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as PostScript" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a PostScript file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object sender, EventArgs e)
+	{
+		using SaveFileDialog saveFileDialogPostScript = new()
+		{
+			Filter = "PostScript files (*.ps)|*.ps|All files (*.*)|*.*",
+			DefaultExt = "ps",
+			Title = "Save database information as PostScript"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogPostScript, ext: saveFileDialogPostScript.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the PostScript content
+		StringBuilder psContent = new();
+		psContent.AppendLine(value: "%!PS-Adobe-3.0");
+		psContent.AppendLine(value: "%%Title: Database Information");
+		psContent.AppendLine(value: "%%Pages: 1");
+		psContent.AppendLine(value: "%%EndComments");
+		psContent.AppendLine(value: "/Times-Roman findfont 12 scalefont setfont");
+		psContent.AppendLine(value: "50 750 moveto");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the PostScript content
+				psContent.AppendLine(value: $"({label}: {value}) show");
+				psContent.AppendLine(value: "0 -20 rmoveto");
+			}
+		}
+		psContent.AppendLine(value: "showpage");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogPostScript.FileName, contents: psContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as EPUB" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as an EPUB file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsEpub_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogEpub = new()
+		{
+			Filter = "EPUB files (*.epub)|*.epub|All files (*.*)|*.*",
+			DefaultExt = "epub",
+			Title = "Save database information as EPUB"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogEpub, ext: saveFileDialogEpub.DefaultExt))
+		{
+			return;
+		}
+		// Create the EPUB file as a ZipArchive
+		using (FileStream zipToOpen = new(path: saveFileDialogEpub.FileName, mode: FileMode.Create))
+		{
+			using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
+			// 1. mimetype (must be first, uncompressed)
+			System.IO.Compression.ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype", compressionLevel: System.IO.Compression.CompressionLevel.NoCompression);
+			using (StreamWriter writer = new(stream: mimetypeEntry.Open()))
+			{
+				writer.Write(value: "application/epub+zip");
+			}
+			// 2. META-INF/container.xml
+			System.IO.Compression.ZipArchiveEntry containerEntry = archive.CreateEntry(entryName: "META-INF/container.xml");
+			using (StreamWriter writer = new(stream: containerEntry.Open()))
+			{
+				writer.Write(value: "<?xml version=\"1.0\"?><container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
+			}
+			// 3. OEBPS/content.opf
+			System.IO.Compression.ZipArchiveEntry opfEntry = archive.CreateEntry(entryName: "OEBPS/content.opf");
+			using (StreamWriter writer = new(stream: opfEntry.Open()))
+			{
+				writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><package xmlns=\"http://www.idpf.org/2007/opf\" unique-identifier=\"uuid_id\" version=\"2.0\"><metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:title>Database Information</dc:title><dc:language>en</dc:language><dc:identifier id=\"uuid_id\" opf:scheme=\"uuid\">urn:uuid:00000000-0000-0000-0000-000000000000</dc:identifier></metadata><manifest><item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/><item id=\"content\" href=\"content.xhtml\" media-type=\"application/xhtml+xml\"/></manifest><spine toc=\"ncx\"><itemref idref=\"content\"/></spine></package>");
+			}
+			// 4. OEBPS/toc.ncx
+			System.IO.Compression.ZipArchiveEntry ncxEntry = archive.CreateEntry(entryName: "OEBPS/toc.ncx");
+			using (StreamWriter writer = new(stream: ncxEntry.Open()))
+			{
+				writer.Write(value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\"><head><meta name=\"dtb:uid\" content=\"urn:uuid:00000000-0000-0000-0000-000000000000\"/><meta name=\"dtb:depth\" content=\"1\"/><meta name=\"dtb:totalPageCount\" content=\"0\"/><meta name=\"dtb:maxPageNumber\" content=\"0\"/></head><docTitle><text>Database Information</text></docTitle><navMap><navPoint id=\"navPoint-1\" playOrder=\"1\"><navLabel><text>Database Information</text></navLabel><content src=\"content.xhtml\"/></navPoint></navMap></ncx>");
+			}
+			// 5. OEBPS/content.xhtml
+			System.IO.Compression.ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "OEBPS/content.xhtml");
+			using (StreamWriter writer = new(stream: contentEntry.Open()))
+			{
+				StringBuilder xhtmlContent = new();
+				xhtmlContent.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+				xhtmlContent.AppendLine(value: "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">");
+				xhtmlContent.AppendLine(value: "<html xmlns=\"http://www.w3.org/1999/xhtml\">");
+				xhtmlContent.AppendLine(value: "<head><title>Database Information</title></head>");
+				xhtmlContent.AppendLine(value: "<body>");
+				xhtmlContent.AppendLine(value: "<h1>Database Information</h1>");
+				xhtmlContent.AppendLine(value: "<table border=\"1\" style=\"width: 100%;\">");
+				// Iterate through the rows of the table layout panel
+				for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+				{
+					// Get the control in the first column (label)
+					Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+					// Get the control in the second column (value)
+					Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+					// Check if both controls are not null
+					if (controlLabel is not null && controlValue is not null)
+					{
+						// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+						string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+						string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+						// Append the line to the XHTML content
+						xhtmlContent.AppendLine(value: $"<tr><td>{label}</td><td>{value}</td></tr>");
+					}
+				}
+				xhtmlContent.AppendLine(value: "</table>");
+				xhtmlContent.AppendLine(value: "</body>");
+				xhtmlContent.AppendLine(value: "</html>");
+				writer.Write(value: xhtmlContent.ToString());
+			}
+		}
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Save as Mobi" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method displays a Save File dialog to prompt the user for a file location and name. It
+	/// collects the displayed database information from the form and saves it as a Mobi file. A
+	/// confirmation message is shown upon successful completion.</remarks>
+	private void ToolStripMenuItemSaveAsMobi_Click(object sender, EventArgs e)
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogMobi = new()
+		{
+			Filter = "Mobi files (*.mobi)|*.mobi|All files (*.*)|*.*",
+			DefaultExt = "mobi",
+			Title = "Save database information as Mobi"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogMobi, ext: saveFileDialogMobi.DefaultExt))
+		{
+			return;
+		}
+		// Create a string builder to build the Mobi content (HTML based)
+		StringBuilder mobiContent = new();
+		mobiContent.AppendLine(value: "<html>");
+		mobiContent.AppendLine(value: "<head><title>Database Information</title></head>");
+		mobiContent.AppendLine(value: "<body>");
+		mobiContent.AppendLine(value: "<h1>Database Information</h1>");
+		// Iterate through the rows of the table layout panel
+		for (int row = 0; row < tableLayoutPanel.RowCount; row++)
+		{
+			// Get the control in the first column (label)
+			Control? controlLabel = tableLayoutPanel.GetControlFromPosition(column: 0, row: row);
+			// Get the control in the second column (value)
+			Control? controlValue = tableLayoutPanel.GetControlFromPosition(column: 1, row: row);
+			// Check if both controls are not null
+			if (controlLabel is not null && controlValue is not null)
+			{
+				// Get the text from the controls, preferring KryptonLabel.Values.Text if available, otherwise Control.Text
+				string label = controlLabel is Krypton.Toolkit.KryptonLabel kLabel ? kLabel.Values.Text : controlLabel.Text;
+				string value = controlValue is Krypton.Toolkit.KryptonLabel kValue ? kValue.Values.Text : controlValue.Text;
+				// Append the line to the Mobi content
+				mobiContent.AppendLine(value: $"<p><strong>{label}</strong>: {value}</p>");
+			}
+		}
+		mobiContent.AppendLine(value: "</body>");
+		mobiContent.AppendLine(value: "</html>");
+		// Write the content to the file
+		File.WriteAllText(path: saveFileDialogMobi.FileName, contents: mobiContent.ToString(), encoding: Encoding.UTF8);
+		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	#endregion

--- a/Forms/DatabaseInformationForm.resx
+++ b/Forms/DatabaseInformationForm.resx
@@ -118,18 +118,146 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>268, 17</value>
+    <value>264, 17</value>
   </metadata>
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>485, 17</value>
+  </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>126, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>53</value>
+  <metadata name="contextMenuFullCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>612, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="menuitemCopyToClipboardName.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardPath.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardSize.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardCreationDate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardLastAccessDate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardLastWriteDate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardAttributes.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="contextMenuSaveToFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>848, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>57</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAoAICAQAAEABADoAgAApgAAABgYEAABAAQA6AEAAI4DAAAQEBAAAQAEACgBAAB2BQAAICAAAAEA

--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -275,7 +275,7 @@ namespace Planetoid_DB
 			contextMenuSaveList.AccessibleName = "Save list";
 			contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsMobi });
+			contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi });
 			contextMenuSaveList.Name = "contextMenuStrip1";
 			contextMenuSaveList.Size = new Size(216, 466);
 			contextMenuSaveList.TabStop = true;


### PR DESCRIPTION
Adds export and clipboard actions to `DatabaseInformationForm`, enabling users to copy individual database metadata fields and export the displayed information in multiple file formats.

**Changes:**
- Added toolbar + context menus for “Copy to clipboard” and “Save to file” in `DatabaseInformationForm`.
- Implemented many new export handlers (TXT, LaTeX, Markdown, Word/ODT/RTF, Excel/ODS, CSV/TSV/PSV, HTML/XML/JSON/YAML/SQL, PDF/PS/EPUB/MOBI).
- Minor ordering adjustment in the “Save list” context menu for `ListReadableDesignationsForm`.