### PR TITLE
Added some exports file formats and redesigned gui

### DIFF
--- a/Forms/ExportDataSheetForm.Designer.cs
+++ b/Forms/ExportDataSheetForm.Designer.cs
@@ -35,125 +35,48 @@ namespace Planetoid_DB
 		{
 			components = new Container();
 			ComponentResourceManager resources = new ComponentResourceManager(typeof(ExportDataSheetForm));
-			buttonExportAsJson = new KryptonButton();
-			buttonExportAsTxt = new KryptonButton();
-			buttonExportAsXml = new KryptonButton();
-			buttonExportAsHtml = new KryptonButton();
 			statusStrip = new KryptonStatusStrip();
-			labelInformation = new ToolStripStatusLabel();
-			buttonUnmarkAll = new KryptonButton();
-			buttonMarkAll = new KryptonButton();
-			toolStripContainer = new ToolStripContainer();
+			labelStatus = new ToolStripStatusLabel();
 			panel = new KryptonPanel();
 			checkedListBoxOrbitalElements = new KryptonCheckedListBox();
-			saveFileDialogTxt = new SaveFileDialog();
-			saveFileDialogHtml = new SaveFileDialog();
-			saveFileDialogXml = new SaveFileDialog();
-			saveFileDialogJson = new SaveFileDialog();
 			kryptonManager = new KryptonManager(components);
+			toolStripContainer = new ToolStripContainer();
+			kryptonToolStripIcons = new KryptonToolStrip();
+			toolStripDropDownButtonExport = new ToolStripDropDownButton();
+			contextMenuExport = new ContextMenuStrip(components);
+			toolStripMenuItemExportAsText = new ToolStripMenuItem();
+			toolStripMenuItemExportAsLatex = new ToolStripMenuItem();
+			toolStripMenuItemExportAsMarkdown = new ToolStripMenuItem();
+			toolStripMenuItemExportAsWord = new ToolStripMenuItem();
+			toolStripMenuItemExportAsOdt = new ToolStripMenuItem();
+			toolStripMenuItemExportAsRtf = new ToolStripMenuItem();
+			toolStripMenuItemExportAsExcel = new ToolStripMenuItem();
+			toolStripMenuItemExportAsOds = new ToolStripMenuItem();
+			toolStripMenuItemExportAsCsv = new ToolStripMenuItem();
+			toolStripMenuItemExportAsTsv = new ToolStripMenuItem();
+			toolStripMenuItemExportAsPsv = new ToolStripMenuItem();
+			toolStripMenuItemExportAsHtml = new ToolStripMenuItem();
+			toolStripMenuItemExportAsXml = new ToolStripMenuItem();
+			toolStripMenuItemExportAsJson = new ToolStripMenuItem();
+			toolStripMenuItemExportAsYaml = new ToolStripMenuItem();
+			toolStripMenuItemExportAsSql = new ToolStripMenuItem();
+			toolStripMenuItemExportAsPdf = new ToolStripMenuItem();
+			toolStripMenuItemExportAsPostScript = new ToolStripMenuItem();
+			toolStripMenuItemExportAsEpub = new ToolStripMenuItem();
+			toolStripMenuItemExportAsMobi = new ToolStripMenuItem();
+			toolStripSeparator1 = new ToolStripSeparator();
+			toolStripButtonMarkAll = new ToolStripButton();
+			toolStripButtonUnmarkAll = new ToolStripButton();
 			statusStrip.SuspendLayout();
-			toolStripContainer.BottomToolStripPanel.SuspendLayout();
-			toolStripContainer.ContentPanel.SuspendLayout();
-			toolStripContainer.SuspendLayout();
 			((ISupportInitialize)panel).BeginInit();
 			panel.SuspendLayout();
+			toolStripContainer.BottomToolStripPanel.SuspendLayout();
+			toolStripContainer.ContentPanel.SuspendLayout();
+			toolStripContainer.TopToolStripPanel.SuspendLayout();
+			toolStripContainer.SuspendLayout();
+			kryptonToolStripIcons.SuspendLayout();
+			contextMenuExport.SuspendLayout();
 			SuspendLayout();
-			// 
-			// buttonExportAsJson
-			// 
-			buttonExportAsJson.AccessibleDescription = "Exports the data sheet as JSON file";
-			buttonExportAsJson.AccessibleName = "Export as JSON";
-			buttonExportAsJson.AccessibleRole = AccessibleRole.PushButton;
-			buttonExportAsJson.Location = new Point(348, 245);
-			buttonExportAsJson.Margin = new Padding(4, 3, 4, 3);
-			buttonExportAsJson.Name = "buttonExportAsJson";
-			buttonExportAsJson.Size = new Size(111, 46);
-			buttonExportAsJson.StateCommon.Content.Image.ImageV = PaletteRelativeAlign.Near;
-			buttonExportAsJson.TabIndex = 6;
-			buttonExportAsJson.ToolTipValues.Description = "Exports the data sheet as JSON file.";
-			buttonExportAsJson.ToolTipValues.EnableToolTips = true;
-			buttonExportAsJson.ToolTipValues.Heading = "Export as JSON";
-			buttonExportAsJson.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonExportAsJson.Values.DropDownArrowColor = Color.Empty;
-			buttonExportAsJson.Values.Image = FatcowIcons16px.fatcow_page_white_code_16px;
-			buttonExportAsJson.Values.Text = "Export as JSON";
-			buttonExportAsJson.Click += ButtonExportAsJson_Click;
-			buttonExportAsJson.Enter += Control_Enter;
-			buttonExportAsJson.Leave += Control_Leave;
-			buttonExportAsJson.MouseEnter += Control_Enter;
-			buttonExportAsJson.MouseLeave += Control_Leave;
-			// 
-			// buttonExportAsTxt
-			// 
-			buttonExportAsTxt.AccessibleDescription = "Exports the data sheet as text file";
-			buttonExportAsTxt.AccessibleName = "Export as TXT";
-			buttonExportAsTxt.AccessibleRole = AccessibleRole.PushButton;
-			buttonExportAsTxt.Location = new Point(348, 85);
-			buttonExportAsTxt.Margin = new Padding(4, 3, 4, 3);
-			buttonExportAsTxt.Name = "buttonExportAsTxt";
-			buttonExportAsTxt.Size = new Size(112, 46);
-			buttonExportAsTxt.StateCommon.Content.Image.ImageV = PaletteRelativeAlign.Near;
-			buttonExportAsTxt.TabIndex = 3;
-			buttonExportAsTxt.ToolTipValues.Description = "Exports the data sheet as text file.";
-			buttonExportAsTxt.ToolTipValues.EnableToolTips = true;
-			buttonExportAsTxt.ToolTipValues.Heading = "Export as TXT";
-			buttonExportAsTxt.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonExportAsTxt.Values.DropDownArrowColor = Color.Empty;
-			buttonExportAsTxt.Values.Image = FatcowIcons16px.fatcow_page_white_text_16px;
-			buttonExportAsTxt.Values.Text = "Export as TXT";
-			buttonExportAsTxt.Click += ButtonExportAsTxt_Click;
-			buttonExportAsTxt.Enter += Control_Enter;
-			buttonExportAsTxt.Leave += Control_Leave;
-			buttonExportAsTxt.MouseEnter += Control_Enter;
-			buttonExportAsTxt.MouseLeave += Control_Leave;
-			// 
-			// buttonExportAsXml
-			// 
-			buttonExportAsXml.AccessibleDescription = "Exports the data sheet as XML file";
-			buttonExportAsXml.AccessibleName = "Export as XML";
-			buttonExportAsXml.AccessibleRole = AccessibleRole.PushButton;
-			buttonExportAsXml.Location = new Point(349, 192);
-			buttonExportAsXml.Margin = new Padding(4, 3, 4, 3);
-			buttonExportAsXml.Name = "buttonExportAsXml";
-			buttonExportAsXml.Size = new Size(111, 46);
-			buttonExportAsXml.StateCommon.Content.Image.ImageV = PaletteRelativeAlign.Near;
-			buttonExportAsXml.TabIndex = 5;
-			buttonExportAsXml.ToolTipValues.Description = "Exports the data sheet as XML file.";
-			buttonExportAsXml.ToolTipValues.EnableToolTips = true;
-			buttonExportAsXml.ToolTipValues.Heading = "Export as XML";
-			buttonExportAsXml.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonExportAsXml.Values.DropDownArrowColor = Color.Empty;
-			buttonExportAsXml.Values.Image = FatcowIcons16px.fatcow_page_white_code_16px;
-			buttonExportAsXml.Values.Text = "Export as XML";
-			buttonExportAsXml.Click += ButtonExportAsXml_Click;
-			buttonExportAsXml.Enter += Control_Enter;
-			buttonExportAsXml.Leave += Control_Leave;
-			buttonExportAsXml.MouseEnter += Control_Enter;
-			buttonExportAsXml.MouseLeave += Control_Leave;
-			// 
-			// buttonExportAsHtml
-			// 
-			buttonExportAsHtml.AccessibleDescription = "Exports the data sheet as HTML file";
-			buttonExportAsHtml.AccessibleName = "Export as HTML";
-			buttonExportAsHtml.AccessibleRole = AccessibleRole.PushButton;
-			buttonExportAsHtml.Location = new Point(348, 138);
-			buttonExportAsHtml.Margin = new Padding(4, 3, 4, 3);
-			buttonExportAsHtml.Name = "buttonExportAsHtml";
-			buttonExportAsHtml.Size = new Size(111, 46);
-			buttonExportAsHtml.StateCommon.Content.Image.ImageV = PaletteRelativeAlign.Near;
-			buttonExportAsHtml.TabIndex = 4;
-			buttonExportAsHtml.ToolTipValues.Description = "Exports the data sheet as HTML file.";
-			buttonExportAsHtml.ToolTipValues.EnableToolTips = true;
-			buttonExportAsHtml.ToolTipValues.Heading = "Export as HTML";
-			buttonExportAsHtml.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonExportAsHtml.Values.DropDownArrowColor = Color.Empty;
-			buttonExportAsHtml.Values.Image = FatcowIcons16px.fatcow_page_white_code_16px;
-			buttonExportAsHtml.Values.Text = "Export as HTML";
-			buttonExportAsHtml.Click += ButtonExportAsHtml_Click;
-			buttonExportAsHtml.Enter += Control_Enter;
-			buttonExportAsHtml.Leave += Control_Leave;
-			buttonExportAsHtml.MouseEnter += Control_Enter;
-			buttonExportAsHtml.MouseLeave += Control_Leave;
 			// 
 			// statusStrip
 			// 
@@ -162,119 +85,53 @@ namespace Planetoid_DB
 			statusStrip.AccessibleRole = AccessibleRole.StatusBar;
 			statusStrip.Dock = DockStyle.None;
 			statusStrip.Font = new Font("Segoe UI", 9F);
-			statusStrip.Items.AddRange(new ToolStripItem[] { labelInformation });
+			statusStrip.Items.AddRange(new ToolStripItem[] { labelStatus });
 			statusStrip.Location = new Point(0, 0);
 			statusStrip.Name = "statusStrip";
 			statusStrip.ProgressBars = null;
 			statusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
-			statusStrip.Size = new Size(474, 22);
+			statusStrip.Size = new Size(284, 22);
 			statusStrip.SizingGrip = false;
 			statusStrip.TabIndex = 0;
 			statusStrip.Text = "status bar";
+			statusStrip.Enter += Control_Enter;
+			statusStrip.Leave += Control_Leave;
+			statusStrip.MouseEnter += Control_Enter;
+			statusStrip.MouseLeave += Control_Leave;
 			// 
-			// labelInformation
+			// labelStatus
 			// 
-			labelInformation.AccessibleDescription = "Shows some information";
-			labelInformation.AccessibleName = "Shows some information";
-			labelInformation.AccessibleRole = AccessibleRole.StaticText;
-			labelInformation.AutoToolTip = true;
-			labelInformation.Image = FatcowIcons16px.fatcow_lightbulb_16px;
-			labelInformation.Margin = new Padding(5, 3, 0, 2);
-			labelInformation.Name = "labelInformation";
-			labelInformation.Size = new Size(144, 17);
-			labelInformation.Text = "some information here";
-			labelInformation.ToolTipText = "Shows some information";
-			// 
-			// buttonUnmarkAll
-			// 
-			buttonUnmarkAll.AccessibleDescription = "Unmarks all orbital elements in the list";
-			buttonUnmarkAll.AccessibleName = "Unmark all orbital elements";
-			buttonUnmarkAll.AccessibleRole = AccessibleRole.PushButton;
-			buttonUnmarkAll.ButtonStyle = ButtonStyle.Form;
-			buttonUnmarkAll.Location = new Point(349, 50);
-			buttonUnmarkAll.Margin = new Padding(4, 3, 4, 3);
-			buttonUnmarkAll.Name = "buttonUnmarkAll";
-			buttonUnmarkAll.Size = new Size(110, 29);
-			buttonUnmarkAll.TabIndex = 2;
-			buttonUnmarkAll.ToolTipValues.Description = "Unmarks all orbital elements in the list.";
-			buttonUnmarkAll.ToolTipValues.EnableToolTips = true;
-			buttonUnmarkAll.ToolTipValues.Heading = "Unmark all orbital elements";
-			buttonUnmarkAll.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonUnmarkAll.Values.DropDownArrowColor = Color.Empty;
-			buttonUnmarkAll.Values.Text = "&Unmark all";
-			buttonUnmarkAll.Click += ButtonUnmarkAll_Click;
-			buttonUnmarkAll.Enter += Control_Enter;
-			buttonUnmarkAll.Leave += Control_Leave;
-			buttonUnmarkAll.MouseEnter += Control_Enter;
-			buttonUnmarkAll.MouseLeave += Control_Leave;
-			// 
-			// buttonMarkAll
-			// 
-			buttonMarkAll.AccessibleDescription = "Marks all orbital elements in the list";
-			buttonMarkAll.AccessibleName = "Mark all orbital elements";
-			buttonMarkAll.AccessibleRole = AccessibleRole.PushButton;
-			buttonMarkAll.ButtonStyle = ButtonStyle.Form;
-			buttonMarkAll.Location = new Point(349, 14);
-			buttonMarkAll.Margin = new Padding(4, 3, 4, 3);
-			buttonMarkAll.Name = "buttonMarkAll";
-			buttonMarkAll.Size = new Size(110, 29);
-			buttonMarkAll.TabIndex = 1;
-			buttonMarkAll.ToolTipValues.Description = "Marks all orbital elements in the list.";
-			buttonMarkAll.ToolTipValues.EnableToolTips = true;
-			buttonMarkAll.ToolTipValues.Heading = "Mark all orbital elements";
-			buttonMarkAll.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-			buttonMarkAll.Values.DropDownArrowColor = Color.Empty;
-			buttonMarkAll.Values.Image = FatcowIcons16px.fatcow_asterisk_orange_16px;
-			buttonMarkAll.Values.Text = "&Mark all";
-			buttonMarkAll.Click += ButtonMarkAll_Click;
-			buttonMarkAll.Enter += Control_Enter;
-			buttonMarkAll.Leave += Control_Leave;
-			buttonMarkAll.MouseEnter += Control_Enter;
-			buttonMarkAll.MouseLeave += Control_Leave;
-			// 
-			// toolStripContainer
-			// 
-			toolStripContainer.AccessibleDescription = "Container to arrange the toolbars";
-			toolStripContainer.AccessibleName = "Container to arrange the toolbars";
-			toolStripContainer.AccessibleRole = AccessibleRole.Grouping;
-			// 
-			// toolStripContainer.BottomToolStripPanel
-			// 
-			toolStripContainer.BottomToolStripPanel.Controls.Add(statusStrip);
-			// 
-			// toolStripContainer.ContentPanel
-			// 
-			toolStripContainer.ContentPanel.Controls.Add(panel);
-			toolStripContainer.ContentPanel.Margin = new Padding(4, 3, 4, 3);
-			toolStripContainer.ContentPanel.Size = new Size(474, 308);
-			toolStripContainer.Dock = DockStyle.Fill;
-			toolStripContainer.Location = new Point(0, 0);
-			toolStripContainer.Margin = new Padding(4, 3, 4, 3);
-			toolStripContainer.Name = "toolStripContainer";
-			toolStripContainer.Size = new Size(474, 330);
-			toolStripContainer.TabIndex = 3;
-			toolStripContainer.TopToolStripPanelVisible = false;
+			labelStatus.AccessibleDescription = "Shows some information";
+			labelStatus.AccessibleName = "Show some information";
+			labelStatus.AccessibleRole = AccessibleRole.StaticText;
+			labelStatus.AutoToolTip = true;
+			labelStatus.Image = FatcowIcons16px.fatcow_lightbulb_16px;
+			labelStatus.Margin = new Padding(5, 3, 0, 2);
+			labelStatus.Name = "labelStatus";
+			labelStatus.Size = new Size(144, 17);
+			labelStatus.Text = "some information here";
+			labelStatus.ToolTipText = "Shows some information";
+			labelStatus.MouseEnter += Control_Enter;
+			labelStatus.MouseLeave += Control_Leave;
 			// 
 			// panel
 			// 
 			panel.AccessibleDescription = "Groups the data";
-			panel.AccessibleName = "pane";
+			panel.AccessibleName = "Pane";
 			panel.AccessibleRole = AccessibleRole.Pane;
-			panel.Controls.Add(buttonExportAsJson);
-			panel.Controls.Add(buttonUnmarkAll);
-			panel.Controls.Add(buttonExportAsXml);
-			panel.Controls.Add(buttonExportAsTxt);
-			panel.Controls.Add(buttonExportAsHtml);
 			panel.Controls.Add(checkedListBoxOrbitalElements);
-			panel.Controls.Add(buttonMarkAll);
 			panel.Dock = DockStyle.Fill;
 			panel.Location = new Point(0, 0);
 			panel.Margin = new Padding(4, 3, 4, 3);
 			panel.Name = "panel";
 			panel.PanelBackStyle = PaletteBackStyle.FormMain;
-			panel.Size = new Size(474, 308);
+			panel.Size = new Size(284, 299);
 			panel.TabIndex = 0;
-			panel.TabStop = true;
+			panel.TabStop = true;				 
+			panel.Enter += Control_Enter;
+			panel.Leave += Control_Leave;
+			panel.MouseEnter += Control_Enter;
+			panel.MouseLeave += Control_Leave;
 			// 
 			// checkedListBoxOrbitalElements
 			// 
@@ -283,13 +140,14 @@ namespace Planetoid_DB
 			checkedListBoxOrbitalElements.AccessibleRole = AccessibleRole.List;
 			checkedListBoxOrbitalElements.BackStyle = PaletteBackStyle.InputControlRibbon;
 			checkedListBoxOrbitalElements.CheckOnClick = true;
+			checkedListBoxOrbitalElements.Dock = DockStyle.Fill;
 			checkedListBoxOrbitalElements.FormattingEnabled = true;
 			checkedListBoxOrbitalElements.HorizontalScrollbar = true;
-			checkedListBoxOrbitalElements.Items.AddRange(new object[] { "Index No.", "Readable designation", "Epoch (in packed form, .0 TT)", "Mean anomaly at the epoch (degrees)", "Argument of perihelion, J2000.0 (degrees)", "Longitude of the ascending node, J2000.0", "Inclination to the ecliptic, J2000.0 (degrees)", "Orbital eccentricity", "Mean daily motion (degrees per day)", "Semimajor axis (AU)", "Absolute magnitude, H (mag)", "Slope parameter, G", "Reference", "Number of oppositions", "Number of observations", "Observation span", "r.m.s. residual (arseconds)", "Computer name", "4-hexdigit flags", "Date of last observation (YYYMMDD)", "Linear eccentricity (AU)", "Semi-minor axis (AU)", "Major axis (AU)", "Minor axis (AU)", "Eccenctric anomaly (degrees)", "True anomaly (degrees)", "Perihelion distance (AU)", "Aphelion distance (AU)", "Longitude of Descending node (degrees)", "Argument of aphelion (degrees)", "Focal parameter (AU)", "Semi-latus rectum (AU)", "Latus rectum (AU)", "Orbital period (years)", "Orbital area (AU²)", "Orbital perimeter (AU)", "Semi-mean axis (AU)", "Mean axis (AU)", "Standard gravitational parameter (AU³/a²)" });
-			checkedListBoxOrbitalElements.Location = new Point(14, 14);
+			checkedListBoxOrbitalElements.Items.AddRange(new object[] { "Index No.", "Readable designation", "Epoch (in packed form, .0 TT)", "Mean anomaly at the epoch (degrees)", "Argument of perihelion, J2000.0 (degrees)", "Longitude of the ascending node, J2000.0", "Inclination to the ecliptic, J2000.0 (degrees)", "Orbital eccentricity", "Mean daily motion (degrees per day)", "Semimajor axis (AU)", "Absolute magnitude, H (mag)", "Slope parameter, G", "Reference", "Number of oppositions", "Number of observations", "Observation span", "r.m.s. residual (arcseconds)", "Computer name", "4-hexdigit flags", "Date of last observation (YYYMMDD)", "Linear eccentricity (AU)", "Semi-minor axis (AU)", "Major axis (AU)", "Minor axis (AU)", "Eccentric anomaly (degrees)", "True anomaly (degrees)", "Perihelion distance (AU)", "Aphelion distance (AU)", "Longitude of Descending node (degrees)", "Argument of aphelion (degrees)", "Focal parameter (AU)", "Semi-latus rectum (AU)", "Latus rectum (AU)", "Orbital period (years)", "Orbital area (AU²)", "Orbital perimeter (AU)", "Semi-mean axis (AU)", "Mean axis (AU)", "Standard gravitational parameter (AU³/a²)" });
+			checkedListBoxOrbitalElements.Location = new Point(0, 0);
 			checkedListBoxOrbitalElements.Margin = new Padding(4, 3, 4, 3);
 			checkedListBoxOrbitalElements.Name = "checkedListBoxOrbitalElements";
-			checkedListBoxOrbitalElements.Size = new Size(327, 277);
+			checkedListBoxOrbitalElements.Size = new Size(284, 299);
 			checkedListBoxOrbitalElements.TabIndex = 0;
 			checkedListBoxOrbitalElements.ToolTipValues.Description = "Checks some orbital elements to print on a data sheet.";
 			checkedListBoxOrbitalElements.ToolTipValues.EnableToolTips = true;
@@ -301,31 +159,448 @@ namespace Planetoid_DB
 			checkedListBoxOrbitalElements.MouseEnter += Control_Enter;
 			checkedListBoxOrbitalElements.MouseLeave += Control_Leave;
 			// 
-			// saveFileDialogTxt
-			// 
-			saveFileDialogTxt.DefaultExt = "txt";
-			saveFileDialogTxt.Filter = "text files|*.txt|all files|*.*";
-			// 
-			// saveFileDialogHtml
-			// 
-			saveFileDialogHtml.DefaultExt = "html";
-			saveFileDialogHtml.Filter = "HTML files|*.html|all files|*.*";
-			// 
-			// saveFileDialogXml
-			// 
-			saveFileDialogXml.DefaultExt = "xml";
-			saveFileDialogXml.Filter = "XML files|*.xml|all files|*.*";
-			// 
-			// saveFileDialogJson
-			// 
-			saveFileDialogJson.DefaultExt = "json";
-			saveFileDialogJson.Filter = "JSON files|*.json|all files|*.*";
-			// 
 			// kryptonManager
 			// 
 			kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 			kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 			kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+			// 
+			// toolStripContainer
+			// 
+			toolStripContainer.AccessibleDescription = "Container to arrange the toolbars";
+			toolStripContainer.AccessibleName = "Container to arrange the toolbars";
+			toolStripContainer.AccessibleRole = AccessibleRole.Grouping;
+			toolStripContainer.Enter += Control_Enter;
+			toolStripContainer.Leave += Control_Leave;
+			toolStripContainer.MouseEnter += Control_Enter;
+			toolStripContainer.MouseLeave += Control_Leave;
+
+			// 
+			// toolStripContainer.BottomToolStripPanel
+			// 
+			toolStripContainer.BottomToolStripPanel.Controls.Add(statusStrip);
+			// 
+			// toolStripContainer.ContentPanel
+			// 
+			toolStripContainer.ContentPanel.Controls.Add(panel);
+			toolStripContainer.ContentPanel.Size = new Size(284, 299);
+			toolStripContainer.Dock = DockStyle.Fill;
+			toolStripContainer.Location = new Point(0, 0);
+			toolStripContainer.Name = "toolStripContainer";
+			toolStripContainer.Size = new Size(284, 346);
+			toolStripContainer.TabIndex = 5;
+			toolStripContainer.Text = "toolStripContainer";
+			// 
+			// toolStripContainer.TopToolStripPanel
+			// 
+			toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripIcons);
+			// 
+			// kryptonToolStripIcons
+			// 
+			kryptonToolStripIcons.AccessibleDescription = "Toolbar of exporting orbital elements to file";
+			kryptonToolStripIcons.AccessibleName = "Toolbar of exporting orbital elements to file";
+			kryptonToolStripIcons.AccessibleRole = AccessibleRole.ToolBar;
+			kryptonToolStripIcons.Dock = DockStyle.None;
+			kryptonToolStripIcons.Font = new Font("Segoe UI", 9F);
+			kryptonToolStripIcons.Items.AddRange(new ToolStripItem[] { toolStripDropDownButtonExport, toolStripSeparator1, toolStripButtonMarkAll, toolStripButtonUnmarkAll });
+			kryptonToolStripIcons.Location = new Point(0, 0);
+			kryptonToolStripIcons.Name = "kryptonToolStripIcons";
+			kryptonToolStripIcons.Size = new Size(284, 25);
+			kryptonToolStripIcons.Stretch = true;
+			kryptonToolStripIcons.TabIndex = 0;
+			kryptonToolStripIcons.TabStop = true;	
+			kryptonToolStripIcons.Enter += Control_Enter;
+			kryptonToolStripIcons.Leave += Control_Leave;
+			kryptonToolStripIcons.MouseEnter += Control_Enter;
+			kryptonToolStripIcons.MouseLeave += Control_Leave;
+			// 
+			// toolStripDropDownButtonExport
+			// 
+			toolStripDropDownButtonExport.AccessibleDescription = "Exports the data entry";
+			toolStripDropDownButtonExport.AccessibleName = "Export";
+			toolStripDropDownButtonExport.AccessibleRole = AccessibleRole.PushButton;
+			toolStripDropDownButtonExport.DropDown = contextMenuExport;
+			toolStripDropDownButtonExport.Image = FatcowIcons16px.fatcow_document_export_16px;
+			toolStripDropDownButtonExport.ImageTransparentColor = Color.Magenta;
+			toolStripDropDownButtonExport.Name = "toolStripDropDownButtonExport";
+			toolStripDropDownButtonExport.Size = new Size(70, 22);
+			toolStripDropDownButtonExport.Text = "&Export";
+			toolStripDropDownButtonExport.MouseEnter += Control_Enter;
+			toolStripDropDownButtonExport.MouseLeave += Control_Leave;
+			// 
+			// contextMenuExport
+			// 
+			contextMenuExport.AccessibleDescription = "Exports data sheet";
+			contextMenuExport.AccessibleName = "Export";
+			contextMenuExport.AccessibleRole = AccessibleRole.MenuPopup;
+			contextMenuExport.Font = new Font("Segoe UI", 9F);
+			contextMenuExport.Items.AddRange(new ToolStripItem[] { toolStripMenuItemExportAsText, toolStripMenuItemExportAsLatex, toolStripMenuItemExportAsMarkdown, toolStripMenuItemExportAsWord, toolStripMenuItemExportAsOdt, toolStripMenuItemExportAsRtf, toolStripMenuItemExportAsExcel, toolStripMenuItemExportAsOds, toolStripMenuItemExportAsCsv, toolStripMenuItemExportAsTsv, toolStripMenuItemExportAsPsv, toolStripMenuItemExportAsHtml, toolStripMenuItemExportAsXml, toolStripMenuItemExportAsJson, toolStripMenuItemExportAsYaml, toolStripMenuItemExportAsSql, toolStripMenuItemExportAsPdf, toolStripMenuItemExportAsPostScript, toolStripMenuItemExportAsEpub, toolStripMenuItemExportAsMobi });
+			contextMenuExport.Name = "contextMenuSaveToFile";
+			contextMenuExport.Size = new Size(226, 444);
+			contextMenuExport.TabStop = true;
+			contextMenuExport.Text = "Export";	 
+			contextMenuExport.MouseEnter += Control_Enter;
+			contextMenuExport.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsText
+			// 
+			toolStripMenuItemExportAsText.AccessibleDescription = "Exports the information as text file";
+			toolStripMenuItemExportAsText.AccessibleName = "Export as text";
+			toolStripMenuItemExportAsText.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsText.AutoToolTip = true;
+			toolStripMenuItemExportAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemExportAsText.Name = "toolStripMenuItemExportAsText";
+			toolStripMenuItemExportAsText.ShortcutKeyDisplayString = "Strg+X";
+			toolStripMenuItemExportAsText.ShortcutKeys = Keys.Control | Keys.X;
+			toolStripMenuItemExportAsText.Size = new Size(225, 22);
+			toolStripMenuItemExportAsText.Text = "Export as te&xt";
+			toolStripMenuItemExportAsText.Click += ToolStripMenuItemExportAsText_Click;
+			toolStripMenuItemExportAsText.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsText.MouseLeave += Control_Leave;
+
+			// 
+			// toolStripMenuItemExportAsLatex
+			// 
+			toolStripMenuItemExportAsLatex.AccessibleDescription = "Exports the information as Latex file";
+			toolStripMenuItemExportAsLatex.AccessibleName = "Export as Latex";
+			toolStripMenuItemExportAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsLatex.AutoToolTip = true;
+			toolStripMenuItemExportAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemExportAsLatex.Name = "toolStripMenuItemExportAsLatex";
+			toolStripMenuItemExportAsLatex.ShortcutKeyDisplayString = "Strg+E";
+			toolStripMenuItemExportAsLatex.ShortcutKeys = Keys.Control | Keys.E;
+			toolStripMenuItemExportAsLatex.Size = new Size(225, 22);
+			toolStripMenuItemExportAsLatex.Text = "Export as Lat&ex";
+			toolStripMenuItemExportAsLatex.Click += ToolStripMenuItemExportAsLatex_Click;
+			toolStripMenuItemExportAsLatex.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsLatex.MouseLeave += Control_Leave;
+
+			// 
+			// toolStripMenuItemExportAsMarkdown
+			// 
+			toolStripMenuItemExportAsMarkdown.AccessibleDescription = "Exports the information as Markdown file";
+			toolStripMenuItemExportAsMarkdown.AccessibleName = "Export as Markdown";
+			toolStripMenuItemExportAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsMarkdown.AutoToolTip = true;
+			toolStripMenuItemExportAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+			toolStripMenuItemExportAsMarkdown.Name = "toolStripMenuItemExportAsMarkdown";
+			toolStripMenuItemExportAsMarkdown.ShortcutKeyDisplayString = "Strg+K";
+			toolStripMenuItemExportAsMarkdown.ShortcutKeys = Keys.Control | Keys.K;
+			toolStripMenuItemExportAsMarkdown.Size = new Size(225, 22);
+			toolStripMenuItemExportAsMarkdown.Text = "Export as Mar&kdown";
+			toolStripMenuItemExportAsMarkdown.Click += ToolStripMenuItemExportAsMarkdown_Click;
+			toolStripMenuItemExportAsMarkdown.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsMarkdown.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsWord
+			// 
+			toolStripMenuItemExportAsWord.AccessibleDescription = "Exports the information as Word file";
+			toolStripMenuItemExportAsWord.AccessibleName = "Export as Word";
+			toolStripMenuItemExportAsWord.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsWord.AutoToolTip = true;
+			toolStripMenuItemExportAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemExportAsWord.Name = "toolStripMenuItemExportAsWord";
+			toolStripMenuItemExportAsWord.ShortcutKeyDisplayString = "Strg+W";
+			toolStripMenuItemExportAsWord.ShortcutKeys = Keys.Control | Keys.W;
+			toolStripMenuItemExportAsWord.Size = new Size(225, 22);
+			toolStripMenuItemExportAsWord.Text = "Export as &Word";
+			toolStripMenuItemExportAsWord.Click += ToolStripMenuItemExportAsWord_Click;
+			toolStripMenuItemExportAsWord.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsWord.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsOdt
+			// 
+			toolStripMenuItemExportAsOdt.AccessibleDescription = "Exports the information as ODT file";
+			toolStripMenuItemExportAsOdt.AccessibleName = "Export as ODT";
+			toolStripMenuItemExportAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsOdt.AutoToolTip = true;
+			toolStripMenuItemExportAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemExportAsOdt.Name = "toolStripMenuItemExportAsOdt";
+			toolStripMenuItemExportAsOdt.ShortcutKeyDisplayString = "Strg+D";
+			toolStripMenuItemExportAsOdt.ShortcutKeys = Keys.Control | Keys.D;
+			toolStripMenuItemExportAsOdt.Size = new Size(225, 22);
+			toolStripMenuItemExportAsOdt.Text = "Export as O&DT";
+			toolStripMenuItemExportAsOdt.Click += ToolStripMenuItemExportAsOdt_Click;
+			toolStripMenuItemExportAsOdt.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsOdt.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsRtf
+			// 
+			toolStripMenuItemExportAsRtf.AccessibleDescription = "Exports the information as RTF file";
+			toolStripMenuItemExportAsRtf.AccessibleName = "Export as RTF";
+			toolStripMenuItemExportAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsRtf.AutoToolTip = true;
+			toolStripMenuItemExportAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+			toolStripMenuItemExportAsRtf.Name = "toolStripMenuItemExportAsRtf";
+			toolStripMenuItemExportAsRtf.ShortcutKeyDisplayString = "Strg+R";
+			toolStripMenuItemExportAsRtf.ShortcutKeys = Keys.Control | Keys.R;
+			toolStripMenuItemExportAsRtf.Size = new Size(225, 22);
+			toolStripMenuItemExportAsRtf.Text = "Export as &RTF";
+			toolStripMenuItemExportAsRtf.Click += ToolStripMenuItemExportAsRtf_Click;
+			toolStripMenuItemExportAsRtf.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsRtf.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsExcel
+			// 
+			toolStripMenuItemExportAsExcel.AccessibleDescription = "Exports the information as Excel file";
+			toolStripMenuItemExportAsExcel.AccessibleName = "Export as Excel";
+			toolStripMenuItemExportAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsExcel.AutoToolTip = true;
+			toolStripMenuItemExportAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemExportAsExcel.Name = "toolStripMenuItemExportAsExcel";
+			toolStripMenuItemExportAsExcel.ShortcutKeyDisplayString = "Strg+L";
+			toolStripMenuItemExportAsExcel.ShortcutKeys = Keys.Control | Keys.L;
+			toolStripMenuItemExportAsExcel.Size = new Size(225, 22);
+			toolStripMenuItemExportAsExcel.Text = "Export as Exce&l";
+			toolStripMenuItemExportAsExcel.Click += ToolStripMenuItemExportAsExcel_Click;
+			toolStripMenuItemExportAsExcel.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsExcel.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsOds
+			// 
+			toolStripMenuItemExportAsOds.AccessibleDescription = "Exports the information as ODS file";
+			toolStripMenuItemExportAsOds.AccessibleName = "Export as ODS";
+			toolStripMenuItemExportAsOds.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsOds.AutoToolTip = true;
+			toolStripMenuItemExportAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemExportAsOds.Name = "toolStripMenuItemExportAsOds";
+			toolStripMenuItemExportAsOds.ShortcutKeyDisplayString = "Strg+S";
+			toolStripMenuItemExportAsOds.ShortcutKeys = Keys.Control | Keys.S;
+			toolStripMenuItemExportAsOds.Size = new Size(225, 22);
+			toolStripMenuItemExportAsOds.Text = "Export as OD&S";
+			toolStripMenuItemExportAsOds.Click += ToolStripMenuItemExportAsOds_Click;
+			toolStripMenuItemExportAsOds.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsOds.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsCsv
+			// 
+			toolStripMenuItemExportAsCsv.AccessibleDescription = "Exports the information as CSV file";
+			toolStripMenuItemExportAsCsv.AccessibleName = "Export as CSV";
+			toolStripMenuItemExportAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsCsv.AutoToolTip = true;
+			toolStripMenuItemExportAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemExportAsCsv.Name = "toolStripMenuItemExportAsCsv";
+			toolStripMenuItemExportAsCsv.ShortcutKeyDisplayString = "Strg+C";
+			toolStripMenuItemExportAsCsv.ShortcutKeys = Keys.Control | Keys.C;
+			toolStripMenuItemExportAsCsv.Size = new Size(225, 22);
+			toolStripMenuItemExportAsCsv.Text = "Export as &CSV";
+			toolStripMenuItemExportAsCsv.Click += ToolStripMenuItemExportAsCsv_Click;
+			toolStripMenuItemExportAsCsv.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsCsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsTsv
+			// 
+			toolStripMenuItemExportAsTsv.AccessibleDescription = "Exports the information as TSV file";
+			toolStripMenuItemExportAsTsv.AccessibleName = "Export as TSV";
+			toolStripMenuItemExportAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsTsv.AutoToolTip = true;
+			toolStripMenuItemExportAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemExportAsTsv.Name = "toolStripMenuItemExportAsTsv";
+			toolStripMenuItemExportAsTsv.ShortcutKeyDisplayString = "Strg+T";
+			toolStripMenuItemExportAsTsv.ShortcutKeys = Keys.Control | Keys.T;
+			toolStripMenuItemExportAsTsv.Size = new Size(225, 22);
+			toolStripMenuItemExportAsTsv.Text = "Export as &TSV";
+			toolStripMenuItemExportAsTsv.Click += ToolStripMenuItemExportAsTsv_Click;
+			toolStripMenuItemExportAsTsv.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsTsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsPsv
+			// 
+			toolStripMenuItemExportAsPsv.AccessibleDescription = "Exports the information as PSV file";
+			toolStripMenuItemExportAsPsv.AccessibleName = "Export as PSV";
+			toolStripMenuItemExportAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsPsv.AutoToolTip = true;
+			toolStripMenuItemExportAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+			toolStripMenuItemExportAsPsv.Name = "toolStripMenuItemExportAsPsv";
+			toolStripMenuItemExportAsPsv.ShortcutKeyDisplayString = "Strg+V";
+			toolStripMenuItemExportAsPsv.ShortcutKeys = Keys.Control | Keys.V;
+			toolStripMenuItemExportAsPsv.Size = new Size(225, 22);
+			toolStripMenuItemExportAsPsv.Text = "Export as PS&V";
+			toolStripMenuItemExportAsPsv.Click += ToolStripMenuItemExportAsPsv_Click;
+			toolStripMenuItemExportAsPsv.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsPsv.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsHtml
+			// 
+			toolStripMenuItemExportAsHtml.AccessibleDescription = "Exports the information as HTML file";
+			toolStripMenuItemExportAsHtml.AccessibleName = "Export as HTML";
+			toolStripMenuItemExportAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsHtml.AutoToolTip = true;
+			toolStripMenuItemExportAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+			toolStripMenuItemExportAsHtml.Name = "toolStripMenuItemExportAsHtml";
+			toolStripMenuItemExportAsHtml.ShortcutKeyDisplayString = "Strg+H";
+			toolStripMenuItemExportAsHtml.ShortcutKeys = Keys.Control | Keys.H;
+			toolStripMenuItemExportAsHtml.Size = new Size(225, 22);
+			toolStripMenuItemExportAsHtml.Text = "Export as &HTML";
+			toolStripMenuItemExportAsHtml.Click += ToolStripMenuItemExportAsHtml_Click;
+			toolStripMenuItemExportAsHtml.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsHtml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsXml
+			// 
+			toolStripMenuItemExportAsXml.AccessibleDescription = "Exports the information as XML file";
+			toolStripMenuItemExportAsXml.AccessibleName = "Export as XML";
+			toolStripMenuItemExportAsXml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsXml.AutoToolTip = true;
+			toolStripMenuItemExportAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+			toolStripMenuItemExportAsXml.Name = "toolStripMenuItemExportAsXml";
+			toolStripMenuItemExportAsXml.ShortcutKeyDisplayString = "Strg+M";
+			toolStripMenuItemExportAsXml.ShortcutKeys = Keys.Control | Keys.M;
+			toolStripMenuItemExportAsXml.Size = new Size(225, 22);
+			toolStripMenuItemExportAsXml.Text = "Export as X&ML";
+			toolStripMenuItemExportAsXml.Click += ToolStripMenuItemExportAsXml_Click;
+			toolStripMenuItemExportAsXml.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsXml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsJson
+			// 
+			toolStripMenuItemExportAsJson.AccessibleDescription = "Exports the information as JSON file";
+			toolStripMenuItemExportAsJson.AccessibleName = "Export as JSON";
+			toolStripMenuItemExportAsJson.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsJson.AutoToolTip = true;
+			toolStripMenuItemExportAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+			toolStripMenuItemExportAsJson.Name = "toolStripMenuItemExportAsJson";
+			toolStripMenuItemExportAsJson.ShortcutKeyDisplayString = "Strg+J";
+			toolStripMenuItemExportAsJson.ShortcutKeys = Keys.Control | Keys.J;
+			toolStripMenuItemExportAsJson.Size = new Size(225, 22);
+			toolStripMenuItemExportAsJson.Text = "Export as &JSON";
+			toolStripMenuItemExportAsJson.Click += ToolStripMenuItemExportAsJson_Click;
+			toolStripMenuItemExportAsJson.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsJson.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsYaml
+			// 
+			toolStripMenuItemExportAsYaml.AccessibleDescription = "Exports the information as YAML file";
+			toolStripMenuItemExportAsYaml.AccessibleName = "Export as YAML";
+			toolStripMenuItemExportAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsYaml.AutoToolTip = true;
+			toolStripMenuItemExportAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+			toolStripMenuItemExportAsYaml.Name = "toolStripMenuItemExportAsYaml";
+			toolStripMenuItemExportAsYaml.ShortcutKeyDisplayString = "Strg+Y";
+			toolStripMenuItemExportAsYaml.ShortcutKeys = Keys.Control | Keys.Y;
+			toolStripMenuItemExportAsYaml.Size = new Size(225, 22);
+			toolStripMenuItemExportAsYaml.Text = "Export as &YAML";
+			toolStripMenuItemExportAsYaml.Click += ToolStripMenuItemExportAsYaml_Click;
+			toolStripMenuItemExportAsYaml.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsYaml.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsSql
+			// 
+			toolStripMenuItemExportAsSql.AccessibleDescription = "Exports the information as SQL script";
+			toolStripMenuItemExportAsSql.AccessibleName = "Export as SQL";
+			toolStripMenuItemExportAsSql.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsSql.AutoToolTip = true;
+			toolStripMenuItemExportAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+			toolStripMenuItemExportAsSql.Name = "toolStripMenuItemExportAsSql";
+			toolStripMenuItemExportAsSql.ShortcutKeyDisplayString = "Strg+Q";
+			toolStripMenuItemExportAsSql.ShortcutKeys = Keys.Control | Keys.Q;
+			toolStripMenuItemExportAsSql.Size = new Size(225, 22);
+			toolStripMenuItemExportAsSql.Text = "Export as S&QL";
+			toolStripMenuItemExportAsSql.Click += ToolStripMenuItemExportAsSql_Click;
+			toolStripMenuItemExportAsSql.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsSql.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsPdf
+			// 
+			toolStripMenuItemExportAsPdf.AccessibleDescription = "Exports the information as PDF file";
+			toolStripMenuItemExportAsPdf.AccessibleName = "Export as PDF";
+			toolStripMenuItemExportAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsPdf.AutoToolTip = true;
+			toolStripMenuItemExportAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemExportAsPdf.Name = "toolStripMenuItemExportAsPdf";
+			toolStripMenuItemExportAsPdf.ShortcutKeyDisplayString = "Strg+F";
+			toolStripMenuItemExportAsPdf.ShortcutKeys = Keys.Control | Keys.F;
+			toolStripMenuItemExportAsPdf.Size = new Size(225, 22);
+			toolStripMenuItemExportAsPdf.Text = "Export as PD&F";
+			toolStripMenuItemExportAsPdf.Click += ToolStripMenuItemExportAsPdf_Click;
+			toolStripMenuItemExportAsPdf.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsPdf.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsPostScript
+			// 
+			toolStripMenuItemExportAsPostScript.AccessibleDescription = "Exports the information as PostScript file";
+			toolStripMenuItemExportAsPostScript.AccessibleName = "Export as PS";
+			toolStripMenuItemExportAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsPostScript.AutoToolTip = true;
+			toolStripMenuItemExportAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemExportAsPostScript.Name = "toolStripMenuItemExportAsPostScript";
+			toolStripMenuItemExportAsPostScript.ShortcutKeyDisplayString = "Strg+P";
+			toolStripMenuItemExportAsPostScript.ShortcutKeys = Keys.Control | Keys.P;
+			toolStripMenuItemExportAsPostScript.Size = new Size(225, 22);
+			toolStripMenuItemExportAsPostScript.Text = "Export as &PS";
+			toolStripMenuItemExportAsPostScript.Click += ToolStripMenuItemExportAsPostScript_Click;
+			toolStripMenuItemExportAsPostScript.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsPostScript.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsEpub
+			// 
+			toolStripMenuItemExportAsEpub.AccessibleDescription = "Exports the information as EPUB file";
+			toolStripMenuItemExportAsEpub.AccessibleName = "Export as EPUB";
+			toolStripMenuItemExportAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsEpub.AutoToolTip = true;
+			toolStripMenuItemExportAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemExportAsEpub.Name = "toolStripMenuItemExportAsEpub";
+			toolStripMenuItemExportAsEpub.ShortcutKeyDisplayString = "Strg+B";
+			toolStripMenuItemExportAsEpub.ShortcutKeys = Keys.Control | Keys.B;
+			toolStripMenuItemExportAsEpub.Size = new Size(225, 22);
+			toolStripMenuItemExportAsEpub.Text = "Export as EPU&B";
+			toolStripMenuItemExportAsEpub.Click += ToolStripMenuItemExportAsEpub_Click;
+			toolStripMenuItemExportAsEpub.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsEpub.MouseLeave += Control_Leave;
+			// 
+			// toolStripMenuItemExportAsMobi
+			// 
+			toolStripMenuItemExportAsMobi.AccessibleDescription = "Exports the information as MOBI file";
+			toolStripMenuItemExportAsMobi.AccessibleName = "Export as MOBI";
+			toolStripMenuItemExportAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+			toolStripMenuItemExportAsMobi.AutoToolTip = true;
+			toolStripMenuItemExportAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+			toolStripMenuItemExportAsMobi.Name = "toolStripMenuItemExportAsMobi";
+			toolStripMenuItemExportAsMobi.ShortcutKeyDisplayString = "Strg+I";
+			toolStripMenuItemExportAsMobi.ShortcutKeys = Keys.Control | Keys.I;
+			toolStripMenuItemExportAsMobi.Size = new Size(225, 22);
+			toolStripMenuItemExportAsMobi.Text = "Export as MOB&I";
+			toolStripMenuItemExportAsMobi.Click += ToolStripMenuItemExportAsMobi_Click;
+			toolStripMenuItemExportAsMobi.MouseEnter += Control_Enter;
+			toolStripMenuItemExportAsMobi.MouseLeave += Control_Leave;
+			// 
+			// toolStripSeparator1
+			// 
+			toolStripSeparator1.AccessibleDescription = "Just a separator";
+			toolStripSeparator1.AccessibleName = "Just a separator";
+			toolStripSeparator1.AccessibleRole = AccessibleRole.Separator;
+			toolStripSeparator1.Name = "toolStripSeparator1";
+			toolStripSeparator1.Size = new Size(6, 25);
+			toolStripSeparator1.MouseEnter += Control_Enter;
+			toolStripSeparator1.MouseLeave += Control_Leave;
+			// 
+			// toolStripButtonMarkAll
+			// 
+			toolStripButtonMarkAll.AccessibleDescription = "Marks all orbital elements in the list";
+			toolStripButtonMarkAll.AccessibleName = "Mark all orbital elements";
+			toolStripButtonMarkAll.AccessibleRole = AccessibleRole.PushButton;
+			toolStripButtonMarkAll.Image = FatcowIcons16px.fatcow_check_box_16px;
+			toolStripButtonMarkAll.ImageTransparentColor = Color.Magenta;
+			toolStripButtonMarkAll.Name = "toolStripButtonMarkAll";
+			toolStripButtonMarkAll.Size = new Size(69, 22);
+			toolStripButtonMarkAll.Text = "&Mark all";
+			toolStripButtonMarkAll.Click += ToolStripButtonMarkAll_Click;
+			toolStripButtonMarkAll.MouseEnter += Control_Enter;
+			toolStripButtonMarkAll.MouseLeave += Control_Leave;
+			// 
+			// toolStripButtonUnmarkAll
+			// 
+			toolStripButtonUnmarkAll.AccessibleDescription = "Unmarks all orbital elements in the list";
+			toolStripButtonUnmarkAll.AccessibleName = "Unmark all orbital elements";
+			toolStripButtonUnmarkAll.AccessibleRole = AccessibleRole.PushButton;
+			toolStripButtonUnmarkAll.Image = FatcowIcons16px.fatcow_check_box_uncheck_16px;
+			toolStripButtonUnmarkAll.ImageTransparentColor = Color.Magenta;
+			toolStripButtonUnmarkAll.Name = "toolStripButtonUnmarkAll";
+			toolStripButtonUnmarkAll.Size = new Size(84, 22);
+			toolStripButtonUnmarkAll.Text = "&Unmark all";
+			toolStripButtonUnmarkAll.Click += ToolStripButtonUnmarkAll_Click;
+			toolStripButtonUnmarkAll.MouseEnter += Control_Enter;
+			toolStripButtonUnmarkAll.MouseLeave += Control_Leave;
 			// 
 			// ExportDataSheetForm
 			// 
