### PR TITLE
Updated image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/e11cf8fe-ed25-43b6-9a2e-c387fc979059" />
+<img width="868" height="423" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/4bf96ef6-ec00-430c-b07f-ffe84e5e0ece" />


### PR DESCRIPTION
Updates the README’s embedded screenshot to point to a new GitHub user-attachments asset, keeping the project documentation current.

**Changes:**
- Replaced the screenshot image `src` URL in `README.md` with a new user-attachments link.