### PR TITLE
Updated image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/2b3797ad-6369-4643-902d-b9332e39ce4a" />
+<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/c73ae925-bbfd-434a-b8f0-23fc7ab6058d" />


### PR DESCRIPTION
Updates the README to point to a new hosted screenshot asset, keeping the project’s documentation visuals current.

**Changes:**
- Replaced the README screenshot image URL with an updated `github.com/user-attachments` asset link.