@@ -334,7 +609,7 @@ namespace Planetoid_DB
 			AccessibleRole = AccessibleRole.Dialog;
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
-			ClientSize = new Size(474, 330);
+			ClientSize = new Size(284, 346);
 			ControlBox = false;
 			Controls.Add(toolStripContainer);
 			FormBorderStyle = FormBorderStyle.FixedToolWindow;
@@ -349,32 +624,53 @@ namespace Planetoid_DB
 			Load += ExportDataSheetForm_Load;
 			statusStrip.ResumeLayout(false);
 			statusStrip.PerformLayout();
+			((ISupportInitialize)panel).EndInit();
+			panel.ResumeLayout(false);
 			toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
 			toolStripContainer.BottomToolStripPanel.PerformLayout();
 			toolStripContainer.ContentPanel.ResumeLayout(false);
+			toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+			toolStripContainer.TopToolStripPanel.PerformLayout();
 			toolStripContainer.ResumeLayout(false);
 			toolStripContainer.PerformLayout();
-			((ISupportInitialize)panel).EndInit();
-			panel.ResumeLayout(false);
+			kryptonToolStripIcons.ResumeLayout(false);
+			kryptonToolStripIcons.PerformLayout();
+			contextMenuExport.ResumeLayout(false);
 			ResumeLayout(false);
 		}
 
 		#endregion
