### PR TITLE
Added several file formats to save the result list

### DIFF
--- a/Forms/DatabaseDifferencesForm.Designer.cs
+++ b/Forms/DatabaseDifferencesForm.Designer.cs
@@ -33,8 +33,45 @@ partial class DatabaseDifferencesForm
 		ComponentResourceManager resources = new ComponentResourceManager(typeof(DatabaseDifferencesForm));
 		panelMain = new KryptonPanel();
 		groupBoxResults = new GroupBox();
+		kryptonButtonGoto = new KryptonButton();
 		kryptonButtonNoteAbbreviations = new KryptonButton();
 		dropButtonSaveList = new KryptonDropButton();
+		contextMenuSaveList = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		saveAsXPSToolStripMenuItem = new ToolStripMenuItem();
+		saveAsFB2ToolStripMenuItem = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
 		listViewResults = new ListView();
 		columnHeaderResultsNumber = new ColumnHeader();
 		columnHeaderResultsDesignation = new ColumnHeader();
@@ -57,30 +94,10 @@ partial class DatabaseDifferencesForm
 		toolStripSeparator1 = new ToolStripSeparator();
 		toolStripLabelProgress = new ToolStripLabel();
 		kryptonProgressBar = new KryptonProgressBarToolStripItem();
-		contextMenuSaveList = new ContextMenuStrip(components);
-		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
 		((ISupportInitialize)panelMain).BeginInit();
 		panelMain.SuspendLayout();
 		groupBoxResults.SuspendLayout();
+		contextMenuSaveList.SuspendLayout();
 		groupBoxFile1.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
 		groupBoxFile2.SuspendLayout();
@@ -90,7 +107,6 @@ partial class DatabaseDifferencesForm
 		toolStripContainer.TopToolStripPanel.SuspendLayout();
 		toolStripContainer.SuspendLayout();
 		kryptonToolStripIcons.SuspendLayout();
-		contextMenuSaveList.SuspendLayout();
 		SuspendLayout();
 		// 
 		// panelMain
@@ -117,6 +133,7 @@ partial class DatabaseDifferencesForm
 		groupBoxResults.AccessibleName = "Group the results";
 		groupBoxResults.AccessibleRole = AccessibleRole.Grouping;
 		groupBoxResults.BackColor = Color.Transparent;
+		groupBoxResults.Controls.Add(kryptonButtonGoto);
 		groupBoxResults.Controls.Add(kryptonButtonNoteAbbreviations);
 		groupBoxResults.Controls.Add(dropButtonSaveList);
 		groupBoxResults.Controls.Add(listViewResults);
@@ -130,6 +147,29 @@ partial class DatabaseDifferencesForm
 		groupBoxResults.MouseLeave += Control_Leave;
 		groupBoxResults.Enter += Control_Enter;
 		groupBoxResults.Leave += Control_Leave;
+		// 
+		// kryptonButtonGoto
+		// 
+		kryptonButtonGoto.AccessibleDescription = "Go to the selected object";
+		kryptonButtonGoto.AccessibleName = "Go to object";
+		kryptonButtonGoto.AccessibleRole = AccessibleRole.PushButton;
+		kryptonButtonGoto.Location = new Point(429, 273);
+		kryptonButtonGoto.Margin = new Padding(4, 3, 4, 3);
+		kryptonButtonGoto.Name = "kryptonButtonGoto";
+		kryptonButtonGoto.Size = new Size(98, 23);
+		kryptonButtonGoto.TabIndex = 10;
+		kryptonButtonGoto.ToolTipValues.Description = "Go to the selected object";
+		kryptonButtonGoto.ToolTipValues.EnableToolTips = true;
+		kryptonButtonGoto.ToolTipValues.Heading = "Go to object";
+		kryptonButtonGoto.ToolTipValues.Image = Resources.FatcowIcons16px.fatcow_information_16px;
+		kryptonButtonGoto.Values.DropDownArrowColor = Color.Empty;
+		kryptonButtonGoto.Values.Image = Resources.FatcowIcons16px.fatcow_bullet_go_16px;
+		kryptonButtonGoto.Values.Text = "Go to &object";
+		kryptonButtonGoto.Click += KryptonButtonGoto_Click;
+		kryptonButtonGoto.Enter += Control_Enter;
+		kryptonButtonGoto.Leave += Control_Leave;
+		kryptonButtonGoto.MouseEnter += Control_Enter;
+		kryptonButtonGoto.MouseLeave += Control_Leave;
 		// 
 		// kryptonButtonNoteAbbreviations
 		// 
@@ -147,7 +187,7 @@ partial class DatabaseDifferencesForm
 		kryptonButtonNoteAbbreviations.ToolTipValues.Image = Resources.FatcowIcons16px.fatcow_information_16px;
 		kryptonButtonNoteAbbreviations.Values.DropDownArrowColor = Color.Empty;
 		kryptonButtonNoteAbbreviations.Values.Image = Resources.FatcowIcons16px.fatcow_note_16px;
-		kryptonButtonNoteAbbreviations.Values.Text = "&Abbreviations";
+		kryptonButtonNoteAbbreviations.Values.Text = "A&bbreviations";
 		kryptonButtonNoteAbbreviations.Click += KryptonButtonNoteAbbreviations_Click;
 		kryptonButtonNoteAbbreviations.Enter += Control_Enter;
 		kryptonButtonNoteAbbreviations.Leave += Control_Leave;
@@ -183,19 +223,557 @@ partial class DatabaseDifferencesForm
 		dropButtonSaveList.MouseEnter += Control_Enter;
 		dropButtonSaveList.MouseLeave += Control_Leave;
 		// 
