### PR TITLE
Enabled double buffering for the TableLayoutPanel to prevent flickering

### DIFF
--- a/Forms/DatabaseDownloaderForm.cs
+++ b/Forms/DatabaseDownloaderForm.cs
@@ -11,6 +11,7 @@ using Planetoid_DB.Properties;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Net;
+using System.Reflection;
 
 namespace Planetoid_DB;
 
@@ -103,6 +104,20 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 	public DatabaseDownloaderForm(string url)
 	{
 		InitializeComponent();
+		// Enable double buffering for the TableLayoutPanel to prevent flickering
+		try
+		{
+			// Set the DoubleBuffered property (protected)
+			PropertyInfo? dbProp = typeof(Control).GetProperty(name: "DoubleBuffered", bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance);
+			dbProp?.SetValue(obj: tableLayoutPanel, value: true, index: null);
+			// Also set specific control styles via reflection just in case
+			MethodInfo? setStyleMethod = typeof(Control).GetMethod(name: "SetStyle", bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance);
+			setStyleMethod?.Invoke(obj: tableLayoutPanel, parameters: [ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true]);
+		}
+		catch (Exception ex)
+		{
+			logger.Warn(exception: ex, message: "Could not set DoubleBuffered on tableLayoutPanel");
+		}
 		// Validate and store the URL
 		if (string.IsNullOrWhiteSpace(value: url))
 		{


### PR DESCRIPTION
This PR aims to reduce UI flicker in `DatabaseDownloaderForm` by enabling double buffering on the form’s `TableLayoutPanel`, improving the visual experience during updates/progress changes.

**Changes:**
- Added `System.Reflection` usage.
- Enabled double buffering / optimized painting styles on `tableLayoutPanel` via reflection, with a guarded try/catch and NLog warning on failure.