-		private KryptonButton buttonExportAsHtml;
-		private KryptonButton buttonExportAsTxt;
-		private KryptonButton buttonExportAsXml;
-		private KryptonButton buttonExportAsJson;
 		private KryptonStatusStrip statusStrip;
-		private ToolStripStatusLabel labelInformation;
-		private SaveFileDialog saveFileDialogTxt;
-		private SaveFileDialog saveFileDialogHtml;
-		private SaveFileDialog saveFileDialogXml;
-		private SaveFileDialog saveFileDialogJson;
-		private ToolStripContainer toolStripContainer;
+		private ToolStripStatusLabel labelStatus;
 		private KryptonPanel panel;
 		private KryptonCheckedListBox checkedListBoxOrbitalElements;
-		private KryptonButton buttonUnmarkAll;
-		private KryptonButton buttonMarkAll;
 		private KryptonManager kryptonManager;
+		private ToolStripContainer toolStripContainer;
+		private KryptonToolStrip kryptonToolStripIcons;
+		private ToolStripDropDownButton toolStripDropDownButtonExport;
+		private ToolStripSeparator toolStripSeparator1;
+		private ToolStripButton toolStripButtonMarkAll;
+		private ToolStripButton toolStripButtonUnmarkAll;
+		private ContextMenuStrip contextMenuExport;
+		private ToolStripMenuItem toolStripMenuItemExportAsText;
+		private ToolStripMenuItem toolStripMenuItemExportAsLatex;
+		private ToolStripMenuItem toolStripMenuItemExportAsMarkdown;
+		private ToolStripMenuItem toolStripMenuItemExportAsWord;
+		private ToolStripMenuItem toolStripMenuItemExportAsOdt;
+		private ToolStripMenuItem toolStripMenuItemExportAsRtf;
+		private ToolStripMenuItem toolStripMenuItemExportAsExcel;
+		private ToolStripMenuItem toolStripMenuItemExportAsOds;
+		private ToolStripMenuItem toolStripMenuItemExportAsCsv;
+		private ToolStripMenuItem toolStripMenuItemExportAsTsv;
+		private ToolStripMenuItem toolStripMenuItemExportAsPsv;
+		private ToolStripMenuItem toolStripMenuItemExportAsHtml;
+		private ToolStripMenuItem toolStripMenuItemExportAsXml;
+		private ToolStripMenuItem toolStripMenuItemExportAsJson;
+		private ToolStripMenuItem toolStripMenuItemExportAsYaml;
+		private ToolStripMenuItem toolStripMenuItemExportAsSql;
+		private ToolStripMenuItem toolStripMenuItemExportAsPdf;
+		private ToolStripMenuItem toolStripMenuItemExportAsPostScript;
+		private ToolStripMenuItem toolStripMenuItemExportAsEpub;
+		private ToolStripMenuItem toolStripMenuItemExportAsMobi;
 	}
 }