+		// contextMenuSaveList
+		// 
+		contextMenuSaveList.AccessibleDescription = "Save the list as file";
+		contextMenuSaveList.AccessibleName = "Save list";
+		contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuSaveList.Font = new Font("Segoe UI", 9F);
+		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveList.Name = "contextMenuSaveList";
+		contextMenuSaveList.Size = new Size(202, 158);
+		contextMenuSaveList.TabStop = true;
+		contextMenuSaveList.Text = "&Save list";
+		contextMenuSaveList.MouseEnter += Control_Enter;
+		contextMenuSaveList.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemTextFiles
+		// 
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown });
+		toolStripMenuItemTextFiles.Image = Resources.FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.ShortcutKeyDisplayString = "";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseDown += Control_MouseDown;
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		// 
+		// toolStripMenuItemSaveAsText
+		// 
+		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsText.AutoToolTip = true;
+		toolStripMenuItemSaveAsText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+		toolStripMenuItemSaveAsText.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsText.Size = new Size(172, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as te&xt";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsLatex
+		// 
+		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
+		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+		toolStripMenuItemSaveAsLatex.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+		toolStripMenuItemSaveAsLatex.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsLatex.Size = new Size(172, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as Lat&ex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMarkdown
+		// 
+		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
+		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+		toolStripMenuItemSaveAsMarkdown.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+		toolStripMenuItemSaveAsMarkdown.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(172, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as Mar&kdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.ShortcutKeyDisplayString = "";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWord
+		// 
+		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
+		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWord.AutoToolTip = true;
+		toolStripMenuItemSaveAsWord.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+		toolStripMenuItemSaveAsWord.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsWord.Size = new Size(179, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOdt
+		// 
+		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
+		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+		toolStripMenuItemSaveAsOdt.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+		toolStripMenuItemSaveAsOdt.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsOdt.Size = new Size(179, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as O&DT";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsRtf
+		// 
+		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
+		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+		toolStripMenuItemSaveAsRtf.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+		toolStripMenuItemSaveAsRtf.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsRtf.Size = new Size(179, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &RTF";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(179, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(179, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsExcel
+		// 
+		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
+		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+		toolStripMenuItemSaveAsExcel.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+		toolStripMenuItemSaveAsExcel.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsExcel.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as Exce&l";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOds
+		// 
+		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
+		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOds.AutoToolTip = true;
+		toolStripMenuItemSaveAsOds.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+		toolStripMenuItemSaveAsOds.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsOds.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as OD&S";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsCsv
+		// 
+		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
+		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsCsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+		toolStripMenuItemSaveAsCsv.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsCsv.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &CSV";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTsv
+		// 
+		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
+		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsTsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+		toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsTsv.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPsv
+		// 
+		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
+		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsPsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+		toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsPsv.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(142, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &ET";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.ShortcutKeyDisplayString = "";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsHtml
+		// 
+		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
+		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+		toolStripMenuItemSaveAsHtml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+		toolStripMenuItemSaveAsHtml.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXml
+		// 
+		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
+		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXml.AutoToolTip = true;
+		toolStripMenuItemSaveAsXml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+		toolStripMenuItemSaveAsXml.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as X&ML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsToml });
+		toolStripMenuItemConfigurationFiles.Image = Resources.FatcowIcons16px.fatcow_file_extension_dll_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.ShortcutKeyDisplayString = "";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsJson
+		// 
+		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
+		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsJson.AutoToolTip = true;
+		toolStripMenuItemSaveAsJson.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+		toolStripMenuItemSaveAsJson.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsYaml
+		// 
+		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
+		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+		toolStripMenuItemSaveAsYaml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+		toolStripMenuItemSaveAsYaml.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql });
+		toolStripMenuItemDatabaseScripts.Image = Resources.FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.ShortcutKeyDisplayString = "";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSql
+		// 
+		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
+		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSql.AutoToolTip = true;
+		toolStripMenuItemSaveAsSql.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+		toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsSql.Size = new Size(136, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, saveAsXPSToolStripMenuItem, saveAsFB2ToolStripMenuItem, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.ShortcutKeyDisplayString = "";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPdf
+		// 
+		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
+		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+		toolStripMenuItemSaveAsPdf.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+		toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsPdf.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPostScript
+		// 
+		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
+		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+		toolStripMenuItemSaveAsPostScript.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+		toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEpub
+		// 
+		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
+		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+		toolStripMenuItemSaveAsEpub.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+		toolStripMenuItemSaveAsEpub.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsEpub.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as EPU&B";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMobi
+		// 
+		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
+		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+		toolStripMenuItemSaveAsMobi.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+		toolStripMenuItemSaveAsMobi.ShortcutKeyDisplayString = "";
+		toolStripMenuItemSaveAsMobi.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as MOB&I";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
+		// 
+		// saveAsXPSToolStripMenuItem
+		// 
+		saveAsXPSToolStripMenuItem.AccessibleDescription = "Saves the list as XPS file";
+		saveAsXPSToolStripMenuItem.AccessibleName = "Save as XPS";
+		saveAsXPSToolStripMenuItem.AccessibleRole = AccessibleRole.MenuItem;
+		saveAsXPSToolStripMenuItem.AutoToolTip = true;
+		saveAsXPSToolStripMenuItem.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		saveAsXPSToolStripMenuItem.Name = "saveAsXPSToolStripMenuItem";
+		saveAsXPSToolStripMenuItem.Size = new Size(145, 22);
+		saveAsXPSToolStripMenuItem.Text = "Save as &XPS";
+		saveAsXPSToolStripMenuItem.Click += ToolStripMenuItemSaveAsXps_Click;
+		saveAsXPSToolStripMenuItem.MouseEnter += Control_Enter;
+		saveAsXPSToolStripMenuItem.MouseLeave += Control_Leave;
+		// 
+		// saveAsFB2ToolStripMenuItem
+		// 
+		saveAsFB2ToolStripMenuItem.AccessibleDescription = "Saves the list as FB2 file";
+		saveAsFB2ToolStripMenuItem.AccessibleName = "Save as FB2";
+		saveAsFB2ToolStripMenuItem.AccessibleRole = AccessibleRole.MenuItem;
+		saveAsFB2ToolStripMenuItem.AutoToolTip = true;
+		saveAsFB2ToolStripMenuItem.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		saveAsFB2ToolStripMenuItem.Name = "saveAsFB2ToolStripMenuItem";
+		saveAsFB2ToolStripMenuItem.Size = new Size(145, 22);
+		saveAsFB2ToolStripMenuItem.Text = "Save as &FB2";
+		saveAsFB2ToolStripMenuItem.Click += ToolStripMenuItemSaveAsFb2_Click;
+		saveAsFB2ToolStripMenuItem.MouseEnter += Control_Enter;
+		saveAsFB2ToolStripMenuItem.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
+		// 
 		// listViewResults
 		// 
 		listViewResults.AccessibleDescription = "Lists the results";
 		listViewResults.AccessibleName = "Results";
+		listViewResults.AccessibleRole = AccessibleRole.List;
+		listViewResults.AllowColumnReorder = true;
 		listViewResults.Columns.AddRange(new ColumnHeader[] { columnHeaderResultsNumber, columnHeaderResultsDesignation, columnHeaderResultsDifference });
 		listViewResults.FullRowSelect = true;
 		listViewResults.GridLines = true;
 		listViewResults.Location = new Point(3, 19);
+		listViewResults.MultiSelect = false;
 		listViewResults.Name = "listViewResults";
+		listViewResults.ShowItemToolTips = true;
 		listViewResults.Size = new Size(628, 248);
 		listViewResults.TabIndex = 0;
 		listViewResults.UseCompatibleStateImageBehavior = false;
 		listViewResults.View = View.Details;
+		listViewResults.VirtualMode = true;
+		listViewResults.RetrieveVirtualItem += ListViewResults_RetrieveVirtualItem;
+		listViewResults.DoubleClick += ListViewResults_DoubleClick;
 		listViewResults.Enter += Control_Enter;
 		listViewResults.Leave += Control_Leave;
 		listViewResults.MouseEnter += Control_Enter;
@@ -267,7 +845,7 @@ partial class DatabaseDifferencesForm
 		contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
 		contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCopyToClipboard });
 		contextMenuCopyToClipboard.Name = "contextMenuStrip";
-		contextMenuCopyToClipboard.Size = new Size(214, 26);
+		contextMenuCopyToClipboard.Size = new Size(208, 26);
 		contextMenuCopyToClipboard.TabStop = true;
 		contextMenuCopyToClipboard.Text = "Copy to clipboard";
 		contextMenuCopyToClipboard.MouseEnter += Control_Enter;
@@ -281,9 +859,9 @@ partial class DatabaseDifferencesForm
 		ToolStripMenuItemCopyToClipboard.AutoToolTip = true;
 		ToolStripMenuItemCopyToClipboard.Image = Resources.FatcowIcons16px.fatcow_page_copy_16px;
 		ToolStripMenuItemCopyToClipboard.Name = "ToolStripMenuItemCopyToClipboard";
-		ToolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Strg+C";
+		ToolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Alt+C";
 		ToolStripMenuItemCopyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
-		ToolStripMenuItemCopyToClipboard.Size = new Size(213, 22);
+		ToolStripMenuItemCopyToClipboard.Size = new Size(207, 22);
 		ToolStripMenuItemCopyToClipboard.Text = "&Copy to clipboard";
 		ToolStripMenuItemCopyToClipboard.Click += CopyToClipboard_DoubleClick;
 		ToolStripMenuItemCopyToClipboard.MouseEnter += Control_Enter;
@@ -464,7 +1042,7 @@ partial class DatabaseDifferencesForm
 		toolStripButtonCompare.AccessibleDescription = "Compares two version of the file MPCORB.DAT";
 		toolStripButtonCompare.AccessibleName = "Compare";
 		toolStripButtonCompare.AccessibleRole = AccessibleRole.PushButton;
-		toolStripButtonCompare.Image = Resources.FatcowIcons16px.fatcow_bullet_go_16px;
+		toolStripButtonCompare.Image = Resources.FatcowIcons16px.fatcow_database_access_16px;
 		toolStripButtonCompare.ImageTransparentColor = Color.Magenta;
 		toolStripButtonCompare.Name = "toolStripButtonCompare";
 		toolStripButtonCompare.Size = new Size(76, 22);
@@ -524,340 +1102,6 @@ partial class DatabaseDifferencesForm
 		kryptonProgressBar.MouseEnter += Control_Enter;
 		kryptonProgressBar.MouseLeave += Control_Leave;
 		// 
-		// contextMenuSaveList
-		// 
-		contextMenuSaveList.AccessibleDescription = "Save the list as file";
-		contextMenuSaveList.AccessibleName = "Save list";
-		contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
-		contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi });
-		contextMenuSaveList.Name = "contextMenuSaveList";
-		contextMenuSaveList.Size = new Size(216, 444);
-		contextMenuSaveList.TabStop = true;
-		contextMenuSaveList.Text = "&Save list";
-		contextMenuSaveList.MouseEnter += Control_Enter;
-		contextMenuSaveList.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsText
-		// 
-		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
-		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
-		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsText.AutoToolTip = true;
-		toolStripMenuItemSaveAsText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
-		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
-		toolStripMenuItemSaveAsText.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsText.ShortcutKeys = Keys.Control | Keys.X;
-		toolStripMenuItemSaveAsText.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsText.Text = "Save as te&xt";
-		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
-		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsLatex
-		// 
-		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
-		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
-		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
-		toolStripMenuItemSaveAsLatex.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
-		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
-		toolStripMenuItemSaveAsLatex.ShortcutKeyDisplayString = "Strg+E";
-		toolStripMenuItemSaveAsLatex.ShortcutKeys = Keys.Control | Keys.E;
-		toolStripMenuItemSaveAsLatex.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsLatex.Text = "Save as Lat&ex";
-		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
-		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsMarkdown
-		// 
-		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
-		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
-		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
-		toolStripMenuItemSaveAsMarkdown.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
-		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
-		toolStripMenuItemSaveAsMarkdown.ShortcutKeyDisplayString = "Strg+K";
-		toolStripMenuItemSaveAsMarkdown.ShortcutKeys = Keys.Control | Keys.K;
-		toolStripMenuItemSaveAsMarkdown.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsMarkdown.Text = "Save as Mar&kdown";
-		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
-		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsWord
-		// 
-		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
-		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
-		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsWord.AutoToolTip = true;
-		toolStripMenuItemSaveAsWord.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
-		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
-		toolStripMenuItemSaveAsWord.ShortcutKeyDisplayString = "Strg+W";
-		toolStripMenuItemSaveAsWord.ShortcutKeys = Keys.Control | Keys.W;
-		toolStripMenuItemSaveAsWord.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsWord.Text = "Save as &Word";
-		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;	 
-		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsOdt
-		// 
-		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
-		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
-		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
-		toolStripMenuItemSaveAsOdt.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
-		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
-		toolStripMenuItemSaveAsOdt.ShortcutKeyDisplayString = "Strg+D";
-		toolStripMenuItemSaveAsOdt.ShortcutKeys = Keys.Control | Keys.D;
-		toolStripMenuItemSaveAsOdt.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsOdt.Text = "Save as O&DT";
-		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
-		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsRtf
-		// 
-		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
-		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
-		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
-		toolStripMenuItemSaveAsRtf.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
-		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
-		toolStripMenuItemSaveAsRtf.ShortcutKeyDisplayString = "Strg+R";
-		toolStripMenuItemSaveAsRtf.ShortcutKeys = Keys.Control | Keys.R;
-		toolStripMenuItemSaveAsRtf.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsRtf.Text = "Save as &RTF";
-		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
-		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsExcel
-		// 
-		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
-		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
-		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
-		toolStripMenuItemSaveAsExcel.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
-		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
-		toolStripMenuItemSaveAsExcel.ShortcutKeyDisplayString = "Strg+L";
-		toolStripMenuItemSaveAsExcel.ShortcutKeys = Keys.Control | Keys.L;
-		toolStripMenuItemSaveAsExcel.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsExcel.Text = "Save as Exce&l";
-		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;	 
-		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsOds
-		// 
-		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
-		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
-		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsOds.AutoToolTip = true;
-		toolStripMenuItemSaveAsOds.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
-		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
-		toolStripMenuItemSaveAsOds.ShortcutKeyDisplayString = "Strg+S";
-		toolStripMenuItemSaveAsOds.ShortcutKeys = Keys.Control | Keys.S;
-		toolStripMenuItemSaveAsOds.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsOds.Text = "Save as OD&S";
-		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;		
-		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsCsv
-		// 
-		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
-		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
-		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
-		toolStripMenuItemSaveAsCsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
-		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
-		toolStripMenuItemSaveAsCsv.ShortcutKeyDisplayString = "Strg+C";
-		toolStripMenuItemSaveAsCsv.ShortcutKeys = Keys.Control | Keys.C;
-		toolStripMenuItemSaveAsCsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsCsv.Text = "Save as &CSV";
-		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;			
-		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsTsv
-		// 
-		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
-		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
-		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
-		toolStripMenuItemSaveAsTsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
-		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
-		toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "Strg+T";
-		toolStripMenuItemSaveAsTsv.ShortcutKeys = Keys.Control | Keys.T;
-		toolStripMenuItemSaveAsTsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
-		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;	  
-		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsPsv
-		// 
-		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
-		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
-		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
-		toolStripMenuItemSaveAsPsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
-		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
-		toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "Strg+V";
-		toolStripMenuItemSaveAsPsv.ShortcutKeys = Keys.Control | Keys.V;
-		toolStripMenuItemSaveAsPsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
-		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;	
-		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsHtml
-		// 
-		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
-		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
-		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
-		toolStripMenuItemSaveAsHtml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
-		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
-		toolStripMenuItemSaveAsHtml.ShortcutKeyDisplayString = "Strg+H";
-		toolStripMenuItemSaveAsHtml.ShortcutKeys = Keys.Control | Keys.H;
-		toolStripMenuItemSaveAsHtml.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
-		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;		
-		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsXml
-		// 
-		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
-		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
-		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsXml.AutoToolTip = true;
-		toolStripMenuItemSaveAsXml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
-		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
-		toolStripMenuItemSaveAsXml.ShortcutKeyDisplayString = "Strg+M";
-		toolStripMenuItemSaveAsXml.ShortcutKeys = Keys.Control | Keys.M;
-		toolStripMenuItemSaveAsXml.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsXml.Text = "Save as X&ML";
-		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;	
-		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsJson
-		// 
-		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
-		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
-		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsJson.AutoToolTip = true;
-		toolStripMenuItemSaveAsJson.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
-		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
-		toolStripMenuItemSaveAsJson.ShortcutKeyDisplayString = "Strg+J";
-		toolStripMenuItemSaveAsJson.ShortcutKeys = Keys.Control | Keys.J;
-		toolStripMenuItemSaveAsJson.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
-		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;		 
-		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsYaml
-		// 
-		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
-		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
-		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
-		toolStripMenuItemSaveAsYaml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
-		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
-		toolStripMenuItemSaveAsYaml.ShortcutKeyDisplayString = "Strg+Y";
-		toolStripMenuItemSaveAsYaml.ShortcutKeys = Keys.Control | Keys.Y;
-		toolStripMenuItemSaveAsYaml.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
-		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;		
-		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsSql
-		// 
-		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
-		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
-		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsSql.AutoToolTip = true;
-		toolStripMenuItemSaveAsSql.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
-		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
-		toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+Q";
-		toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.Q;
-		toolStripMenuItemSaveAsSql.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
-		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;	
-		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsPdf
-		// 
-		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
-		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
-		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
-		toolStripMenuItemSaveAsPdf.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
-		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
-		toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "Strg+F";
-		toolStripMenuItemSaveAsPdf.ShortcutKeys = Keys.Control | Keys.F;
-		toolStripMenuItemSaveAsPdf.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
-		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;	   
-		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsPostScript
-		// 
-		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
-		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
-		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
-		toolStripMenuItemSaveAsPostScript.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
-		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
-		toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "Strg+P";
-		toolStripMenuItemSaveAsPostScript.ShortcutKeys = Keys.Control | Keys.P;
-		toolStripMenuItemSaveAsPostScript.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
-		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
-		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsEpub
-		// 
-		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
-		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
-		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
-		toolStripMenuItemSaveAsEpub.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
-		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
-		toolStripMenuItemSaveAsEpub.ShortcutKeyDisplayString = "Strg+B";
-		toolStripMenuItemSaveAsEpub.ShortcutKeys = Keys.Control | Keys.B;
-		toolStripMenuItemSaveAsEpub.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsEpub.Text = "Save as EPU&B";
-		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;		  
-		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemSaveAsMobi
-		// 
-		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
-		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
-		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
-		toolStripMenuItemSaveAsMobi.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
-		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
-		toolStripMenuItemSaveAsMobi.ShortcutKeyDisplayString = "Strg+I";
-		toolStripMenuItemSaveAsMobi.ShortcutKeys = Keys.Control | Keys.I;
-		toolStripMenuItemSaveAsMobi.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsMobi.Text = "Save as MOB&I";
-		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;			
-		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
-		// 
 		// DatabaseDifferencesForm
 		// 
 		AccessibleDescription = "Compares two MPCORB.DAT files";
