### PR TITLE
Replaceed screenshot of Planetoid-DB in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/c73ae925-bbfd-434a-b8f0-23fc7ab6058d" />
+<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/e11cf8fe-ed25-43b6-9a2e-c387fc979059" />


### PR DESCRIPTION
Updates the README’s embedded screenshot to point to a newer uploaded image, keeping the project documentation’s UI preview current.

**Changes:**
- Replaced the README screenshot image `src` URL with a new GitHub user-attachments asset.