--- a/Forms/ExportDataSheetForm.cs
+++ b/Forms/ExportDataSheetForm.cs
@@ -6,6 +6,7 @@
 using Planetoid_DB.Forms;
 
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Text;
 
 namespace Planetoid_DB;
@@ -33,7 +34,7 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 	/// <remarks>
 	/// Derived classes should override this property to provide the specific label.
 	/// </remarks>
-	protected override ToolStripStatusLabel? StatusLabel => labelInformation;
+	protected override ToolStripStatusLabel? StatusLabel => labelStatus;
 
 	#region constructor
 
@@ -87,8 +88,7 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 			// Check or uncheck the item at index i
 			checkedListBoxOrbitalElements.SetItemChecked(index: i, value: check);
 		}
-		// Enable or disable the export buttons based on the check state
-		buttonExportAsTxt.Enabled = buttonExportAsHtml.Enabled = buttonExportAsXml.Enabled = buttonExportAsJson.Enabled = check;
+		toolStripDropDownButtonExport.Enabled = !IsAllUnmarked();
 	}
 
 	/// <summary>
@@ -139,7 +139,7 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 	/// </remarks>
 	private void ExportDataSheetForm_Load(object sender, EventArgs e)
 	{
-		ClearStatusBar(label: labelInformation); // Clear the status bar text
+		ClearStatusBar(label: labelStatus); // Clear the status bar text
 		MarkAll(); // Mark all items in the list
 	}
 