@@ -879,6 +1123,7 @@ partial class DatabaseDifferencesForm
 		((ISupportInitialize)panelMain).EndInit();
 		panelMain.ResumeLayout(false);
 		groupBoxResults.ResumeLayout(false);
+		contextMenuSaveList.ResumeLayout(false);
 		groupBoxFile1.ResumeLayout(false);
 		contextMenuCopyToClipboard.ResumeLayout(false);
 		groupBoxFile2.ResumeLayout(false);
@@ -893,7 +1138,6 @@ partial class DatabaseDifferencesForm
 		toolStripContainer.PerformLayout();
 		kryptonToolStripIcons.ResumeLayout(false);
 		kryptonToolStripIcons.PerformLayout();
-		contextMenuSaveList.ResumeLayout(false);
 		ResumeLayout(false);
 	}
 
@@ -944,4 +1188,20 @@ partial class DatabaseDifferencesForm
 	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
 	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
 	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem saveAsXPSToolStripMenuItem;
+	private ToolStripMenuItem saveAsFB2ToolStripMenuItem;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private KryptonButton kryptonButtonGoto;
 }

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -31,6 +31,11 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 		WriteIndented = true
 	};
 
+	/// <summary>Gets the name of the file that stores the database differences.</summary>
+	/// <remarks>This field stores the name of the file where the database differences are saved. It is used to identify
+	/// the file when performing read or write operations related to database differences.</remarks>
+	private readonly string fileName = "database-differences";
+
 	/// <summary>Gets or sets the background worker used for asynchronous operations.</summary>
 	/// <remarks>This field is initialized to null and should be assigned a valid instance of BackgroundWorker
 	/// before use. Ensure that the worker is properly configured to handle events such as DoWork, RunWorkerCompleted, and
@@ -75,15 +80,10 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// <remarks>This constructor sets up the form and initializes the background worker.</remarks>
 	public DatabaseDifferencesForm()
 	{
-		// ReSharper disable once VirtualMemberCallInConstructor
+		// Initialize the form's components, setting up the user interface elements and layout as defined in the designer file.
 		InitializeComponent();
 		// Initialize the background worker for asynchronous operations
 		InitializeBackgroundWorker();
-		// Set up the ListView for virtual mode to efficiently handle large datasets
-		listViewResults.VirtualMode = true;
-		// Attach event handlers for retrieving virtual items and handling double-clicks on the ListView
-		listViewResults.RetrieveVirtualItem += ListViewResults_RetrieveVirtualItem;
-		listViewResults.DoubleClick += ListViewResults_DoubleClick;
 	}
 
 	#endregion
@@ -168,6 +168,40 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 		return diffs.Count > 0 ? string.Join(separator: "; ", values: diffs) : string.Empty;
 	}
 
