### PR TITLE
Updated to version 0.8.3.54

### DIFF
--- a/Forms/DatabaseDifferencesForm.Designer.cs
+++ b/Forms/DatabaseDifferencesForm.Designer.cs
@@ -249,8 +249,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemTextFiles.ShortcutKeyDisplayString = "";
 		toolStripMenuItemTextFiles.Size = new Size(201, 22);
 		toolStripMenuItemTextFiles.Text = "&Text files";
-		toolStripMenuItemTextFiles.MouseDown += Control_MouseDown;
 		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsText
 		// 
@@ -845,7 +845,7 @@ partial class DatabaseDifferencesForm
 		contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
 		contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { ToolStripMenuItemCopyToClipboard });
 		contextMenuCopyToClipboard.Name = "contextMenuStrip";
-		contextMenuCopyToClipboard.Size = new Size(208, 26);
+		contextMenuCopyToClipboard.Size = new Size(214, 26);
 		contextMenuCopyToClipboard.TabStop = true;
 		contextMenuCopyToClipboard.Text = "Copy to clipboard";
 		contextMenuCopyToClipboard.MouseEnter += Control_Enter;
@@ -859,9 +859,9 @@ partial class DatabaseDifferencesForm
 		ToolStripMenuItemCopyToClipboard.AutoToolTip = true;
 		ToolStripMenuItemCopyToClipboard.Image = Resources.FatcowIcons16px.fatcow_page_copy_16px;
 		ToolStripMenuItemCopyToClipboard.Name = "ToolStripMenuItemCopyToClipboard";
-		ToolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Alt+C";
+		ToolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Strg+C";
 		ToolStripMenuItemCopyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
-		ToolStripMenuItemCopyToClipboard.Size = new Size(207, 22);
+		ToolStripMenuItemCopyToClipboard.Size = new Size(213, 22);
 		ToolStripMenuItemCopyToClipboard.Text = "&Copy to clipboard";
 		ToolStripMenuItemCopyToClipboard.Click += CopyToClipboard_DoubleClick;
 		ToolStripMenuItemCopyToClipboard.MouseEnter += Control_Enter;

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -266,14 +266,22 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			// Attempt to write the difference results to the selected file in CSV format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
 			try
 			{
+				// Local helper function used to escape individual fields for CSV output by doubling internal quotes and wrapping the value in quotes.
+				static string EscapeCsvField(string? field)
+				{
+					string safeField = field ?? string.Empty;
+					safeField = safeField.Replace(oldValue: "\"", newValue: "\"\"");
+					return $"\"{safeField}\"";
+				}
 				// Open a StreamWriter to the specified file path and write each difference result in a comma-separated format; after writing all results, show a success message to the user
 				using StreamWriter writer = new(path: saveFileDialog.FileName);
 				// Write a header line to the CSV file for clarity
-				writer.WriteLine(value: "Index,Designation,Difference");
+				writer.WriteLine(value: $"{EscapeCsvField(field: "Index")},{EscapeCsvField(field: "Designation")},{EscapeCsvField(field: "Difference")}");
 				// Iterate through the list of difference results and write each one to the CSV file in a comma-separated format
 				foreach (DifferenceResult result in differenceResults)
 				{
-					writer.WriteLine(value: $"{result.Index},\"{result.Designation}\",\"{result.Difference}\"");
+					string indexValue = result.Index.ToString(provider: System.Globalization.CultureInfo.InvariantCulture);
+					writer.WriteLine(value: $"{EscapeCsvField(field: indexValue)},{EscapeCsvField(field: result.Designation)},{EscapeCsvField(field: result.Difference)}");
 				}
 				// After successfully writing the results to the file, display a success message to the user
 				MessageBox.Show(text: "Results successfully saved to CSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);


### PR DESCRIPTION
This PR improves export reliability and UI/accessibility behavior in the `DatabaseDifferencesForm`, primarily focusing on safer CSV output and small WinForms designer wiring updates.

**Changes:**
- Add CSV field escaping (quote-doubling + consistent quoting) when exporting difference results.
- Adjust WinForms designer event wiring and update displayed shortcut text for the copy-to-clipboard context menu.