@@ -148,29 +148,81 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 	#region Click & ButtonClick event handlers
 
 	/// <summary>
-	/// Handles the Click event of the Export As TXT button.
-	/// Prompts the user for a destination file, then writes each checked orbital element
-	/// and its corresponding value as plain text lines in the format "Label: Value".
+	/// Handles the Click event of the Mark All tool strip button.
+	/// Marks all items in the orbital elements checklist.
 	/// </summary>
-	/// <param name="sender">Event source (the export button).</param>
+	/// <param name="sender">Event source (the Mark All tool strip button).</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>
-	/// This method is used to export the selected orbital elements as a plain text file.
+	/// This method is used to mark all items in the orbital elements checklist.
 	/// </remarks>
-	private void ButtonExportAsTxt_Click(object sender, EventArgs e)
+	private void ToolStripButtonMarkAll_Click(object sender, EventArgs e) => MarkAll();
+
+	/// <summary>
+	/// Handles the Click event of the Unmark All tool strip button.
+	/// Unmarks all items in the orbital elements checklist.
+	/// </summary>
+	/// <param name="sender">Event source (the Unmark All tool strip button).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is used to unmark all items in the orbital elements checklist.
+	/// </remarks>
+	private void ToolStripButtonUnmarkAll_Click(object sender, EventArgs e) => UnmarkAll();
+
+	#endregion
+
+	#region SelectedIndexChanged event handlers
+
+	/// <summary>
+	/// Handles the SelectedIndexChanged event of the orbital elements checklist.
+	/// Enables or disables the export buttons depending on whether any items are checked.
+	/// If all items are unmarked (unchecked) the export buttons are disabled; otherwise they are enabled.
+	/// </summary>
+	/// <param name="sender">Event source (the checked list box).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is used to enable or disable the export buttons based on the selection state of the orbital elements.
+	/// </remarks>
+	private void CheckedListBoxOrbitalElements_SelectedIndexChanged(object sender, EventArgs e)
 	{
+		// Enable or disable the export buttons based on whether all items are unmarked
+		// If all items are unmarked, disable the export buttons
+		// If not all items are unmarked, enable the export buttons
+		toolStripDropDownButtonExport.Enabled = !IsAllUnmarked();
+	}
+
+	#endregion
+
+	/// <summary>
+	/// Handles the Click event of the Export As Text menu item.
+	/// Exports the selected orbital elements to a text file.
+	/// </summary>
+	/// <param name="sender">Event source (the Export As Text menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is used to export the selected orbital elements to a text file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsText_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported text file
+		using SaveFileDialog saveFileDialogText = new()
+		{
+			Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
+			DefaultExt = "txt",
+			Title = "Save database information as text"
+		};
 		// Set the initial directory for the save file dialog to the user's documents folder
-		saveFileDialogTxt.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		saveFileDialogText.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
 		// Set the initial directory for the save file dialog to the user's documents folder
-		saveFileDialogTxt.FileName = $"{orbitElements[index: 0]}.{saveFileDialogTxt.DefaultExt}";
+		saveFileDialogText.FileName = $"{orbitElements[index: 0]}.{saveFileDialogText.DefaultExt}";
 		// Show the save file dialog to select the file path and name
 		// If the user selects a file, proceed with exporting
-		if (saveFileDialogTxt.ShowDialog() != DialogResult.OK)
+		if (saveFileDialogText.ShowDialog() != DialogResult.OK)
 		{
 			return;
 		}
 		// Create a new StreamWriter to write the text content to the specified file
-		using StreamWriter streamWriter = new(path: saveFileDialogTxt.FileName);
+		using StreamWriter streamWriter = new(path: saveFileDialogText.FileName);
 		// Write the orbit elements to the text file
 		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
 		{
@@ -190,20 +242,883 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 				streamWriter.Write(value: Environment.NewLine);
 			}
 		}
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>
-	/// Handles the Click event of the Export As HTML button.
-	/// Prompts the user for a destination file, then writes each checked orbital element
-	/// and its corresponding value as HTML lines in the format "<p>Label: Value</p>".
+	/// Handles the Click event of the Export As LaTeX menu item.
+	/// Exports the selected orbital elements to a LaTeX file.
 	/// </summary>
-	/// <param name="sender">Event source (the export button).</param>
+	/// <param name="sender">Event source (the Export As LaTeX menu item).</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>
-	/// This method is used to export the selected orbital elements as an HTML file.
+	/// This method is used to export the selected orbital elements to a LaTeX file.
 	/// </remarks>
-	private void ButtonExportAsHtml_Click(object sender, EventArgs e)
+	private void ToolStripMenuItemExportAsLatex_Click(object sender, EventArgs e)
 	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported LaTeX file