+	/// <summary>Navigates to the corresponding record in the main form based on the user's selection in the ListView.</summary>
+	/// <remarks>If no record is selected, a warning message is displayed. If the selected record has been deleted,
+	/// a notification is shown. Otherwise, the method attempts to jump to the selected record in the main form. This
+	/// method is intended to be used in response to user actions that require focusing on a specific record from a list of
+	/// database differences.</remarks>
+	private void GoToObject()
+	{
+		// Check if there are any selected indices in the ListView, and if not, return early to prevent errors; if there is a selected index, retrieve the corresponding DifferenceResult and either show a message if the record was deleted or jump to the record in the main form if it still exists
+		if (listViewResults.SelectedIndices.Count == 0)
+		{
+			MessageBox.Show(text: "Please select a record to jump to.", caption: "No Record Selected", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			return;
+		}
+		// Get the first selected index from the ListView and check if it is within the bounds of the difference results list; if so, retrieve the corresponding DifferenceResult and determine whether to show a message about a deleted record or to jump to the record in the main form based on the type of difference
+		int selectedIndex = listViewResults.SelectedIndices[index: 0];
+		if (selectedIndex >= 0 && selectedIndex < differenceResults.Count)
+		{
+			DifferenceResult result = differenceResults[index: selectedIndex];
+			if (result.Difference.Equals(value: "Deleted record", comparisonType: StringComparison.OrdinalIgnoreCase))
+			{
+				_ = MessageBox.Show(text: "The selected record has been deleted and is no longer available.", caption: "Record Deleted", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			}
+			else
+			{
+				// Attempt to find the main form of the application and, if it exists, call a method to jump to the record corresponding to the selected difference result based on its index and designation
+				if (Application.OpenForms.OfType<PlanetoidDbForm>().FirstOrDefault() is PlanetoidDbForm mainForm)
+				{
+					Close();
+					mainForm.JumpToRecord(index: result.Index, designation: result.Designation);
+				}
+			}
+		}
+	}
+
 	/// <summary>Saves the results displayed in the list view to a text file, allowing the user to specify the file location and
 	/// format.</summary>
 	/// <remarks>This method prompts the user with a save file dialog to select the destination for the text file.
@@ -176,28 +210,39 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// to the user.</remarks>
 	private void SaveListViewResultsAsText()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the text file; if the user confirms the save operation, attempt to write the difference results to the specified file, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*"
+			Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*",
+			FileName = fileName
 		};
+		// Show the save file dialog and check if the user clicked the OK button; if so, proceed to save the results to the specified file
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a tab-separated format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
+				// Write a header line to the text file for clarity
+				writer.WriteLine(value: "Index\tDesignation\tDifference");
+				// Iterate through the list of difference results and write each one to the file in a tab-separated format
 				foreach (DifferenceResult result in differenceResults)
 				{
 					writer.WriteLine(value: $"{result.Index}\t{result.Designation}\t{result.Difference}");
 				}
+				// After successfully writing the results to the file, display a success message to the user
 				MessageBox.Show(text: "Results successfully saved to text file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to text file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to text file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -210,29 +255,38 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsCsv()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the CSV file; if the user confirms the save operation, attempt to write the difference results to the specified file in CSV format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+			Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in CSV format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a comma-separated format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
+				// Write a header line to the CSV file for clarity
 				writer.WriteLine(value: "Index,Designation,Difference");
+				// Iterate through the list of difference results and write each one to the CSV file in a comma-separated format
 				foreach (DifferenceResult result in differenceResults)
 				{
 					writer.WriteLine(value: $"{result.Index},\"{result.Designation}\",\"{result.Difference}\"");
 				}
+				// After successfully writing the results to the file, display a success message to the user
 				MessageBox.Show(text: "Results successfully saved to CSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to CSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to CSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -245,29 +299,38 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsTsv()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the TSV file; if the user confirms the save operation, attempt to write the difference results to the specified file in TSV format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "TSV Files (*.tsv)|*.tsv|All Files (*.*)|*.*"
+			Filter = "TSV Files (*.tsv)|*.tsv|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in TSV format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a tab-separated format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
+				// Write a header line to the TSV file for clarity
 				writer.WriteLine(value: "Index\tDesignation\tDifference");
+				// Iterate through the list of difference results and write each one to the TSV file in a tab-separated format
 				foreach (DifferenceResult result in differenceResults)
 				{
 					writer.WriteLine(value: $"{result.Index}\t{result.Designation}\t{result.Difference}");
 				}
+				// After successfully writing the results to the file, display a success message to the user
 				MessageBox.Show(text: "Results successfully saved to TSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to TSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to TSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -280,29 +343,38 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsPsv()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the PSV file; if the user confirms the save operation, attempt to write the difference results to the specified file in PSV format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "PSV Files (*.psv)|*.psv|All Files (*.*)|*.*"
+			Filter = "PSV Files (*.psv)|*.psv|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in PSV format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a pipe-separated format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
+				// Write a header line to the PSV file for clarity
 				writer.WriteLine(value: "Index|Designation|Difference");
+				// Iterate through the list of difference results and write each one to the PSV file in a pipe-separated format
 				foreach (DifferenceResult result in differenceResults)
 				{
 					writer.WriteLine(value: $"{result.Index}|{result.Designation}|{result.Difference}");
 				}
+				// After successfully writing the results to the file, display a success message to the user
 				MessageBox.Show(text: "Results successfully saved to PSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PSV file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -315,14 +387,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsMarkdown()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the Markdown file; if the user confirms the save operation, attempt to write the difference results to the specified file in Markdown format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "Markdown Files (*.md)|*.md|All Files (*.*)|*.*"
+			Filter = "Markdown Files (*.md)|*.md|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in Markdown format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a Markdown table format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: "| Index | Designation | Difference |");
 				writer.WriteLine(value: "|-------|-------------|------------|");
@@ -334,11 +410,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Markdown file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Markdown file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -351,41 +429,45 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsExcel()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the Excel file; if the user confirms the save operation, attempt to write the difference results to the specified file in Excel format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*"
+			Filter = "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in Excel format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a new ZipArchive to represent the Excel file structure; then, create the necessary entries for the content types, relationships, workbook, and worksheet, writing the appropriate XML content for each entry based on the difference results; after successfully creating the Excel file, show a success message to the user
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
+				// Create the [Content_Types].xml entry, which defines the content types for the Excel file; write the necessary XML content to specify the default and override content types for the relationships, workbook, and worksheet
 				System.IO.Compression.ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml");
 				using (StreamWriter writer = new(stream: contentTypesEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" /><Default Extension=\"xml\" ContentType=\"application/xml\" /><Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\" /><Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\" /></Types>");
 				}
-
+				// Create the _rels/.rels entry, which defines the relationships for the Excel file; write the necessary XML content to specify the relationship between the package and the workbook
 				System.IO.Compression.ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels");
 				using (StreamWriter writer = new(stream: relsEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\" /></Relationships>");
 				}
-
+				// Create the xl/_rels/workbook.xml.rels entry, which defines the relationships for the workbook; write the necessary XML content to specify the relationship between the workbook and the worksheet
 				System.IO.Compression.ZipArchiveEntry workbookRelsEntry = archive.CreateEntry(entryName: "xl/_rels/workbook.xml.rels");
 				using (StreamWriter writer = new(stream: workbookRelsEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\" /></Relationships>");
 				}
-
+				// Create the xl/workbook.xml entry, which defines the workbook structure for the Excel file; write the necessary XML content to specify the workbook and its sheets, including a sheet named "Differences" that references the worksheet entry
 				System.IO.Compression.ZipArchiveEntry workbookEntry = archive.CreateEntry(entryName: "xl/workbook.xml");
 				using (StreamWriter writer = new(stream: workbookEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><sheets><sheet name=\"Differences\" sheetId=\"1\" r:id=\"rId1\" /></sheets></workbook>");
 				}
-
+				// Create the xl/worksheets/sheet1.xml entry, which defines the worksheet content for the Excel file; write the necessary XML content to specify the worksheet and its data, including a header row and subsequent rows for each difference result, with proper escaping of special characters to ensure valid XML
 				System.IO.Compression.ZipArchiveEntry sheetEntry = archive.CreateEntry(entryName: "xl/worksheets/sheet1.xml");
 				using (StreamWriter writer = new(stream: sheetEntry.Open()))
 				{
@@ -403,11 +485,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Excel file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Excel file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -420,14 +504,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsHtml()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the HTML file; if the user confirms the save operation, attempt to write the difference results to the specified file in HTML format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "HTML Files (*.html)|*.html|All Files (*.*)|*.*"
+			Filter = "HTML Files (*.html)|*.html|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in HTML format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary HTML structure to represent the difference results in a table format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: "<!DOCTYPE html>");
 				writer.WriteLine(value: "<html lang=\"en\">");
@@ -456,11 +544,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to HTML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to HTML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -473,12 +563,15 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsXml()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the XML file; if the user confirms the save operation, attempt to write the difference results to the specified file in XML format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "XML Files (*.xml)|*.xml|All Files (*.*)|*.*"
+			Filter = "XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in XML format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
 				XDocument doc = new(
@@ -500,11 +593,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to XML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to XML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -517,25 +612,31 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsJson()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the JSON file; if the user confirms the save operation, attempt to write the difference results to the specified file in JSON format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*"
+			Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in JSON format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Serialize the list of difference results to a JSON string using System.Text.Json, then write the JSON string to the specified file path; after successfully saving the file, show a success message to the user
 				string json = System.Text.Json.JsonSerializer.Serialize(value: differenceResults, options: jsonSerializerOptions);
 				File.WriteAllText(path: saveFileDialog.FileName, contents: json);
 				MessageBox.Show(text: "Results successfully saved to JSON file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to JSON file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to JSON file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -548,14 +649,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsYaml()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the YAML file; if the user confirms the save operation, attempt to write the difference results to the specified file in YAML format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "YAML Files (*.yaml)|*.yaml|All Files (*.*)|*.*"
+			Filter = "YAML Files (*.yaml)|*.yaml|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in YAML format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write each difference result in a YAML format, ensuring proper escaping of special characters; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				foreach (DifferenceResult result in differenceResults)
 				{
@@ -567,11 +672,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to YAML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to YAML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -584,14 +691,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsLatex()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the LaTeX file; if the user confirms the save operation, attempt to write the difference results to the specified file in LaTeX format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "LaTeX Files (*.tex)|*.tex|All Files (*.*)|*.*"
+			Filter = "LaTeX Files (*.tex)|*.tex|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in LaTeX format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary LaTeX structure to represent the difference results in a tabular format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: "\\documentclass{article}");
 				writer.WriteLine(value: "\\usepackage[utf8]{inputenc}");
@@ -613,11 +724,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to LaTeX file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to LaTeX file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -630,27 +743,31 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// denial occurs during the save operation, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsPdf()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the PDF file; if the user confirms the save operation, attempt to write the difference results to the specified file in PDF format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "PDF Files (*.pdf)|*.pdf|All Files (*.*)|*.*"
+			Filter = "PDF Files (*.pdf)|*.pdf|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in PDF format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and write the necessary PDF structure to represent the difference results in a simple text format; after writing all results, show a success message to the user
 				using FileStream fs = new(path: saveFileDialog.FileName, mode: FileMode.Create, access: FileAccess.Write);
 				using StreamWriter writer = new(stream: fs, encoding: System.Text.Encoding.ASCII);
 				writer.NewLine = "\n";
-
+				// Initialize a list to keep track of the byte offsets for each PDF object, starting with a dummy entry for object 0 which is reserved in PDF files; this list will be used to generate the cross-reference table at the end of the PDF file
 				List<long> xrefs = [0]; // dummy object 0
-
+										// Define a local function to write a PDF object with a given ID and content, which updates the cross-reference list with the current byte offset before writing the object to the file
 				void WriteObj(int id, string content)
 				{
 					writer.Flush();
 					xrefs.Add(item: fs.Position);
 					writer.Write(value: $"{id} 0 obj\n{content}\nendobj\n");
 				}
-
+				// Define a local function to escape special characters in strings for safe inclusion in PDF content streams, replacing non-ASCII characters with a placeholder and escaping parentheses, backslashes, and line breaks according to PDF syntax rules
 				string EscapePdfString(string input)
 				{
 					if (string.IsNullOrEmpty(value: input))
@@ -691,27 +808,27 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					return sb.ToString();
 				}
-
+				// Write the PDF header to indicate the PDF version being used; this is required at the beginning of every PDF file to identify it as a valid PDF document
 				writer.Write(value: "%PDF-1.4\n");
-
+				// Initialize object IDs for the PDF structure, starting with the catalog and pages objects, and prepare lists to hold the page IDs and their corresponding content streams; then, construct the content for each page based on the difference results, ensuring that text is properly formatted and paginated according to PDF specifications
 				int objId = 1;
 				int catalogId = objId++;
 				int pagesId = objId++;
-
+				// Prepare lists to hold the IDs of the page objects and their corresponding content streams, which will be used to construct the PDF structure; as we generate the content for each page, we will keep track of the current vertical position (y-coordinate) to determine when to start a new page, and we will build the content stream for each page using PDF text operators to position and format the text
 				List<int> pageIds = [];
 				List<string> pageContents = [];
-
+				// Start with an initial y-coordinate for the first page; as we add lines of text to the content stream, we will decrease this y-coordinate to position the text correctly on the page, and when it falls below a certain threshold, we will finalize the current page and start a new one
 				double y = 750;
 				System.Text.StringBuilder currentContent = new();
 				currentContent.Append(value: "BT\n/F1 16 Tf\n40 800 Td\n(Database Differences) Tj\n0 -30 Td\n/F1 12 Tf\n");
-
+				// Iterate through the list of difference results and construct the content for each page, ensuring that text is properly formatted and paginated according to PDF specifications; for each result, we will create a line of text that includes the index, designation, and difference, and we will use PDF text operators to position this text on the page; if the y-coordinate falls below a certain threshold (indicating that we have reached the bottom of the page), we will finalize the current page content and start a new page
 				foreach (DifferenceResult result in differenceResults)
 				{
 					string safeIndex = EscapePdfString(input: result.Index);
 					string safeDesig = EscapePdfString(input: result.Designation);
 					string safeDiff = EscapePdfString(input: result.Difference);
 					string line = $"{safeIndex}    {safeDesig}    {safeDiff}";
-
+					// Append the line of text for the current difference result to the content stream, using PDF text operators to position the text correctly on the page; after adding the line, decrease the y-coordinate to move down for the next line, and check if we need to start a new page based on the y-coordinate threshold
 					currentContent.Append(value: $"0 -20 Td\n({line}) Tj\n");
 					y -= 20;
 					if (y < 50)
@@ -728,31 +845,27 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					currentContent.Append(value: "ET\n");
 					pageContents.Add(item: currentContent.ToString());
 				}
-
+				// For each page content generated, assign a unique object ID for the content stream and the corresponding page object, and keep track of these IDs in separate lists; this will allow us to construct the PDF structure correctly, linking each page to its content stream and ensuring that all objects are properly referenced in the catalog and pages objects
 				List<int> contentIds = [];
 				foreach (string _ in pageContents)
 				{
 					contentIds.Add(item: objId++);
 				}
-
 				foreach (string _ in pageContents)
 				{
 					pageIds.Add(item: objId++);
 				}
-
+				//After generating the content for all pages and assigning object IDs, write the PDF objects for the catalog, pages, each page, and their corresponding content streams; also write a font object that will be used in the content streams to specify the font for the text; finally, after writing all objects, generate the cross-reference table and trailer to complete the PDF file structure, and show a success message to the user
 				int fontId = objId++;
-
 				WriteObj(id: catalogId, content: $"<< /Type /Catalog /Pages {pagesId} 0 R >>");
 				WriteObj(id: pagesId, content: $"<< /Type /Pages /Kids [ {string.Join(separator: " ", values: pageIds.Select(selector: p => $"{p} 0 R"))} ] /Count {pageIds.Count} >>");
-
 				for (int i = 0; i < pageContents.Count; i++)
 				{
 					WriteObj(id: contentIds[index: i], content: $"<< /Length {pageContents[index: i].Length} >>\nstream\n{pageContents[index: i]}\nendstream");
 					WriteObj(id: pageIds[index: i], content: $"<< /Type /Page /Parent {pagesId} 0 R /Resources << /Font << /F1 {fontId} 0 R >> >> /MediaBox [0 0 595 842] /Contents {contentIds[index: i]} 0 R >>");
 				}
-
 				WriteObj(id: fontId, content: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
-
+				// After writing all PDF objects, generate the cross-reference table and trailer to complete the PDF file structure; this involves writing the xref section with byte offsets for each object, followed by the trailer that specifies the size of the PDF and the reference to the root catalog object; finally, show a success message to the user indicating that the results were successfully saved to the PDF file
 				writer.Flush();
 				long startXref = fs.Position;
 				writer.Write(value: $"xref\n0 {xrefs.Count}\n0000000000 65535 f \n");
@@ -760,34 +873,44 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				{
 					writer.Write(value: $"{xrefs[index: i]:D10} 00000 n \n");
 				}
-
 				writer.Write(value: $"trailer\n<< /Size {xrefs.Count} /Root {catalogId} 0 R >>\nstartxref\n{startXref}\n%%EOF\n");
 				writer.Flush();
 				MessageBox.Show(text: "Results successfully saved to PDF file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PDF file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PDF file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
 
+	/// <summary>Saves the results displayed in the list view to a user-specified SQL file, creating a table and inserting each
+	/// difference as a row.</summary>
+	/// <remarks>The method prompts the user to select a file location and name for the SQL file. It handles
+	/// potential I/O and access errors, displaying appropriate messages to the user. The SQL file will contain a CREATE
+	/// TABLE statement followed by INSERT statements for each difference result.</remarks>
 	private void SaveListViewResultsAsSql()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the SQL file; if the user confirms the save operation, attempt to write the difference results to the specified file in SQL format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "SQL Files (*.sql)|*.sql|All Files (*.*)|*.*"
+			Filter = "SQL Files (*.sql)|*.sql|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in SQL format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary SQL statements to create a table and insert each difference result as a row; ensure that any single quotes in the data are properly escaped to prevent SQL syntax errors; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: "CREATE TABLE Differences (DifferenceIndex TEXT, Designation VARCHAR(255), Difference TEXT);");
 				foreach (DifferenceResult result in differenceResults)
@@ -798,42 +921,49 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to SQL file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to SQL file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
 
+	/// <summary>Saves the results displayed in the ListView to a Word document (.docx) at a user-specified location.</summary>
+	/// <remarks>This method prompts the user with a SaveFileDialog to select the destination file. It creates a
+	/// Word document structure and populates it with the ListView data. If an I/O error or access denial occurs during the
+	/// save process, an error message is shown to the user.</remarks>
 	private void SaveListViewResultsAsWord()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the Word document; if the user confirms the save operation, attempt to write the difference results to the specified file in Word format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "Word Documents (*.docx)|*.docx|All Files (*.*)|*.*"
+			Filter = "Word Documents (*.docx)|*.docx|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in Word format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents a Word document; write the necessary XML files for the content types, relationships, and main document content, populating the main document with the difference results in a tabular format; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the Word file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
 				System.IO.Compression.ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml");
 				using (StreamWriter writer = new(stream: contentTypesEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" /><Default Extension=\"xml\" ContentType=\"application/xml\" /><Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\" /></Types>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels");
 				using (StreamWriter writer = new(stream: relsEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\" /></Relationships>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry docEntry = archive.CreateEntry(entryName: "word/document.xml");
 				using (StreamWriter writer = new(stream: docEntry.Open()))
 				{
@@ -851,11 +981,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Word file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Word file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -869,14 +1001,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsRtf()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the RTF file; if the user confirms the save operation, attempt to write the difference results to the specified file in RTF format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "RTF Files (*.rtf)|*.rtf|All Files (*.*)|*.*"
+			Filter = "RTF Files (*.rtf)|*.rtf|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in RTF format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary RTF structure to represent the difference results in a formatted manner; ensure that any special characters in the data are properly escaped according to RTF syntax rules; after writing all results, show a success message to the user indicating that the results were successfully saved to the RTF file
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Arial;}}");
 				writer.WriteLine(value: @"{\*\generator PlanetoidDB;}\viewkind4\uc1 ");
@@ -894,11 +1030,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to RTF file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to RTF file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -912,29 +1050,30 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsOdt()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the ODT file; if the user confirms the save operation, attempt to write the difference results to the specified file in ODT format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "ODT Files (*.odt)|*.odt|All Files (*.*)|*.*"
+			Filter = "ODT Files (*.odt)|*.odt|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in ODT format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents an ODT document; write the necessary XML files for the mimetype, manifest, and main content, populating the main content with the difference results in a tabular format; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the ODT file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
 				System.IO.Compression.ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype");
 				using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "application/vnd.oasis.opendocument.text");
 				}
-
 				System.IO.Compression.ZipArchiveEntry manifestEntry = archive.CreateEntry(entryName: "META-INF/manifest.xml");
 				using (StreamWriter writer = new(stream: manifestEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><manifest:manifest xmlns:manifest=\"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0\" manifest:version=\"1.2\"><manifest:file-entry manifest:full-path=\"/\" manifest:media-type=\"application/vnd.oasis.opendocument.text\"/><manifest:file-entry manifest:full-path=\"content.xml\" manifest:media-type=\"text/xml\"/></manifest:manifest>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "content.xml");
 				using (StreamWriter writer = new(stream: contentEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -952,11 +1091,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ODT file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ODT file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -970,29 +1111,30 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsOds()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the ODS file; if the user confirms the save operation, attempt to write the difference results to the specified file in ODS format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "ODS Files (*.ods)|*.ods|All Files (*.*)|*.*"
+			Filter = "ODS Files (*.ods)|*.ods|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in ODS format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents an ODS document; write the necessary XML files for the mimetype, manifest, and main content, populating the main content with the difference results in a tabular format; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the ODS file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
 				System.IO.Compression.ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype");
 				using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "application/vnd.oasis.opendocument.spreadsheet");
 				}
-
 				System.IO.Compression.ZipArchiveEntry manifestEntry = archive.CreateEntry(entryName: "META-INF/manifest.xml");
 				using (StreamWriter writer = new(stream: manifestEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><manifest:manifest xmlns:manifest=\"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0\" manifest:version=\"1.2\"><manifest:file-entry manifest:full-path=\"/\" manifest:media-type=\"application/vnd.oasis.opendocument.spreadsheet\"/><manifest:file-entry manifest:full-path=\"content.xml\" manifest:media-type=\"text/xml\"/></manifest:manifest>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "content.xml");
 				using (StreamWriter writer = new(stream: contentEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -1010,11 +1152,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ODS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ODS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1028,42 +1172,41 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsPostScript()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the PostScript file; if the user confirms the save operation, attempt to write the difference results to the specified file in PostScript format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "PostScript Files (*.ps)|*.ps|All Files (*.*)|*.*"
+			Filter = "PostScript Files (*.ps)|*.ps|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in PostScript format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary PostScript commands to represent the difference results in a formatted manner; ensure that any special characters in the data are properly escaped according to PostScript syntax rules; after writing all results, show a success message to the user indicating that the results were successfully saved to the PostScript file
 				static string EscapePostScriptString(string input)
 				{
 					return string.IsNullOrEmpty(value: input)
 						? string.Empty
 						: input.Replace(oldValue: "\\", newValue: "\\\\").Replace(oldValue: "(", newValue: "\\(").Replace(oldValue: ")", newValue: "\\)");
 				}
-
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: "%!PS");
 				writer.WriteLine(value: "/Courier findfont");
 				writer.WriteLine(value: "10 scalefont");
 				writer.WriteLine(value: "setfont");
-
 				int y = 750;
 				writer.WriteLine(value: "72 770 moveto");
 				writer.WriteLine(value: "(Database Differences) show");
-
 				foreach (DifferenceResult result in differenceResults)
 				{
 					string safeIndex = EscapePostScriptString(input: result.Index);
 					string safeDesig = EscapePostScriptString(input: result.Designation);
 					string safeDiff = EscapePostScriptString(input: result.Difference);
 					string line = $"{safeIndex}    {safeDesig}    {safeDiff}";
-
 					writer.WriteLine(value: $"72 {y} moveto");
 					writer.WriteLine(value: $"({line}) show");
 					y -= 12;
-
 					if (y < 50)
 					{
 						writer.WriteLine(value: "showpage");
@@ -1078,11 +1221,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PostScript file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PostScript file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1096,41 +1241,40 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsEpub()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the EPUB file; if the user confirms the save operation, attempt to write the difference results to the specified file in EPUB format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "EPUB Files (*.epub)|*.epub|All Files (*.*)|*.*"
+			Filter = "EPUB Files (*.epub)|*.epub|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in EPUB format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents an EPUB document; write the necessary XML files for the mimetype, container, manifest, navigation, and main content, populating the main content with the difference results in a tabular format; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the EPUB file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
 				System.IO.Compression.ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype", compressionLevel: System.IO.Compression.CompressionLevel.NoCompression);
 				using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "application/epub+zip");
 				}
-
 				System.IO.Compression.ZipArchiveEntry containerEntry = archive.CreateEntry(entryName: "META-INF/container.xml");
 				using (StreamWriter writer = new(stream: containerEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\"?><container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry opfEntry = archive.CreateEntry(entryName: "OEBPS/content.opf");
 				using (StreamWriter writer = new(stream: opfEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><package xmlns=\"http://www.idpf.org/2007/opf\" version=\"3.0\" unique-identifier=\"pub-id\"><metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:title>Database Differences</dc:title><dc:language>en</dc:language><dc:identifier id=\"pub-id\">urn:uuid:12345</dc:identifier></metadata><manifest><item id=\"nav\" href=\"nav.html\" media-type=\"application/xhtml+xml\" properties=\"nav\"/><item id=\"content\" href=\"content.html\" media-type=\"application/xhtml+xml\"/></manifest><spine><itemref idref=\"content\"/></spine></package>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry navEntry = archive.CreateEntry(entryName: "OEBPS/nav.html");
 				using (StreamWriter writer = new(stream: navEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><head><title>Navigation</title></head><body><nav epub:type=\"toc\" id=\"toc\"><h1>Table of Contents</h1><ol><li><a href=\"content.html\">Database Differences</a></li></ol></nav></body></html>");
 				}
-
 				System.IO.Compression.ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "OEBPS/content.html");
 				using (StreamWriter writer = new(stream: contentEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -1148,11 +1292,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to EPUB file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to EPUB file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1166,17 +1312,21 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsMobi()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the MOBI file; if the user confirms the save operation, attempt to write the difference results to the specified file in MOBI format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "MOBI Files (*.mobi)|*.mobi|AZW3 Files (*.azw3)|*.azw3|All Files (*.*)|*.*"
+			Filter = "MOBI Files (*.mobi)|*.mobi|AZW3 Files (*.azw3)|*.azw3|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in MOBI format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and write the necessary headers and content to represent the difference results in a valid MOBI format; ensure that all required fields in the MOBI header are properly populated, and that the content is formatted according to MOBI specifications; after writing the file, show a success message to the user indicating that the results were successfully saved to the MOBI file
 				using FileStream fs = new(path: saveFileDialog.FileName, mode: FileMode.Create, access: FileAccess.Write);
 				string title = "Database Differences";
-
+				// Build the HTML content for the MOBI file, ensuring that all special characters in the difference results are properly escaped to prevent issues with HTML rendering; the content will include a simple structure with a title and a list of differences formatted in paragraphs
 				System.Text.StringBuilder html = new();
 				html.Append(value: "<html><head><title>Database Differences</title></head><body><h1>Database Differences</h1>");
 				foreach (DifferenceResult result in differenceResults)
@@ -1187,10 +1337,10 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					html.Append(value: $"<p><b>{safeIndex}</b> {safeDesig} : {safeDiff}</p>");
 				}
 				html.Append(value: "</body></html>");
-
+				// Build the HTML content for the MOBI file, ensuring that all special characters in the difference results are properly escaped to prevent issues with HTML rendering; the content will include a simple structure with a title and a list of differences formatted in paragraphs
 				byte[] contentBytes = System.Text.Encoding.UTF8.GetBytes(html.ToString());
 				byte[] titleBytes = System.Text.Encoding.UTF8.GetBytes(title);
-
+				// Helper methods to write big-endian values and strings to the FileStream, which is necessary for constructing the MOBI file format correctly; these methods will be used to write the various headers and content sections of the MOBI file according to the specifications
 				void WriteBE16(ushort v)
 				{
 					fs.WriteByte(value: (byte)(v >> 8));
@@ -1211,7 +1361,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 						fs.WriteByte(value: i < b.Length ? b[i] : (byte)0);
 					}
 				}
-
+				// Write the Palm Database Header, Record Info List, and Record 0 (Headers) for the MOBI file, ensuring that all fields are correctly populated according to the MOBI specifications; this includes writing the necessary metadata in the Palm Database Header, setting up the Record Info List with the correct offsets and attributes for each record, and constructing the PalmDoc and MOBI headers within Record 0 to define the content structure of the MOBI file
 				// Palm Database Header (78 bytes)
 				WriteString(s: title, len: 32);     // Database name
 				WriteBE16(v: 0);               // Attributes
@@ -1227,36 +1377,30 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				WriteBE32(v: 3);               // Unique ID seed
 				WriteBE32(v: 0);               // Next record list ID
 				WriteBE16(v: 3);               // Record count: 0 (headers), 1 (content), 2 (EOF FLIS)
-
-				// Record Info List (8 bytes per record) 
+											   // Record Info List (8 bytes per record) 
 				uint rec0Offset = 78 + (3 * 8) + 2;
 				WriteBE32(v: rec0Offset);
 				fs.WriteByte(value: 0); // Attributes
 				fs.WriteByte(value: 0); fs.WriteByte(value: 0); fs.WriteByte(value: 0); // Unique ID 0
-
 				uint rec1Offset = rec0Offset + 16 + 232 + (uint)titleBytes.Length;
 				WriteBE32(v: rec1Offset);
 				fs.WriteByte(value: 0);
 				fs.WriteByte(value: 0); fs.WriteByte(value: 0); fs.WriteByte(value: 1); // Unique ID 1
-
 				uint rec2Offset = rec1Offset + (uint)contentBytes.Length;
 				WriteBE32(v: rec2Offset);
 				fs.WriteByte(value: 0);
-				fs.WriteByte(value: 0); fs.WriteByte(value: 0); fs.WriteByte(value: 2); // Unique ID 2
-
+				fs.WriteByte(value: 0); fs.WriteByte(value: 0); fs.WriteByte(value: 2); // Unique ID 2				
 				WriteBE16(v: 0); // Padding
-
-				// Record 0 (Headers)
-				// PalmDoc Header (16 bytes)
+								 // Record 0 (Headers)
+								 // PalmDoc Header (16 bytes)
 				WriteBE16(v: 1);               // Compression (1 = none)
 				WriteBE16(v: 0);               // Unused
 				WriteBE32(v: (uint)contentBytes.Length); // Text length
 				WriteBE16(v: 1);               // Record count
 				WriteBE16(v: 4096);            // Record size
 				WriteBE16(v: 0);               // Encryption
-				WriteBE16(v: 0);               // Unknown
-
-				// MOBI Header (232 bytes)
+				WriteBE16(v: 0);               // Unknown				
+											   // MOBI Header (232 bytes)
 				WriteString(s: "MOBI", len: 4);     // Identifier
 				WriteBE32(v: 232);             // Header length
 				WriteBE32(v: 2);               // Mobi type (MobiBook)
@@ -1290,17 +1434,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				{
 					WriteBE32(v: 0xFFFFFFFF); // filling unknown/unused to 232 bytes length
 				}
-
 				for (int i = 0; i < 4; i++)
 				{
 					WriteBE32(v: 0); // padding
 				}
-
 				fs.Write(buffer: titleBytes, offset: 0, count: titleBytes.Length); // Add the real title name
-
-				// Record 1 (The content)
+																				   // Record 1 (The content)
 				fs.Write(buffer: contentBytes, offset: 0, count: contentBytes.Length);
-
 				// Record 2 (EOF)
 				WriteString(s: "FLIS", len: 4);
 				WriteBE32(v: 8);
@@ -1317,11 +1457,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to MOBI file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to MOBI file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1335,14 +1477,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsToml()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the TOML file; if the user confirms the save operation, attempt to write the difference results to the specified file in TOML format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*"
+			Filter = "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in TOML format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary TOML syntax to represent the difference results in a structured manner; ensure that any special characters in the data are properly escaped according to TOML syntax rules; after writing all results, show a success message to the user indicating that the results were successfully saved to the TOML file
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				foreach (DifferenceResult result in differenceResults)
 				{
@@ -1356,11 +1502,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to TOML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to TOML file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1374,20 +1522,23 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsXps()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the XPS file; if the user confirms the save operation, attempt to write the difference results to the specified file in XPS format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*"
+			Filter = "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in XPS format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents an XPS document; write the necessary XML files for the content types, relationships, fixed document sequence, fixed document, and fixed pages, populating the fixed pages with the difference results formatted as needed; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the XPS file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
 				int itemsPerPage = 50;
 				int pages = Math.Max(val1: 1, val2: (int)Math.Ceiling(a: differenceResults.Count / (double)itemsPerPage));
-
+				// Create the [Content_Types].xml file, which defines the content types for the various parts of the XPS document; write the necessary XML structure for the content types, including Default and Override elements that specify the content types for the relationships, fixed document sequence, fixed document, fixed pages, and any other resources used in the XPS document
 				System.IO.Compression.ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml");
 				using (StreamWriter writer = new(stream: contentTypesEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -1398,25 +1549,25 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</Types>");
 				}
-
+				// Create the relationships file for the package, which defines the relationship to the FixedDocumentSequence part; write the necessary XML structure for the relationships, including the Relationship element that points to the FixedDocumentSequence
 				System.IO.Compression.ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels");
 				using (StreamWriter writer = new(stream: relsEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.microsoft.com/xps/2005/06/fixedrepresentation\" Target=\"FixedDocumentSequence.fdseq\" /></Relationships>");
 				}
-
+				// Create the FixedDocumentSequence part, which serves as the root of the XPS document structure and references the FixedDocument part; write the necessary XML structure for the FixedDocumentSequence, including the DocumentReference element that points to the FixedDocument, and also create the corresponding relationships file that defines the required resources for the FixedDocumentSequence
 				System.IO.Compression.ZipArchiveEntry fdseqEntry = archive.CreateEntry(entryName: "FixedDocumentSequence.fdseq");
 				using (StreamWriter writer = new(stream: fdseqEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<FixedDocumentSequence xmlns=\"http://schemas.microsoft.com/xps/2005/06\"><DocumentReference Source=\"Documents/1/FixedDocument.fdoc\" /></FixedDocumentSequence>");
 				}
-
+				// Create the relationships file for the FixedDocumentSequence, which defines the relationship to the FixedDocument part; write the necessary XML structure for the relationships, including the Relationship element that points to the FixedDocument
 				System.IO.Compression.ZipArchiveEntry fdseqRelsEntry = archive.CreateEntry(entryName: "_rels/FixedDocumentSequence.fdseq.rels");
 				using (StreamWriter writer = new(stream: fdseqRelsEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.microsoft.com/xps/2005/06/required-resource\" Target=\"/Documents/1/FixedDocument.fdoc\" /></Relationships>");
 				}
-
+				// Create the FixedDocument part, which references the individual FixedPage parts for each page of results; write the necessary XML structure for the FixedDocument, including the PageContent elements that point to each FixedPage, and also create the corresponding relationships file that defines the required resources for the FixedDocument
 				System.IO.Compression.ZipArchiveEntry fdocEntry = archive.CreateEntry(entryName: "Documents/1/FixedDocument.fdoc");
 				using (StreamWriter writer = new(stream: fdocEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -1427,7 +1578,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</FixedDocument>");
 				}
-
+				// Create the relationships file for the FixedDocument, which defines the relationships to the FixedPage parts; write the necessary XML structure for the relationships, including Relationship elements that point to each FixedPage
 				System.IO.Compression.ZipArchiveEntry fdocRelsEntry = archive.CreateEntry(entryName: "Documents/1/_rels/FixedDocument.fdoc.rels");
 				using (StreamWriter writer = new(stream: fdocRelsEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
 				{
@@ -1438,8 +1589,8 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</Relationships>");
 				}
-
-				string fontPath = System.IO.Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.Fonts), path2: "arial.ttf");
+				// Create the FixedPage parts, which contain the actual content for each page of results; for each page, write the necessary XML structure for the FixedPage, including Glyphs elements that represent the text of the difference results, and also create the corresponding relationships file that defines the required resources (such as fonts) for each FixedPage; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing
+				string fontPath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.Fonts), path2: "arial.ttf");
 				if (File.Exists(path: fontPath))
 				{
 					System.IO.Compression.ZipArchiveEntry fontEntry = archive.CreateEntry(entryName: "Resources/Fonts/arial.ttf");
@@ -1447,17 +1598,14 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					using FileStream fontSrc = File.OpenRead(path: fontPath);
 					fontSrc.CopyTo(destination: fontDest);
 				}
-
 				for (int i = 1; i <= pages; i++)
 				{
 					System.IO.Compression.ZipArchiveEntry pageEntry = archive.CreateEntry(entryName: $"Documents/1/Pages/{i}.fpage");
 					using StreamWriter writer = new(stream: pageEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 					writer.Write(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
-
 					int y = 50;
 					writer.Write(value: $"<Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Fonts/arial.ttf\" FontRenderingEmSize=\"16\" OriginX=\"50\" OriginY=\"{y}\" UnicodeString=\"Database Differences\" />");
 					y += 30;
-
 					int stopIndex = Math.Min(val1: i * itemsPerPage, val2: differenceResults.Count);
 					for (int j = (i - 1) * itemsPerPage; j < stopIndex; j++)
 					{
@@ -1466,13 +1614,11 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 						string safeDesig = System.Security.SecurityElement.Escape(str: result.Designation) ?? string.Empty;
 						string safeDiff = System.Security.SecurityElement.Escape(str: result.Difference) ?? string.Empty;
 						string line = $"{safeIndex}    {safeDesig}    {safeDiff}";
-
 						writer.Write(value: $"<Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Fonts/arial.ttf\" FontRenderingEmSize=\"12\" OriginX=\"50\" OriginY=\"{y}\" UnicodeString=\"{line}\" />");
 						y += 18;
 					}
-
 					writer.Write(value: "</FixedPage>");
-
+					// Create the relationships file for the FixedPage, which defines the relationship to the font resource; write the necessary XML structure for the relationships, including a Relationship element that points to the font used in the FixedPage
 					System.IO.Compression.ZipArchiveEntry pageRelsEntry = archive.CreateEntry(entryName: $"Documents/1/Pages/_rels/{i}.fpage.rels");
 					using StreamWriter relsWriter = new(stream: pageRelsEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 					relsWriter.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.microsoft.com/xps/2005/06/required-resource\" Target=\"/Resources/Fonts/arial.ttf\" /></Relationships>");
@@ -1481,11 +1627,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to XPS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to XPS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1499,14 +1647,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsWps()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the WPS file; if the user confirms the save operation, attempt to write the difference results to the specified file in WPS format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "WPS Writer Files (*.wps)|*.wps|All Files (*.*)|*.*"
+			Filter = "WPS Writer Files (*.wps)|*.wps|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in WPS format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a StreamWriter to the specified file path and write the necessary RTF syntax to represent the difference results in a structured manner; ensure that any special characters in the data are properly escaped according to RTF syntax rules; after writing all results, show a success message to the user indicating that the results were successfully saved to the WPS file
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				writer.WriteLine(value: @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Arial;}}");
 				writer.WriteLine(value: @"{\*\generator PlanetoidDB;}\viewkind4\uc1 ");
@@ -1524,11 +1676,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to WPS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to WPS file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1542,41 +1696,45 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsEt()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the ET file; if the user confirms the save operation, attempt to write the difference results to the specified file in ET format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "WPS Spreadsheet Files (*.et)|*.et|All Files (*.*)|*.*"
+			Filter = "WPS Spreadsheet Files (*.et)|*.et|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in ET format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create a ZIP archive structure that represents an ET document; write the necessary XML files for the content types, relationships, workbook, and worksheet, populating the worksheet with the difference results formatted as needed; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing; after writing all necessary files to the ZIP archive, show a success message to the user indicating that the results were successfully saved to the ET file
 				using FileStream zipToOpen = new(path: saveFileDialog.FileName, mode: FileMode.Create);
 				using System.IO.Compression.ZipArchive archive = new(stream: zipToOpen, mode: System.IO.Compression.ZipArchiveMode.Create);
-
+				// Create the [Content_Types].xml file, which defines the content types for the various parts of the ET document; write the necessary XML structure for the content types, including Default and Override elements that specify the content types for the relationships, workbook, worksheet, and any other resources used in the ET document
 				System.IO.Compression.ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml");
 				using (StreamWriter writer = new(stream: contentTypesEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" /><Default Extension=\"xml\" ContentType=\"application/xml\" /><Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\" /><Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\" /></Types>");
 				}
-
+				// Create the relationships file for the package, which defines the relationship to the workbook part; write the necessary XML structure for the relationships, including the Relationship element that points to the workbook
 				System.IO.Compression.ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels");
 				using (StreamWriter writer = new(stream: relsEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\" /></Relationships>");
 				}
-
+				// Create the relationships file for the workbook, which defines the relationship to the worksheet part; write the necessary XML structure for the relationships, including the Relationship element that points to the worksheet
 				System.IO.Compression.ZipArchiveEntry workbookRelsEntry = archive.CreateEntry(entryName: "xl/_rels/workbook.xml.rels");
 				using (StreamWriter writer = new(stream: workbookRelsEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\" /></Relationships>");
 				}
-
+				// Create the workbook part, which serves as the main entry point for the spreadsheet content and references the worksheet; write the necessary XML structure for the workbook, including the sheets element that defines the sheet and its relationship to the worksheet part
 				System.IO.Compression.ZipArchiveEntry workbookEntry = archive.CreateEntry(entryName: "xl/workbook.xml");
 				using (StreamWriter writer = new(stream: workbookEntry.Open()))
 				{
 					writer.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><sheets><sheet name=\"Differences\" sheetId=\"1\" r:id=\"rId1\" /></sheets></workbook>");
 				}
-
+				// Create the worksheet part, which contains the actual content for the spreadsheet; write the necessary XML structure for the worksheet, including the sheetData element that represents the rows and cells of the spreadsheet, and populate it with the difference results formatted as needed; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing
 				System.IO.Compression.ZipArchiveEntry sheetEntry = archive.CreateEntry(entryName: "xl/worksheets/sheet1.xml");
 				using (StreamWriter writer = new(stream: sheetEntry.Open()))
 				{
@@ -1594,11 +1752,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ET file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ET file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1612,14 +1772,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsFb2()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the FB2 file; if the user confirms the save operation, attempt to write the difference results to the specified file in FB2 format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "FB2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*"
+			Filter = "FB2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in FB2 format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Open a FileStream to the specified file path and create an XML document that represents the difference results in FB2 format; write the necessary XML structure for the FB2 document, including the description, title-info, document-info, and body elements, populating them with the difference results formatted as needed; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing; after writing the XML document to the file, show a success message to the user indicating that the results were successfully saved to the FB2 file
 				XNamespace ns = "http://www.gribuser.ru/xml/fictionbook/2.0";
 				XDocument doc = new(
 					declaration: new XDeclaration(version: "1.0", encoding: "utf-8", standalone: null),
@@ -1673,11 +1837,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to FB2 file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to FB2 file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1691,22 +1857,25 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsChm()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the CHM file; if the user confirms the save operation, attempt to write the difference results to the specified file in CHM format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "CHM Files (*.chm)|*.chm|All Files (*.*)|*.*"
+			Filter = "CHM Files (*.chm)|*.chm|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in CHM format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Create a temporary directory to hold the intermediate files needed for CHM compilation, such as the HTML content file, the table of contents file, and the project file; ensure that the temporary directory is cleaned up after the compilation process is complete
 				string tempDir = Path.Combine(path1: Path.GetTempPath(), path2: Guid.NewGuid().ToString());
 				Directory.CreateDirectory(path: tempDir);
-
 				string htmlFile = Path.Combine(path1: tempDir, path2: "content.html");
 				string hhcFile = Path.Combine(path1: tempDir, path2: "toc.hhc");
 				string hhpFile = Path.Combine(path1: tempDir, path2: "project.hhp");
 				string chmFile = saveFileDialog.FileName;
-
+				// Write the HTML content file, which contains the formatted difference results; ensure that any special characters in the difference results are properly escaped to prevent issues with HTML parsing; after writing the HTML file, create the necessary table of contents and project files for CHM compilation
 				using (StreamWriter writer = new(path: htmlFile))
 				{
 					writer.WriteLine(value: "<!DOCTYPE html><html><head><title>Database Differences</title>");
@@ -1721,7 +1890,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.WriteLine(value: "</table></body></html>");
 				}
-
+				// Write the table of contents file, which defines the structure of the CHM help file; write the necessary HTML structure for the table of contents, including an object element that specifies the properties of the CHM file and a list of links to the content pages
 				using (StreamWriter writer = new(path: hhcFile))
 				{
 					writer.WriteLine(value: "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML//EN\">");
@@ -1735,7 +1904,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: "</object></li></ul>");
 					writer.WriteLine(value: "</body></html>");
 				}
-
+				// Write the project file, which contains the settings for CHM compilation; write the necessary structure for the project file, including the options section that specifies the compatibility, compiled file name, contents file, display settings, language, and title, as well as the files section that lists the HTML content file to be included in the CHM compilation
 				using (StreamWriter writer = new(path: hhpFile))
 				{
 					writer.WriteLine(value: "[OPTIONS]");
@@ -1749,7 +1918,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: "[FILES]");
 					writer.WriteLine(value: "content.html");
 				}
-
+				// Attempt to locate the HTML Help Workshop compiler (hhc.exe) on the system; check both the Program Files (x86) and Program Files directories for the presence of hhc.exe, and if found, use it to compile the CHM file from the project file; if hhc.exe is not found, display a warning message to the user indicating that HTML Help Workshop is required for CHM compilation
 				string hhcPath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.ProgramFilesX86), path2: "HTML Help Workshop");
 				hhcPath = Path.Combine(path1: hhcPath, path2: "hhc.exe");
 				if (!File.Exists(path: hhcPath))
@@ -1757,14 +1926,12 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					hhcPath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.ProgramFiles), path2: "HTML Help Workshop");
 					hhcPath = Path.Combine(path1: hhcPath, path2: "hhc.exe");
 				}
-
 				if (File.Exists(path: hhcPath))
 				{
 					if (File.Exists(path: chmFile))
 					{
 						File.Delete(path: chmFile);
 					}
-
 					ProcessStartInfo startInfo = new()
 					{
 						FileName = hhcPath,
@@ -1772,10 +1939,8 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 						CreateNoWindow = true,
 						UseShellExecute = false
 					};
-
 					using Process? process = Process.Start(startInfo: startInfo);
 					process?.WaitForExit();
-
 					if (!File.Exists(path: chmFile))
 					{
 						MessageBox.Show(text: "Failed to compile CHM file.", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
@@ -1797,11 +1962,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to CHM file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to CHM file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1815,14 +1982,18 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// user.</remarks>
 	private void SaveListViewResultsAsDocBook()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the DocBook file; if the user confirms the save operation, attempt to write the difference results to the specified file in DocBook format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*"
+			Filter = "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in DocBook format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Create an XML document that represents the difference results in DocBook format; write the necessary XML structure for the DocBook document, including the article, info, and table elements, populating them with the difference results formatted as needed; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing; after writing the XML document to the file, show a success message to the user indicating that the results were successfully saved to the DocBook file
 				XNamespace ns = "http://docbook.org/ns/docbook";
 				XDocument doc = new(
 					declaration: new XDeclaration(version: "1.0", encoding: "utf-8", standalone: null),
@@ -1858,11 +2029,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to DocBook file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to DocBook file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -1874,16 +2047,20 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// includes formatted database difference entries, with special characters properly escaped to ensure valid ABW
 	/// output. If an I/O error or access denial occurs during the save process, an error message is displayed to the
 	/// user.</remarks>
-	private void SaveListViewResultsAsAbw()
+	private void SaveListViewResultsAsAbiword()
 	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the ABW file; if the user confirms the save operation, attempt to write the difference results to the specified file in ABW format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
 		{
-			Filter = "AbiWord Files (*.abw)|*.abw|All Files (*.*)|*.*"
+			Filter = "AbiWord Files (*.abw)|*.abw|All Files (*.*)|*.*",
+			FileName = fileName
 		};
 		if (saveFileDialog.ShowDialog() == DialogResult.OK)
 		{
+			// Attempt to write the difference results to the selected file in ABW format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Create an XML document that represents the difference results in ABW format; write the necessary XML structure for the ABW document, including the abiword root element and nested section and paragraph elements, populating them with the difference results formatted as needed; ensure that any special characters in the difference results are properly escaped to prevent issues with XML parsing; after writing the XML document to the file, show a success message to the user indicating that the results were successfully saved to the ABW file
 				XDocument doc = new(
 					declaration: new XDeclaration(version: "1.0", encoding: "utf-8", standalone: null),
 					content: new XElement(name: "abiword",
@@ -1914,11 +2091,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			}
 			catch (IOException ex)
 			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ABW file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ABW file '{FilePath}'.", args: saveFileDialog.FileName);
 				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
@@ -2081,6 +2260,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 						 "G - Slope Parameter";
 		MessageBox.Show(text: message, caption: "Abbreviations", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
+
+	/// <summary>Handles the click event for the Krypton button and initiates navigation to a specific object.</summary>
+	/// <remarks>Use this method to respond to user interactions that require navigating to a particular object
+	/// within the form. This method is intended for UI event handling scenarios.</remarks>
+	/// <param name="sender">The source of the event, typically the Krypton button that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void KryptonButtonGoto_Click(object sender, EventArgs e) => GoToObject();
 
 	/// <summary>Handles the click event for the 'Save As Text' menu item and initiates saving the current list view results as a
 	/// text file.</summary>
@@ -2299,12 +2485,11 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 
 	/// <summary>Handles the click event for the 'Save As ABW' menu item and initiates saving the current list view results in ABW
 	/// format.</summary>
-	/// <remarks>This method invokes the SaveListViewResultsAsAbw method to perform the save operation. Use this
+	/// <remarks>This method invokes the SaveListViewResultsAsAbiword method to perform the save operation. Use this
 	/// event handler to enable users to export list view data in ABW format from the interface.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">The event data associated with the click event.</param>
-	private void ToolStripMenuItemSaveAsAbw_Click(object sender, EventArgs e) => SaveListViewResultsAsAbw();
-
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e) => SaveListViewResultsAsAbiword();
 	#endregion
 
 	#region BackgroundWorker event handlers
@@ -2543,32 +2728,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// <param name="sender">The source of the event.</param>
 	/// <param name="e">The event data associated with the DoubleClick event.</param>
 	/// <remarks>This event is triggered when the user double-clicks on an item in the ListView.</remarks>
-	private void ListViewResults_DoubleClick(object? sender, EventArgs e)
-	{
-		// Check if there are any selected indices in the ListView, and if not, return early to prevent errors; if there is a selected index, retrieve the corresponding DifferenceResult and either show a message if the record was deleted or jump to the record in the main form if it still exists
-		if (listViewResults.SelectedIndices.Count == 0)
-		{
-			return;
-		}
-		// Get the first selected index from the ListView and check if it is within the bounds of the difference results list; if so, retrieve the corresponding DifferenceResult and determine whether to show a message about a deleted record or to jump to the record in the main form based on the type of difference
-		int selectedIndex = listViewResults.SelectedIndices[index: 0];
-		if (selectedIndex >= 0 && selectedIndex < differenceResults.Count)
-		{
-			DifferenceResult result = differenceResults[index: selectedIndex];
-			if (result.Difference.Equals(value: "Deleted record", comparisonType: StringComparison.OrdinalIgnoreCase))
-			{
-				_ = MessageBox.Show(text: "The selected record has been deleted and is no longer available.", caption: "Record Deleted", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
-			}
-			else
-			{
-				// Attempt to find the main form of the application and, if it exists, call a method to jump to the record corresponding to the selected difference result based on its index and designation
-				if (Application.OpenForms.OfType<PlanetoidDbForm>().FirstOrDefault() is PlanetoidDbForm mainForm)
-				{
-					mainForm.JumpToRecord(index: result.Index, designation: result.Designation);
-				}
-			}
-		}
-	}
+	private void ListViewResults_DoubleClick(object? sender, EventArgs e) => GoToObject();
 
 	#endregion
 

--- a/Forms/DatabaseDifferencesForm.resx
+++ b/Forms/DatabaseDifferencesForm.resx
@@ -133,7 +133,7 @@
     <value>643, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>59</value>
+    <value>48</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
This PR expands the “Save list” functionality in `DatabaseDifferencesForm` by adding many additional export formats and reorganizing the save UI, and it also adds a dedicated “Go to object” button that navigates to the selected record in the main form.

**Changes:**
- Added a shared `GoToObject()` navigation method and a new “Go to object” button (also reused by ListView double-click).
- Expanded the save/export surface area (new formats + default save filename across dialogs).
- Reworked the save context menu into categorized submenus and moved some ListView virtual-mode wiring into the designer.