### PR TITLE
Fixed some errors in ExportDataSheetForm

### DIFF
--- a/Forms/ExportDataSheetForm.Designer.cs
+++ b/Forms/ExportDataSheetForm.Designer.cs
@@ -230,8 +230,8 @@ namespace Planetoid_DB
 			// 
 			// contextMenuExport
 			// 
-			contextMenuExport.AccessibleDescription = "Exports data sheet";
-			contextMenuExport.AccessibleName = "Export";
+			contextMenuExport.AccessibleDescription = "Shows the context menu for exporting the data sheet";
+			contextMenuExport.AccessibleName = "Context menu for exporting the data sheet";
 			contextMenuExport.AccessibleRole = AccessibleRole.MenuPopup;
 			contextMenuExport.Font = new Font("Segoe UI", 9F);
 			contextMenuExport.Items.AddRange(new ToolStripItem[] { toolStripMenuItemExportAsText, toolStripMenuItemExportAsLatex, toolStripMenuItemExportAsMarkdown, toolStripMenuItemExportAsWord, toolStripMenuItemExportAsOdt, toolStripMenuItemExportAsRtf, toolStripMenuItemExportAsExcel, toolStripMenuItemExportAsOds, toolStripMenuItemExportAsCsv, toolStripMenuItemExportAsTsv, toolStripMenuItemExportAsPsv, toolStripMenuItemExportAsHtml, toolStripMenuItemExportAsXml, toolStripMenuItemExportAsJson, toolStripMenuItemExportAsYaml, toolStripMenuItemExportAsSql, toolStripMenuItemExportAsPdf, toolStripMenuItemExportAsPostScript, toolStripMenuItemExportAsEpub, toolStripMenuItemExportAsMobi });

--- a/Forms/ExportDataSheetForm.cs
+++ b/Forms/ExportDataSheetForm.cs
@@ -602,6 +602,7 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 				<manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
 				<manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
 				<manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="META-INF/manifest.xml" manifest:media-type="text/xml"/>
 			</manifest:manifest>
 			""";
 		// Create a new FileStream to write the ODT document content to the specified file
@@ -925,6 +926,7 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 				<manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
 				<manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
 				<manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
+				<manifest:file-entry manifest:full-path="META-INF/manifest.xml" manifest:media-type="text/xml"/>
 			</manifest:manifest>
 			""";
 		// Create a new FileStream to write the ODS file content to the specified file
@@ -1459,8 +1461,23 @@ public partial class ExportDataSheetForm : BaseKryptonForm
 			// If it is checked, append the value to the SQL content
 			if (checkedListBoxOrbitalElements.GetItemChecked(index: i))
 			{
-				// Append the value to the SQL content
-				_ = sb.AppendLine(value: $"'{orbitElements[index: i]}',");
+				// Append the value to the SQL content, ensuring it is safely represented in SQL
+				string? value = orbitElements[index: i];
+				// If the value is null or empty, represent it as NULL in SQL
+				if (string.IsNullOrEmpty(value))
+				{
+					_ = sb.AppendLine(value: "NULL,");
+				}
+				// Otherwise, escape any single quotes in the value and represent it as a string in SQL
+				else
+				{
+					string escapedValue = value
+						.Replace(oldValue: "'", newValue: "''", comparisonType: StringComparison.Ordinal)
+						.Replace(oldValue: "\r\n", newValue: " ", comparisonType: StringComparison.Ordinal)
+						.Replace(oldValue: "\n", newValue: " ", comparisonType: StringComparison.Ordinal)
+						.Replace(oldValue: "\r", newValue: " ", comparisonType: StringComparison.Ordinal);
+					_ = sb.AppendLine(value: $"'{escapedValue}',");
+				}
 			}
 		}
 		// Append the closing parenthesis for the values


### PR DESCRIPTION
This PR fixes several errors in `ExportDataSheetForm`: it adds the missing `META-INF/manifest.xml` self-referencing file-entry in both the ODT and ODS manifest XML (required for valid ODF archives), improves SQL value escaping to safely represent `NULL` values and escape single quotes and newlines, and updates the context menu's accessible description and name to follow the established accessibility convention.

**Changes:**
- Added the missing `<manifest:file-entry manifest:full-path="META-INF/manifest.xml" .../>` entry to both the ODT and ODS manifest XML strings.
- Replaced the simple `sb.AppendLine($"'{orbitElements[i]}',")` with null-aware, properly escaped SQL value generation (single-quote doubling, newline normalization, and NULL for empty values).
- Updated `contextMenuExport.AccessibleDescription` and `AccessibleName` to match the codebase convention (`"Shows the context menu for …"` / `"Context menu for …"`).