+		using SaveFileDialog saveFileDialogLatex = new()
+		{
+			Filter = "LaTeX files (*.tex)|*.tex|All files (*.*)|*.*",
+			DefaultExt = "tex",
+			Title = "Save database information as LaTeX"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogLatex.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogLatex.FileName = $"{orbitElements[index: 0]}.{saveFileDialogLatex.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogLatex.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the LaTeX content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogLatex.FileName);
+		// Create a StringBuilder to build the LaTeX content
+		StringBuilder sb = new();
+		// Append the LaTeX content to the StringBuilder
+		_ = sb.AppendLine(value: "\\documentclass{article}");
+		_ = sb.AppendLine(value: "\\usepackage[utf8]{inputenc}");
+		_ = sb.AppendLine(value: "\\usepackage{amsmath}");
+		_ = sb.AppendLine(value: "\\usepackage{amsfonts}");
+		_ = sb.AppendLine(value: "\\usepackage{amssymb}");
+		_ = sb.AppendLine(value: "\\usepackage{geometry}");
+		_ = sb.AppendLine(value: "\\geometry{a4paper, margin=1in}");
+		_ = sb.AppendLine(handler: $"\\title{{Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}}}");
+		_ = sb.AppendLine(value: "\\begin{document}");
+		_ = sb.AppendLine(value: "\\maketitle");
+		_ = sb.AppendLine(value: "\\begin{itemize}");
+		// Append the orbit elements to the LaTeX content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, append the orbit element to the LaTeX content
+			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				// Append the orbit element to the LaTeX content
+				_ = sb.AppendLine(handler: $"\t\\item \\textbf{{{checkedListBoxOrbitalElements.Items[index: i]}:}} {orbitElements[index: i]}");
+			}
+		}
+		// Append the closing tags for the LaTeX content
+		_ = sb.AppendLine(value: "\\end{itemize}");
+		_ = sb.AppendLine(value: "\\end{document}");
+		// Write the LaTeX content to the file
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the Export As Markdown menu item.
+	/// Exports the selected orbital elements to a Markdown file.
+	/// </summary>
+	/// <param name="sender">Event source (the Export As Markdown menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is used to export the selected orbital elements to a Markdown file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsMarkdown_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported Markdown file
+		using SaveFileDialog saveFileDialogMarkdown = new()
+		{
+			Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+			DefaultExt = "md",
+			Title = "Save database information as Markdown"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogMarkdown.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogMarkdown.FileName = $"{orbitElements[index: 0]}.{saveFileDialogMarkdown.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogMarkdown.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the Markdown content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogMarkdown.FileName);
+		// Create a StringBuilder to build the Markdown content
+		StringBuilder sb = new();
+		// Write the Markdown header
+		_ = sb.AppendLine(value: $"# Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}");
+		_ = sb.AppendLine();
+		// Append the orbit elements to the Markdown content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, append the orbit element to the Markdown content
+			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				// Append the orbit element to the Markdown content
+				_ = sb.AppendLine(value: $"* **{checkedListBoxOrbitalElements.Items[index: i]}:** {orbitElements[index: i]}");
+			}
+		}
+		// Write the Markdown content to the file
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the Export As Word menu item.
+	/// Exports the selected orbital elements to a Word document.
+	/// </summary>
+	/// <param name="sender">Event source (the Export As Word menu item).</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>
+	/// This method is used to export the selected orbital elements to a Word document.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsWord_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported Word document
+		using SaveFileDialog saveFileDialogWord = new()
+		{
+			Filter = "Word files (*.docx)|*.docx|All files (*.*)|*.*",
+			DefaultExt = "docx",
+			Title = "Save database information as Word document"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogWord.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogWord.FileName = $"{orbitElements[index: 0]}.{saveFileDialogWord.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogWord.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Helper method to escape special XML characters in the content
+		static string EscapeXml(string value) => value
+			.Replace(oldValue: "&", newValue: "&amp;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "<", newValue: "&lt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ">", newValue: "&gt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "\"", newValue: "&quot;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "'", newValue: "&apos;", comparisonType: StringComparison.Ordinal);
+		// Create a list of lines to be included in the Word document
+		List<string> lines = [];
+		lines.Add(item: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}");
+		lines.Add(item: string.Empty);
+		// Append the selected orbital elements to the list of lines
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			lines.Add(item: $"{checkedListBoxOrbitalElements.Items[index: i]}: {orbitElements[index: i]}");
+		}
+		// If no elements are selected, add a line indicating that no elements are selected
+		if (lines.Count == 2)
+		{
+			lines.Add(item: "No selected elements.");
+		}
+		// Create a StringBuilder to build the XML content for the Word document
+		StringBuilder paragraphs = new();
+		// Append each line as a separate paragraph in the Word document XML
+		foreach (string line in lines)
+		{
+			_ = paragraphs.Append(value: "<w:p><w:r><w:t xml:space=\"preserve\">");
+			_ = paragraphs.Append(value: EscapeXml(value: line));
+			_ = paragraphs.Append(value: "</w:t></w:r></w:p>");
+		}
+		// Define the XML content for the content types of the Word document
+		string contentTypesXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+				<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+				<Default Extension="xml" ContentType="application/xml"/>
+				<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+			</Types>
+			""";
+		// Define the XML content for the root relationships of the Word document
+		string rootRelsXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+				<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+			</Relationships>
+			""";
+		// Define the XML content for the main document of the Word document, including the paragraphs with the orbital elements
+		string documentXml = $"""
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas"
+				xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+				xmlns:o="urn:schemas-microsoft-com:office:office"
+				xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+				xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+				xmlns:v="urn:schemas-microsoft-com:vml"
+				xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing"
+				xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+				xmlns:w10="urn:schemas-microsoft-com:office:word"
+				xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+				xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+				xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+				xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk"
+				xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml"
+				xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+				mc:Ignorable="w14 wp14">
+				<w:body>
+					{paragraphs}
+					<w:sectPr>
+						<w:pgSz w:w="11906" w:h="16838"/>
+						<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="0"/>
+						<w:cols w:space="708"/>
+						<w:docGrid w:linePitch="360"/>
+					</w:sectPr>
+				</w:body>
+			</w:document>
+			""";
+		// Create a new FileStream to write the Word document content to the specified file
+		using FileStream fileStream = new(path: saveFileDialogWord.FileName, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None);
+		// Create a new ZipArchive to create the Word document as a ZIP file containing the necessary XML parts
+		using ZipArchive archive = new(stream: fileStream, mode: ZipArchiveMode.Create);
+		// Helper method to add an entry to the ZIP archive with the specified name and content
+		void AddEntry(string entryName, string content)
+		{
+			ZipArchiveEntry entry = archive.CreateEntry(entryName: entryName, compressionLevel: CompressionLevel.Optimal);
+			using StreamWriter writer = new(stream: entry.Open(), encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			writer.Write(value: content);
+		}
+		// Add the necessary XML parts to the ZIP archive to create a valid Word document
+		AddEntry(entryName: "[Content_Types].xml", content: contentTypesXml);
+		AddEntry(entryName: "_rels/.rels", content: rootRelsXml);
+		AddEntry(entryName: "word/document.xml", content: documentXml);
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for exporting data as an ODT document.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>
+	/// This method handles the export of data as an ODT document.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsOdt_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported ODT document
+		using SaveFileDialog saveFileDialogOdt = new()
+		{
+			Filter = "ODT files (*.odt)|*.odt|All files (*.*)|*.*",
+			DefaultExt = "odt",
+			Title = "Save database information as ODT document"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogOdt.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogOdt.FileName = $"{orbitElements[index: 0]}.{saveFileDialogOdt.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogOdt.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Helper method to escape special XML characters in the content
+		static string EscapeXml(string value) => value
+			.Replace(oldValue: "&", newValue: "&amp;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "<", newValue: "&lt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ">", newValue: "&gt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "\"", newValue: "&quot;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "'", newValue: "&apos;", comparisonType: StringComparison.Ordinal);
+		// Create a StringBuilder to build the XML content for the ODT document
+		StringBuilder paragraphs = new();
+		_ = paragraphs.AppendLine(value: $"<text:h text:outline-level=\"1\"><text:span text:style-name=\"T1\">{EscapeXml(value: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}")}</text:span></text:h>");
+		// Append the selected orbital elements to the XML content for the ODT document
+		bool hasSelectedElements = false;
+		// Iterate through the items in the checked list box and append the checked items to the XML content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Mark that there are selected elements to be included in the ODT document
+			hasSelectedElements = true;
+			// Append the checked item and its corresponding orbit element value to the XML content for the ODT document
+			string elementName = EscapeXml(value: checkedListBoxOrbitalElements.Items[index: i].ToString() ?? string.Empty);
+			string elementValue = EscapeXml(value: orbitElements[index: i]);
+			_ = paragraphs.AppendLine(value: $"<text:p><text:span text:style-name=\"T1\">{elementName}:</text:span> {elementValue}</text:p>");
+		}
+		// If no elements are selected, add a paragraph indicating that no elements are selected
+		if (!hasSelectedElements)
+		{
+			_ = paragraphs.AppendLine(value: "<text:p>No selected elements.</text:p>");
+		}
+		// Define the XML content for the content types of the ODT document
+		string contentXml = $"""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-content
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+				xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+				office:version="1.2">
+				<office:automatic-styles>
+					<style:style style:name="T1" style:family="text">
+						<style:text-properties fo:font-weight="bold" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"/>
+					</style:style>
+				</office:automatic-styles>
+				<office:body>
+					<office:text>
+						{paragraphs}
+					</office:text>
+				</office:body>
+			</office:document-content>
+			""";
+		// Define the XML content for the styles of the ODT document
+		string stylesXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-styles
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				office:version="1.2">
+				<office:styles/>
+			</office:document-styles>
+			""";
+		// Define the XML content for the meta information of the ODT document
+		string metaXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-meta
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+				office:version="1.2">
+				<office:meta>
+					<meta:generator>Planetoid-DB</meta:generator>
+				</office:meta>
+			</office:document-meta>
+			""";
+		// Define the XML content for the settings of the ODT document
+		string settingsXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-settings
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				office:version="1.2">
+				<office:settings/>
+			</office:document-settings>
+			""";
+		// Define the XML content for the manifest of the ODT document, which lists the files included in the ODT package
+		string manifestXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.2">
+				<manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.text"/>
+				<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
+			</manifest:manifest>
+			""";
+		// Create a new FileStream to write the ODT document content to the specified file
+		using FileStream fileStream = new(path: saveFileDialogOdt.FileName, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None);
+		// Create a new ZipArchive to create the ODT document as a ZIP file containing the necessary XML parts
+		using ZipArchive archive = new(stream: fileStream, mode: ZipArchiveMode.Create);
+		// Helper method to add an entry to the ZIP archive with the specified name, content, and compression level
+		void AddEntry(string entryName, string content, CompressionLevel compressionLevel = CompressionLevel.Optimal)
+		{
+			ZipArchiveEntry entry = archive.CreateEntry(entryName, compressionLevel);
+			using StreamWriter writer = new(stream: entry.Open(), encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			writer.Write(value: content);
+		}
+		// Add the necessary XML parts to the ZIP archive to create a valid ODT document
+		AddEntry(entryName: "mimetype", content: "application/vnd.oasis.opendocument.text", compressionLevel: CompressionLevel.NoCompression);
+		AddEntry(entryName: "content.xml", content: contentXml);
+		AddEntry(entryName: "styles.xml", content: stylesXml);
+		AddEntry(entryName: "meta.xml", content: metaXml);
+		AddEntry(entryName: "settings.xml", content: settingsXml);
+		AddEntry(entryName: "META-INF/manifest.xml", content: manifestXml);
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event to export selected orbital element data as a Rich Text Format (RTF) document.
+	/// </summary>
+	/// <remarks>This method displays a save file dialog allowing the user to specify the location and name of the
+	/// RTF file. It formats the selected orbital elements into RTF and writes the content to the chosen file. If no
+	/// elements are selected, the output will indicate this in the document.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs instance containing the event data.</param>
+	private void ToolStripMenuItemExportAsRtf_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported RTF document
+		using SaveFileDialog saveFileDialogRtf = new()
+		{
+			Filter = "RTF files (*.rtf)|*.rtf|All files (*.*)|*.*",
+			DefaultExt = "rtf",
+			Title = "Save database information as RTF document"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogRtf.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogRtf.FileName = $"{orbitElements[index: 0]}.{saveFileDialogRtf.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogRtf.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Helper method to escape special characters in RTF format
+		static string EscapeRtf(string value) => value
+			.Replace(oldValue: "\\", newValue: "\\\\", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "{", newValue: "\\{", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "}", newValue: "\\}", comparisonType: StringComparison.Ordinal);
+		// Create a StringBuilder to build the RTF content for the document
+		StringBuilder sb = new();
+		_ = sb.AppendLine(value: "{\\rtf1\\ansi\\deff0");
+		_ = sb.AppendLine(value: $"\\b {EscapeRtf(value: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}")}\\b0\\par");
+		_ = sb.AppendLine(value: "\\par");
+		// Append the selected orbital elements to the RTF content
+		bool hasSelectedElements = false;
+		// Iterate through the items in the checked list box and append the checked items to the RTF content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Mark that there are selected elements to be included in the RTF document
+			hasSelectedElements = true;
+			string elementName = EscapeRtf(value: checkedListBoxOrbitalElements.Items[index: i].ToString() ?? string.Empty);
+			string elementValue = EscapeRtf(value: orbitElements[index: i]);
+			// Append the checked item and its corresponding orbit element value to the RTF content for the document
+			_ = sb.AppendLine(value: $"\\b {elementName}:\\b0 {elementValue}\\par");
+		}
+		// If no elements are selected, add a line indicating that no elements are selected
+		if (!hasSelectedElements)
+		{
+			_ = sb.AppendLine(value: "No selected elements.\\par");
+		}
+		// Append the closing brace for the RTF content
+		_ = sb.Append(value: "}");
+		// Create a new StreamWriter to write the RTF content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogRtf.FileName);
+		// Write the RTF content to the file
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event to export selected orbital element data to an Excel file in .xlsx format.
+	/// </summary>
+	/// <remarks>This method displays a save file dialog allowing the user to specify the location and name of the
+	/// Excel file. It generates an Excel document containing the selected orbital elements from the list, formatted as
+	/// XML. If no elements are selected, the output will indicate this in the exported file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs instance containing the event data.</param>
+	private void ToolStripMenuItemExportAsExcel_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported Excel document
+		using SaveFileDialog saveFileDialogExcel = new()
+		{
+			Filter = "Excel files (*.xlsx)|*.xlsx|All files (*.*)|*.*",
+			DefaultExt = "xlsx",
+			Title = "Save database information as Excel document"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogExcel.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogExcel.FileName = $"{orbitElements[index: 0]}.{saveFileDialogExcel.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogExcel.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Helper method to escape special XML characters in the content
+		static string EscapeXml(string value) => value
+			.Replace(oldValue: "&", newValue: "&amp;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "<", newValue: "&lt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ">", newValue: "&gt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "\"", newValue: "&quot;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "'", newValue: "&apos;", comparisonType: StringComparison.Ordinal);
+		// Create a StringBuilder to build the rows of the Excel sheet
+		StringBuilder rows = new();
+		_ = rows.AppendLine(value: "<row r=\"1\"><c r=\"A1\" t=\"inlineStr\"><is><t>Element</t></is></c><c r=\"B1\" t=\"inlineStr\"><is><t>Value</t></is></c></row>");
+		// Append the selected orbital elements to the rows of the Excel sheet
+		int excelRow = 2;
+		bool hasSelectedElements = false;
+		// Iterate through the items in the checked list box and append the checked items to the rows of the Excel sheet
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Mark that there are selected elements to be included in the Excel document
+			hasSelectedElements = true;
+			string elementName = EscapeXml(value: checkedListBoxOrbitalElements.Items[index: i].ToString() ?? string.Empty);
+			string elementValue = EscapeXml(value: orbitElements[index: i]);
+			// Append the checked item and its corresponding orbit element value as a new row in the Excel sheet XML content
+			_ = rows.AppendLine(value: $"<row r=\"{excelRow}\"><c r=\"A{excelRow}\" t=\"inlineStr\"><is><t>{elementName}</t></is></c><c r=\"B{excelRow}\" t=\"inlineStr\"><is><t>{elementValue}</t></is></c></row>");
+			excelRow++;
+		}
+		// If no elements are selected, add a row indicating that no elements are selected
+		if (!hasSelectedElements)
+		{
+			_ = rows.AppendLine(value: "<row r=\"2\"><c r=\"A2\" t=\"inlineStr\"><is><t>No selected elements.</t></is></c></row>");
+		}
+		// Define the XML content for the content types of the Excel document
+		string contentTypesXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+				<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+				<Default Extension="xml" ContentType="application/xml"/>
+				<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+				<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+			</Types>
+			""";
+		// Define the XML content for the root relationships of the Excel document
+		string rootRelsXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+				<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+			</Relationships>
+			""";
+		// Define the XML content for the workbook of the Excel document, which references the worksheet containing the orbital elements
+		string workbookXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+				<sheets>
+					<sheet name="Export" sheetId="1" r:id="rId1"/>
+				</sheets>
+			</workbook>
+			""";
+		// Define the XML content for the workbook relationships of the Excel document, which defines the relationship to the worksheet containing the orbital elements
+		string workbookRelsXml = """
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+				<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+			</Relationships>
+			""";
+		// Define the XML content for the worksheet of the Excel document, which contains the rows with the selected orbital elements
+		string worksheetXml = $"""
+			<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+				<sheetData>
+					{rows}
+				</sheetData>
+			</worksheet>
+			""";
+		// Create a new FileStream to write the Excel document content to the specified file
+		using FileStream fileStream = new(path: saveFileDialogExcel.FileName, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None);
+		// Create a new ZipArchive to create the Excel document as a ZIP file containing the necessary XML parts
+		using ZipArchive archive = new(stream: fileStream, mode: ZipArchiveMode.Create);
+		// Helper method to add an entry to the ZIP archive with the specified name and content
+		void AddEntry(string entryName, string content)
+		{
+			ZipArchiveEntry entry = archive.CreateEntry(entryName: entryName, compressionLevel: CompressionLevel.Optimal);
+			using StreamWriter writer = new(stream: entry.Open(), encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			writer.Write(value: content);
+		}
+		// Add the necessary XML parts to the ZIP archive to create a valid Excel document
+		AddEntry(entryName: "[Content_Types].xml", content: contentTypesXml);
+		AddEntry(entryName: "_rels/.rels", content: rootRelsXml);
+		AddEntry(entryName: "xl/workbook.xml", content: workbookXml);
+		AddEntry(entryName: "xl/_rels/workbook.xml.rels", content: workbookRelsXml);
+		AddEntry(entryName: "xl/worksheets/sheet1.xml", content: worksheetXml);
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for exporting data as an ODS file.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>
+	/// This method creates an ODS file containing the selected orbital elements from the database.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsOds_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported ODS file
+		using SaveFileDialog saveFileDialogOds = new()
+		{
+			Filter = "ODS files (*.ods)|*.ods|All files (*.*)|*.*",
+			DefaultExt = "ods",
+			Title = "Save database information as ODS"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogOds.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial file name for the save file dialog
+		saveFileDialogOds.FileName = $"{orbitElements[index: 0]}.{saveFileDialogOds.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogOds.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Helper method to escape special XML characters in the content
+		static string EscapeXml(string value) => value
+			.Replace(oldValue: "&", newValue: "&amp;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "<", newValue: "&lt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ">", newValue: "&gt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "\"", newValue: "&quot;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "'", newValue: "&apos;", comparisonType: StringComparison.Ordinal);
+		// Create a StringBuilder to build the XML content for the ODS file, starting with the table rows for the selected orbital elements
+		StringBuilder tableRows = new();
+		_ = tableRows.AppendLine(value: "<table:table-row><table:table-cell office:value-type=\"string\"><text:p>Element</text:p></table:table-cell><table:table-cell office:value-type=\"string\"><text:p>Value</text:p></table:table-cell></table:table-row>");
+		// Append the selected orbital elements to the XML content for the ODS file
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Append the checked item and its corresponding orbit element value as a new row in the XML content for the ODS file
+			string elementName = EscapeXml(value: checkedListBoxOrbitalElements.Items[index: i].ToString() ?? string.Empty);
+			string elementValue = EscapeXml(value: orbitElements[index: i]);
+			// Append the checked item and its corresponding orbit element value as a new row in the XML content for the ODS file
+			_ = tableRows.AppendLine(value: $"<table:table-row><table:table-cell office:value-type=\"string\"><text:p>{elementName}</text:p></table:table-cell><table:table-cell office:value-type=\"string\"><text:p>{elementValue}</text:p></table:table-cell></table:table-row>");
+		}
+		// If no elements are selected, add a row indicating that no elements are selected
+		if (tableRows.Length == 0)
+		{
+			_ = tableRows.AppendLine(value: "<table:table-row><table:table-cell office:value-type=\"string\"><text:p>No elements selected</text:p></table:table-cell></table:table-row>");
+		}
+		// Define the XML content for the content of the ODS file, including the table with the selected orbital elements
+		string contentXml = $"""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-content
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+				xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+				office:version="1.2">
+				<office:body>
+					<office:spreadsheet>
+						<table:table table:name="Export">
+							{tableRows}
+						</table:table>
+					</office:spreadsheet>
+				</office:body>
+			</office:document-content>
+			""";
+		// Define the XML content for the styles of the ODS file
+		string stylesXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-styles
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				office:version="1.2">
+				<office:styles/>
+			</office:document-styles>
+			""";
+		// Define the XML content for the meta information of the ODS file
+		string metaXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-meta
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+				office:version="1.2">
+				<office:meta>
+					<meta:generator>Planetoid-DB</meta:generator>
+				</office:meta>
+			</office:document-meta>
+			""";
+		// Define the XML content for the settings of the ODS file
+		string settingsXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<office:document-settings
+				xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+				office:version="1.2">
+				<office:settings/>
+			</office:document-settings>
+			""";
+		// Define the XML content for the manifest of the ODS file
+		string manifestXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.2">
+				<manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>
+				<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
+			</manifest:manifest>
+			""";
+		// Create a new FileStream to write the ODS file content to the specified file
+		using FileStream fileStream = new(path: saveFileDialogOds.FileName, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None);
+		// Create a new ZipArchive to create the ODS file as a ZIP file containing the necessary XML parts
+		using ZipArchive archive = new(stream: fileStream, mode: ZipArchiveMode.Create);
+		// Helper method to add an entry to the ZIP archive with the specified name, content, and compression level
+		void AddEntry(string entryName, string content, CompressionLevel compressionLevel = CompressionLevel.Optimal)
+		{
+			ZipArchiveEntry entry = archive.CreateEntry(entryName: entryName, compressionLevel: compressionLevel);
+			using StreamWriter writer = new(stream: entry.Open(), encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			writer.Write(value: content);
+		}
+		// Add the necessary XML parts to the ZIP archive to create a valid ODS file
+		AddEntry(entryName: "mimetype", content: "application/vnd.oasis.opendocument.spreadsheet", compressionLevel: CompressionLevel.NoCompression);
+		AddEntry(entryName: "content.xml", content: contentXml);
+		AddEntry(entryName: "styles.xml", content: stylesXml);
+		AddEntry(entryName: "meta.xml", content: metaXml);
+		AddEntry(entryName: "settings.xml", content: settingsXml);
+		AddEntry(entryName: "META-INF/manifest.xml", content: manifestXml);
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsCsv control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as a CSV file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsCsv_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported CSV file
+		using SaveFileDialog saveFileDialogCsv = new()
+		{
+			Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+			DefaultExt = "csv",
+			Title = "Save database information as CSV"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogCsv.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogCsv.FileName = $"{orbitElements[index: 0]}.{saveFileDialogCsv.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogCsv.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the CSV content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogCsv.FileName);
+		// Write the orbit elements to the CSV file
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, write the orbit element to the CSV file
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Write the orbit element to the CSV file
+			streamWriter.Write(value: $"{checkedListBoxOrbitalElements.Items[index: i]};{orbitElements[index: i]}");
+			// If it is not the last item, write a new line
+			// to separate the elements in the CSV file
+			if (i < checkedListBoxOrbitalElements.Items.Count - 1)
+			{
+				// Write a new line to separate the elements
+				streamWriter.Write(value: Environment.NewLine);
+			}
+		}
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsTsv control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as a TSV file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsTsv_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported TSV file
+		using SaveFileDialog saveFileDialogTsv = new()
+		{
+			Filter = "TSV files (*.tsv)|*.tsv|All files (*.*)|*.*",
+			DefaultExt = "tsv",
+			Title = "Save database information as TSV"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogTsv.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogTsv.FileName = $"{orbitElements[index: 0]}.{saveFileDialogTsv.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogTsv.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the TSV content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogTsv.FileName);
+		// Write the orbit elements to the TSV file
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, write the orbit element to the TSV file
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Write the orbit element to the TSV file
+			streamWriter.Write(value: $"{checkedListBoxOrbitalElements.Items[index: i]}\t{orbitElements[index: i]}");
+			// If it is not the last item, write a new line
+			// to separate the elements in the TSV file
+			if (i < checkedListBoxOrbitalElements.Items.Count - 1)
+			{
+				// Write a new line to separate the elements
+				streamWriter.Write(value: Environment.NewLine);
+			}
+		}
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsPsv control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as a PSV file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsPsv_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported PSV file
+		using SaveFileDialog saveFileDialogPsv = new()
+		{
+			Filter = "PSV files (*.psv)|*.psv|All files (*.*)|*.*",
+			DefaultExt = "psv",
+			Title = "Save database information as PSV"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogPsv.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogPsv.FileName = $"{orbitElements[index: 0]}.{saveFileDialogPsv.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogPsv.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the PSV content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogPsv.FileName);
+		// Write the orbit elements to the PSV file
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, write the orbit element to the PSV file
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// Write the orbit element to the PSV file
+			streamWriter.Write(value: $"{checkedListBoxOrbitalElements.Items[index: i]}|{orbitElements[index: i]}");
+			// If it is not the last item, write a new line
+			// to separate the elements in the PSV file
+			if (i < checkedListBoxOrbitalElements.Items.Count - 1)
+			{
+				// Write a new line to separate the elements
+				streamWriter.Write(value: Environment.NewLine);
+			}
+		}
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsHtml control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as an HTML file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsHtml_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported HTML file
+		using SaveFileDialog saveFileDialogHtml = new()
+		{
+			Filter = "HTML files (*.html)|*.html|All files (*.*)|*.*",
+			DefaultExt = "html",
+			Title = "Save database information as HTML"
+		};
 		// Set the initial directory for the save file dialog to the user's documents folder
 		saveFileDialogHtml.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
 		// Set the initial directory for the save file dialog to the user's documents folder
@@ -254,20 +1169,27 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 		_ = sb.Append(value: "</html>");
 		// Write the HTML content to the file
 		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>
-	/// Handles the Click event of the Export As XML button.
-	/// Prompts the user for a destination file, then writes each checked orbital element
-	/// and its corresponding value as XML lines in the format "Label: Value".
+	/// Handles the Click event of the ToolStripMenuItemExportAsXml control.
 	/// </summary>
-	/// <param name="sender">Event source (the export button).</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
 	/// <remarks>
-	/// This method is used to export the selected orbital elements as an XML file.
+	/// This method allows the user to export the selected orbital elements as an XML file.
 	/// </remarks>
-	private void ButtonExportAsXml_Click(object sender, EventArgs e)
+	private void ToolStripMenuItemExportAsXml_Click(object sender, EventArgs e)
 	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported XML file
+		using SaveFileDialog saveFileDialogXml = new()
+		{
+			Filter = "XML files (*.xml)|*.xml|All files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save database information as XML"
+		};
 		// Set the initial directory for the save file dialog to the user's documents folder
 		saveFileDialogXml.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
 		// Set the initial directory for the save file dialog to the user's documents folder
@@ -341,20 +1263,27 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 		_ = sb.Append(value: "</MinorPlanet>");
 		// Write the XML content to the file
 		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>
-	/// Handles the Click event of the Export As JSON button.
-	/// Prompts the user for a destination file, then writes each checked orbital element
-	/// and its corresponding value as JSON lines in the format "\"Label\": \"Value\"".
+	/// Handles the Click event of the ToolStripMenuItemExportAsJson control.
 	/// </summary>
-	/// <param name="sender">Event source (the export button).</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
 	/// <remarks>
-	/// This method is used to export the selected orbital elements as JSON.
+	/// This method allows the user to export the selected orbital elements as a JSON file.
 	/// </remarks>
-	private void ButtonExportAsJson_Click(object sender, EventArgs e)
+	private void ToolStripMenuItemExportAsJson_Click(object sender, EventArgs e)
 	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported JSON file
+		using SaveFileDialog saveFileDialogJson = new()
+		{
+			Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+			DefaultExt = "json",
+			Title = "Save database information as JSON"
+		};
 		// Set the initial directory for the save file dialog to the user's documents folder
 		saveFileDialogJson.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
 		// Set the initial directory for the save file dialog to the user's documents folder
@@ -427,53 +1356,523 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 		_ = sb.AppendLine(value: "}");
 		// Write the JSON content to the file
 		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>
-	/// Handles the Click event of the Mark All button.
-	/// Marks all items in the orbital elements checklist and enables export buttons.
+	/// Handles the Click event of the ToolStripMenuItemExportAsYaml control.
 	/// </summary>
-	/// <param name="sender">Event source (the Mark All button).</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
 	/// <remarks>
-	/// This method is used to mark all items in the orbital elements checklist.
+	/// This method allows the user to export the selected orbital elements as a YAML file.
 	/// </remarks>
-	private void ButtonMarkAll_Click(object sender, EventArgs e) => MarkAll();
-
-	/// <summary>
-	/// Handles the Click event of the Unmark All button.
-	/// Unmarks all items in the orbital elements checklist and disables export buttons.
-	/// </summary>
-	/// <param name="sender">Event source (the Unmark All button).</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to unmark all items in the orbital elements checklist.
-	/// </remarks>
-	private void ButtonUnmarkAll_Click(object sender, EventArgs e) => UnmarkAll();
-
-	#endregion
-
-	#region SelectedIndexChanged event handlers
-
-	/// <summary>
-	/// Handles the SelectedIndexChanged event of the orbital elements checklist.
-	/// Enables or disables the export buttons depending on whether any items are checked.
-	/// If all items are unmarked (unchecked) the export buttons are disabled; otherwise they are enabled.
-	/// </summary>
-	/// <param name="sender">Event source (the checked list box).</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>
-	/// This method is used to enable or disable the export buttons based on the selection state of the orbital elements.
-	/// </remarks>
-	private void CheckedListBoxOrbitalElements_SelectedIndexChanged(object sender, EventArgs e)
+	private void ToolStripMenuItemExportAsYaml_Click(object sender, EventArgs e)
 	{
-		// Enable or disable the export buttons based on whether all items are unmarked
-		// If all items are unmarked, disable the export buttons
-		// If not all items are unmarked, enable the export buttons
-		buttonExportAsTxt.Enabled = IsAllUnmarked()
-			? (buttonExportAsHtml.Enabled = buttonExportAsXml.Enabled = buttonExportAsJson.Enabled = false)
-			: (buttonExportAsHtml.Enabled = buttonExportAsXml.Enabled = buttonExportAsJson.Enabled = true);
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported YAML file
+		using SaveFileDialog saveFileDialogYaml = new()
+		{
+			Filter = "YAML files (*.yaml)|*.yaml|All files (*.*)|*.*",
+			DefaultExt = "yaml",
+			Title = "Save database information as YAML"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogYaml.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogYaml.FileName = $"{orbitElements[index: 0]}.{saveFileDialogYaml.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogYaml.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the YAML content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogYaml.FileName);
+		// Create a StringBuilder to build the YAML content
+		StringBuilder sb = new();
+		// Append the YAML content to the StringBuilder
+		// Append the orbit elements to the YAML content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, append the orbit element to the YAML content
+			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				// Append the orbit element to the YAML content
+				_ = sb.AppendLine(value: $"{checkedListBoxOrbitalElements.Items[index: i]}: {orbitElements[index: i]}");
+			}
+		}
+		// Write the YAML content to the file
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
-	#endregion
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsSql control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as a SQL file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsSql_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported SQL file
+		using SaveFileDialog saveFileDialogSql = new()
+		{
+			Filter = "SQL files (*.sql)|*.sql|All files (*.*)|*.*",
+			DefaultExt = "sql",
+			Title = "Save database information as SQL"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogSql.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogSql.FileName = $"{orbitElements[index: 0]}.{saveFileDialogSql.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogSql.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the SQL content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogSql.FileName);
+		StringBuilder sb = new();
+		// Append the SQL content to the StringBuilder
+		_ = sb.AppendLine(value: "INSERT INTO MinorPlanets (");
+		// Append the column names to the SQL content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, append the column name to the SQL content
+			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				// Append the column name to the SQL content
+				_ = sb.AppendLine(value: $"{checkedListBoxOrbitalElements.Items[index: i]},");
+			}
+		}
+		// Append the closing parenthesis for the column names
+		_ = sb.AppendLine(value: ") VALUES (");
+		// Append the values to the SQL content
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			// Check if the item is checked
+			// If it is checked, append the value to the SQL content
+			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				// Append the value to the SQL content
+				_ = sb.AppendLine(value: $"'{orbitElements[index: i]}',");
+			}
+		}
+		// Append the closing parenthesis for the values
+		_ = sb.AppendLine(value: ");");
+		// Write the SQL content to the file
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the Click event of the ToolStripMenuItemExportAsPdf control.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the selected orbital elements as a PDF file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsPdf_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported PDF file
+		using SaveFileDialog saveFileDialogPdf = new()
+		{
+			Filter = "PDF files (*.pdf)|*.pdf|All files (*.*)|*.*",
+			DefaultExt = "pdf",
+			Title = "Save database information as PDF"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogPdf.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial file name for the save file dialog
+		saveFileDialogPdf.FileName = $"{orbitElements[index: 0]}.{saveFileDialogPdf.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogPdf.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Define a method to escape special characters in PDF text
+		static string EscapePdfText(string value)
+		{
+			StringBuilder escaped = new();
+			// Iterate through each character in the input string and escape special characters as needed
+			foreach (char character in value)
+			{
+				_ = character switch
+				{
+					'\\' => escaped.Append(value: "\\\\"),
+					'(' => escaped.Append(value: "\\("),
+					')' => escaped.Append(value: "\\)"),
+					'\r' or '\n' => escaped.Append(value: " "),
+					_ => escaped.Append(value: character is >= ' ' and <= '~' ? character : '?'),
+				};
+			}
+			// Return the escaped string
+			return escaped.ToString();
+		}
+		// Create a list to hold the lines of text to be included in the PDF content
+		List<string> lines = [];
+		// Add a header line to the list with the index and readable designation of the minor planet
+		lines.Add(item: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}");
+		lines.Add(item: string.Empty);
+		// Iterate through the checked items in the checkedListBoxOrbitalElements and add the selected elements to the list of lines
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+
+			}
+			// Add the selected element to the list of lines in the format "ElementName: ElementValue"
+			lines.Add(item: $"{checkedListBoxOrbitalElements.Items[index: i]}: {orbitElements[index: i]}");
+		}
+		// If no elements are selected, add a line indicating that no elements are selected
+		if (lines.Count == 2)
+		{
+			lines.Add(item: "No selected elements.");
+		}
+		// Create a StringBuilder to build the content of the PDF file
+		StringBuilder contentBuilder = new();
+		// Append the PDF content to the StringBuilder using PDF syntax
+		_ = contentBuilder.AppendLine(value: "BT");
+		_ = contentBuilder.AppendLine(value: "/F1 12 Tf");
+		_ = contentBuilder.AppendLine(value: "50 800 Td");
+		_ = contentBuilder.AppendLine(value: "15 TL");
+		// Iterate through the lines of text and append them to the PDF content with proper escaping and formatting
+		foreach (string line in lines)
+		{
+			_ = contentBuilder.AppendLine(value: $"({EscapePdfText(value: line)}) Tj");
+			_ = contentBuilder.AppendLine(value: "T*");
+		}
+		// Append the end text operator to the PDF content
+		_ = contentBuilder.Append(value: "ET");
+		// Convert the PDF content to a byte array using ASCII encoding
+		Encoding asciiEncoding = Encoding.ASCII;
+		byte[] contentBytes = asciiEncoding.GetBytes(s: contentBuilder.ToString());
+		// Define the PDF objects for the catalog, pages, page, font, and content stream
+		string object1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+		string object2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+		string object3 = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n";
+		string object4 = "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+		string object5 = $"5 0 obj\n<< /Length {contentBytes.Length} >>\nstream\n{contentBuilder}\nendstream\nendobj\n";
+		// Create a MemoryStream to hold the PDF content and write the PDF header, objects, cross-reference table, trailer, and EOF marker to the stream
+		using MemoryStream memoryStream = new();
+		// Define a local method to write ASCII-encoded strings to the MemoryStream
+		void WriteAscii(string value)
+		{
+			byte[] bytes = asciiEncoding.GetBytes(s: value);
+			memoryStream.Write(buffer: bytes, offset: 0, count: bytes.Length);
+		}
+		// Write the PDF header to the MemoryStream
+		WriteAscii(value: "%PDF-1.4\n");
+		// Create a list to hold the byte offsets of the PDF objects for the cross-reference table
+		List<long> offsets = [0];
+		// Write each PDF object to the MemoryStream and record its byte offset for the cross-reference table
+		offsets.Add(item: memoryStream.Position);
+		WriteAscii(value: object1);
+		offsets.Add(item: memoryStream.Position);
+		WriteAscii(value: object2);
+		offsets.Add(item: memoryStream.Position);
+		WriteAscii(value: object3);
+		offsets.Add(item: memoryStream.Position);
+		WriteAscii(value: object4);
+		offsets.Add(item: memoryStream.Position);
+		WriteAscii(value: object5);
+		// Write the cross-reference table to the MemoryStream using the recorded byte offsets of the PDF objects
+		long xrefOffset = memoryStream.Position;
+		WriteAscii(value: "xref\n");
+		WriteAscii(value: "0 6\n");
+		WriteAscii(value: "0000000000 65535 f \n");
+		// Iterate through the recorded byte offsets of the PDF objects and write each offset to the cross-reference table in the required format
+		for (int i = 1; i <= 5; i++)
+		{
+			_ = offsets[index: i];
+			WriteAscii(value: $"{offsets[index: i]:0000000000} 00000 n \n");
+		}
+		// Write the trailer, startxref, and EOF marker to the MemoryStream to complete the PDF file structure
+		WriteAscii(value: "trailer\n");
+		WriteAscii(value: "<< /Size 6 /Root 1 0 R >>\n");
+		WriteAscii(value: "startxref\n");
+		WriteAscii(value: $"{xrefOffset}\n");
+		WriteAscii(value: "%%EOF");
+		// Write the content of the MemoryStream to the specified file path as a PDF file
+		File.WriteAllBytes(path: saveFileDialogPdf.FileName, bytes: memoryStream.ToArray());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for exporting data as a PostScript file.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>
+	/// This method allows the user to export the current data as a PostScript file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsPostScript_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported PostScript file
+		using SaveFileDialog saveFileDialogPostScript = new()
+		{
+			Filter = "PostScript files (*.ps)|*.ps|All files (*.*)|*.*",
+			DefaultExt = "ps",
+			Title = "Save database information as PostScript"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogPostScript.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial file name for the save file dialog
+		saveFileDialogPostScript.FileName = $"{orbitElements[index: 0]}.{saveFileDialogPostScript.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogPostScript.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Define a method to escape special characters in PostScript strings
+		static string EscapePostScriptString(string value) => value
+			.Replace(oldValue: "\\", newValue: "\\\\", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "(", newValue: "\\(", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ")", newValue: "\\)", comparisonType: StringComparison.Ordinal);
+		// Create a new StreamWriter to write the PostScript content to the specified file
+		using StreamWriter streamWriter = new(path: saveFileDialogPostScript.FileName);
+		StringBuilder sb = new();
+		// Append the PostScript content to the StringBuilder using PostScript syntax
+		_ = sb.AppendLine(value: "%!PS-Adobe-3.0");
+		_ = sb.AppendLine(value: "%%Creator: Planetoid-DB");
+		_ = sb.AppendLine(value: "%%Pages: 1");
+		_ = sb.AppendLine(value: "%%BoundingBox: 0 0 595 842");
+		_ = sb.AppendLine(value: "%%EndComments");
+		_ = sb.AppendLine(value: "/Helvetica findfont 12 scalefont setfont");
+		_ = sb.AppendLine(value: "50 800 moveto");
+		_ = sb.AppendLine(value: $"({EscapePostScriptString(value: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}")}) show");
+		_ = sb.AppendLine(value: "0 -20 rmoveto");
+		// Iterate through the checked items in the checkedListBoxOrbitalElements and append the selected elements to the PostScript content
+		bool hasSelectedElements = false;
+		// Loop through the items in the checkedListBoxOrbitalElements and check if they are checked
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// If the item is checked, append the orbit element to the PostScript content
+			hasSelectedElements = true;
+			string line = EscapePostScriptString(value: $"{checkedListBoxOrbitalElements.Items[index: i]}: {orbitElements[index: i]}");
+			_ = sb.AppendLine(value: $"({line}) show");
+			_ = sb.AppendLine(value: "0 -15 rmoveto");
+		}
+		// If no elements were selected, add a message to the PostScript content
+		if (!hasSelectedElements)
+		{
+			_ = sb.AppendLine(value: "(No selected elements.) show");
+		}
+		// Append the showpage operator to the PostScript content to indicate the end of the page
+		_ = sb.AppendLine(value: "showpage");
+		streamWriter.Write(value: sb.ToString());
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Export as EPUB" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>
+	/// This method handles the export of database information as an EPUB file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsEpub_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported EPUB file
+		using SaveFileDialog saveFileDialogEpub = new()
+		{
+			Filter = "EPUB files (*.epub)|*.epub|All files (*.*)|*.*",
+			DefaultExt = "epub",
+			Title = "Save database information as EPUB"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogEpub.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial file name for the save file dialog
+		saveFileDialogEpub.FileName = $"{orbitElements[index: 0]}.{saveFileDialogEpub.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogEpub.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a new StreamWriter to write the EPUB content to the specified file
+		static string EscapeXml(string value) => value
+			.Replace(oldValue: "&", newValue: "&amp;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "<", newValue: "&lt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: ">", newValue: "&gt;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "\"", newValue: "&quot;", comparisonType: StringComparison.Ordinal)
+			.Replace(oldValue: "'", newValue: "&apos;", comparisonType: StringComparison.Ordinal);
+		// Create a StringBuilder to build the EPUB content
+		string title = $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}";
+		// Build the body content of the EPUB
+		StringBuilder bodyBuilder = new();
+		_ = bodyBuilder.AppendLine(value: $"<h1>{EscapeXml(value: title)}</h1>");
+		_ = bodyBuilder.AppendLine(value: "<ul>");
+		// Append the orbit elements to the body content of the EPUB
+		bool hasSelectedElements = false;
+		// Loop through the items in the checkedListBoxOrbitalElements and check if they are checked
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// If the item is checked, append the orbit element to the body content of the EPUB
+			hasSelectedElements = true;
+			string elementName = EscapeXml(value: checkedListBoxOrbitalElements.Items[index: i].ToString() ?? string.Empty);
+			string elementValue = EscapeXml(value: orbitElements[index: i]);
+			_ = bodyBuilder.AppendLine(value: $"<li><strong>{elementName}:</strong> {elementValue}</li>");
+		}
+		// If no elements were selected, add a message to the body content of the EPUB
+		if (!hasSelectedElements)
+		{
+			_ = bodyBuilder.AppendLine(value: "<li>No selected elements.</li>");
+		}
+		// Append the closing tags for the body content of the EPUB
+		_ = bodyBuilder.AppendLine(value: "</ul>");
+		// Define the XML content for the EPUB structure
+		string containerXml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+				<rootfiles>
+					<rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+				</rootfiles>
+			</container>
+			""";
+		// Define the XML content for the EPUB package and metadata
+		string contentOpf = $"""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="bookid" version="3.0">
+				<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+					<dc:identifier id="bookid">urn:uuid:{Guid.NewGuid()}</dc:identifier>
+					<dc:title>{EscapeXml(value: title)}</dc:title>
+					<dc:language>en</dc:language>
+				</metadata>
+				<manifest>
+					<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+					<item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
+				</manifest>
+				<spine>
+					<itemref idref="content"/>
+				</spine>
+			</package>
+			""";
+		// Define the XML content for the EPUB navigation document
+		string navXhtml = $"""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<!DOCTYPE html>
+			<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en" xml:lang="en">
+			<head>
+				<meta charset="utf-8" />
+				<title>Table of Contents</title>
+			</head>
+			<body>
+				<nav epub:type="toc" id="toc">
+					<h1>Contents</h1>
+					<ol>
+						<li><a href="content.xhtml">{EscapeXml(value: title)}</a></li>
+					</ol>
+				</nav>
+			</body>
+			</html>
+			""";
+		// Define the XML content for the EPUB main content document
+		string contentXhtml = $"""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<!DOCTYPE html>
+			<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+			<head>
+				<meta charset="utf-8" />
+				<title>{EscapeXml(value: title)}</title>
+			</head>
+			<body>
+				{bodyBuilder}
+			</body>
+			</html>
+			""";
+		// Create a new FileStream to write the EPUB content to the specified file
+		using FileStream fileStream = new(path: saveFileDialogEpub.FileName, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None);
+		// Create a new ZipArchive to write the EPUB content in ZIP format
+		using ZipArchive archive = new(stream: fileStream, mode: ZipArchiveMode.Create);
+		// Define a local function to add an entry to the ZIP archive with the specified name, content, and compression level
+		void AddEntry(string entryName, string content, CompressionLevel compressionLevel = CompressionLevel.Optimal)
+		{
+			ZipArchiveEntry entry = archive.CreateEntry(entryName, compressionLevel);
+			using StreamWriter writer = new(stream: entry.Open(), encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+			writer.Write(value: content);
+		}
+		// Add the necessary entries to the ZIP archive for the EPUB structure and content
+		AddEntry(entryName: "mimetype", content: "application/epub+zip", compressionLevel: CompressionLevel.NoCompression);
+		AddEntry(entryName: "META-INF/container.xml", content: containerXml);
+		AddEntry(entryName: "OEBPS/content.opf", content: contentOpf);
+		AddEntry(entryName: "OEBPS/nav.xhtml", content: navXhtml);
+		AddEntry(entryName: "OEBPS/content.xhtml", content: contentXhtml);
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>
+	/// Handles the click event for the "Export as MOBI" menu item.
+	/// </summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>
+	/// This method handles the export of database information as a MOBI file.
+	/// </remarks>
+	private void ToolStripMenuItemExportAsMobi_Click(object sender, EventArgs e)
+	{
+		// Create a new SaveFileDialog to allow the user to select the file path and name for the exported MOBI file
+		using SaveFileDialog saveFileDialogMobi = new()
+		{
+			Filter = "MOBI files (*.mobi)|*.mobi|All files (*.*)|*.*",
+			DefaultExt = "mobi",
+			Title = "Save database information as MOBI"
+		};
+		// Set the initial directory for the save file dialog to the user's documents folder
+		saveFileDialogMobi.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set the initial file name for the save file dialog
+		saveFileDialogMobi.FileName = $"{orbitElements[index: 0]}.{saveFileDialogMobi.DefaultExt}";
+		// Show the save file dialog to select the file path and name
+		if (saveFileDialogMobi.ShowDialog() != DialogResult.OK)
+		{
+			return;
+		}
+		// Create a StringBuilder to build the content of the MOBI file
+		StringBuilder sb = new();
+		// Append the content to the StringBuilder in a simple text format for the MOBI file
+		_ = sb.AppendLine(value: "BOOKMOBI");
+		_ = sb.AppendLine(value: $"Export for [{orbitElements[index: 0]}] {orbitElements[index: 1]}");
+		_ = sb.AppendLine();
+		// Iterate through the checked items in the checkedListBoxOrbitalElements and append the selected elements to the MOBI content
+		bool hasSelectedElements = false;
+		// Loop through the items in the checkedListBoxOrbitalElements and check if they are checked
+		for (int i = 0; i < checkedListBoxOrbitalElements.Items.Count; i++)
+		{
+			if (!checkedListBoxOrbitalElements.GetItemChecked(index: i))
+			{
+				continue;
+			}
+			// If the item is checked, append the orbit element to the MOBI content
+			hasSelectedElements = true;
+			_ = sb.AppendLine(value: $"{checkedListBoxOrbitalElements.Items[index: i]}: {orbitElements[index: i]}");
+		}
+		// If no elements were selected, add a message to the MOBI content
+		if (!hasSelectedElements)
+		{
+			_ = sb.AppendLine(value: "No selected elements.");
+		}
+		// Write the content of the StringBuilder to the specified file path as a MOBI file
+		File.WriteAllBytes(path: saveFileDialogMobi.FileName, bytes: Encoding.UTF8.GetBytes(s: sb.ToString()));
+		// Show a message box indicating that the data was exported successfully
+		MessageBox.Show(text: "Data exported successfully.", caption: "Export Complete", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
 }

--- a/Forms/ExportDataSheetForm.resx
+++ b/Forms/ExportDataSheetForm.resx
@@ -120,20 +120,14 @@
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="saveFileDialogTxt.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>126, 17</value>
   </metadata>
-  <metadata name="saveFileDialogHtml.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>270, 17</value>
+  <metadata name="kryptonToolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>427, 17</value>
   </metadata>
-  <metadata name="saveFileDialogXml.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>568, 17</value>
-  </metadata>
-  <metadata name="saveFileDialogJson.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>718, 17</value>
-  </metadata>
-  <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>426, 17</value>
+  <metadata name="contextMenuExport.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>268, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>59</value>


### PR DESCRIPTION
Adds a redesigned export UI for `ExportDataSheetForm` and significantly expands the set of supported export formats for orbital element data sheets.

**Changes:**
- Replaces individual export buttons with a ToolStrip dropdown menu and adds ToolStrip mark/unmark actions.
- Adds many new export handlers (e.g., LaTeX/Markdown/Word/ODT/RTF/Excel/ODS/CSV/TSV/PSV/YAML/SQL/PDF/PostScript/EPUB/MOBI) and localizes SaveFileDialog creation to each handler.
- Updates form resources/designer wiring to match the new GUI components (status label rename, new context menu/toolstrip tray items)