### PR TITLE
Fixed typos in ArchiveMpcorbForm

### DIFF
--- a/Forms/ArchiveMpcorbForm.Designer.cs
+++ b/Forms/ArchiveMpcorbForm.Designer.cs
@@ -306,7 +306,7 @@ namespace Planetoid_DB
 			// 
 			toolStripIcons.AccessibleDescription = "Toolbar of archiving and setting";
 			toolStripIcons.AccessibleName = "Toolbar of archiving and setting";
-			toolStripIcons.AccessibleRole = AccessibleRole.ToolTip;
+			toolStripIcons.AccessibleRole = AccessibleRole.ToolBar;
 			toolStripIcons.AllowClickThrough = true;
 			toolStripIcons.AllowItemReorder = true;
 			toolStripIcons.Dock = DockStyle.None;
@@ -506,7 +506,7 @@ namespace Planetoid_DB
 			// 
 			toolStripLabelProgress.AccessibleDescription = "Shows the progress of archiving";
 			toolStripLabelProgress.AccessibleName = "Progress";
-			toolStripLabelProgress.AccessibleRole = AccessibleRole.StatusBar;
+			toolStripLabelProgress.AccessibleRole = AccessibleRole.StaticText;
 			toolStripLabelProgress.AutoToolTip = true;
 			toolStripLabelProgress.Name = "toolStripLabelProgress";
 			toolStripLabelProgress.Size = new Size(52, 22);

--- a/Forms/ArchiveMpcorbForm.cs
+++ b/Forms/ArchiveMpcorbForm.cs
@@ -205,7 +205,7 @@ public partial class ArchiveMpcorbForm : BaseKryptonForm
 	/// <remarks>This method sends a HEAD request to the specified URL to retrieve the last modified date of the MPCORB.DAT.gz file.
 	/// If the request is successful and the Last-Modified header is present, the method returns the date in UTC.
 	/// In case of any errors, the method logs the error and returns null.</remarks>
-	private async Task<DateTime?> GetOnlineLastModifiedAsync()
+	private static async Task<DateTime?> GetOnlineLastModifiedAsync()
 	{
 		// Attempt to retrieve the last modified date of the online MPCORB file
 		try


### PR DESCRIPTION
This PR updates the `ArchiveMpcorbForm` helper method signature while keeping the same functionality intent (retrieve the online file’s Last-Modified timestamp).

**Changes:**
- Made `GetOnlineLastModifiedAsync` a `static` method.