### PR TITLE
Updated files after deleting Helpers/TaskbarProgress.cs

### DIFF
--- a/Forms/DownloadMpcorbDatForm.cs
+++ b/Forms/DownloadMpcorbDatForm.cs
@@ -6,7 +6,6 @@
 using NLog;
 
 using Planetoid_DB.Forms;
-using Planetoid_DB.Helpers;
 using Planetoid_DB.Properties;
 
 using System.ComponentModel;
@@ -186,8 +185,6 @@ public partial class DownloadMpcorbDatForm : BaseKryptonForm
 		progressBarDownload.Value = e.ProgressPercentage;
 		// Update the label with the current progress percentage
 		labelDownload.Text = e.ProgressPercentage + I18nStrings.PercentSign;
-		// Update the status bar with the current progress
-		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: e.ProgressPercentage, progressMax: 100);
 	}
 
 	/// <summary>Handles the DownloadFileCompleted event of the WebClient control.</summary>
@@ -196,8 +193,6 @@ public partial class DownloadMpcorbDatForm : BaseKryptonForm
 	/// <remarks>This method is used to handle the completion of the download operation.</remarks>
 	private async void Completed(object? sender, AsyncCompletedEventArgs e)
 	{
-		// Reset the taskbar progress
-		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: 0, progressMax: 100);
 		if (e.Error == null)
 		{
 			// Set the status to "Refreshing database"

--- a/Forms/SearchForm.cs
+++ b/Forms/SearchForm.cs
@@ -4,7 +4,6 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 using Planetoid_DB.Forms;
-using Planetoid_DB.Helpers;
 
 using System.ComponentModel;
 using System.Diagnostics;
@@ -287,7 +286,6 @@ public partial class SearchForm : BaseKryptonForm
 		{
 			FormatRow(currentPosition: i);
 			backgroundWorker.ReportProgress(percentProgress: i);
-			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: i, progressMax: numberPlanetoids);
 			if (isCancelled)
 			{
 				break;
@@ -312,7 +310,6 @@ public partial class SearchForm : BaseKryptonForm
 		listView.Visible = true;
 		buttonCancel.Enabled = false;
 		progressBar.Enabled = false;
-		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: 0, progressMax: 100);
 	}
 
 	#endregion

--- a/Forms/TableModeForm.cs
+++ b/Forms/TableModeForm.cs
@@ -129,7 +129,6 @@ public partial class TableModeForm : BaseKryptonForm
 		if (!processing)
 		{
 			progressBar.Value = 0;
-			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: 0, progressMax: 100);
 		}
 	}
 
@@ -377,7 +376,6 @@ public partial class TableModeForm : BaseKryptonForm
 		{
 			progressBar.Value = percent;
 			int taskbarPercent = count > 0 ? percent * 100 / count : 0;
-			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: taskbarPercent, progressMax: 100);
 		});
 		// Configure the progress bar
 		progressBar.Maximum = count;


### PR DESCRIPTION
This PR updates WinForms screens to remove usage of the (now-deleted) taskbar progress helper, keeping progress reporting limited to in-form progress bars/labels.

**Changes:**
- Removed `TaskbarProgress.SetValue(...)` calls from progress update paths in multiple forms.
- Removed `using Planetoid_DB.Helpers;` where it became unnecessary due to the TaskbarProgress removal.