### PR TITLE
Enabled windows targeting

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -706,6 +706,7 @@ Public License instead of this License.  But first, please read
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -914,5 +915,6 @@ Public License instead of this License.  But first, please read
       <LastGenOutput>FugueIcons16px.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
This PR updates the project configuration to explicitly enable Windows targeting in the SDK-style .csproj, aligning with the project’s Windows-specific target framework.

**Changes:**
- Added `EnableWindowsTargeting` to the main property group in the project file.
- Normalized the file ending by adding a trailing newline/blank line before `</Project>`.