### PR TITLE
Added several saving formats in ListReadableDesignationsForm

### DIFF
--- a/Forms/DatabaseDifferencesForm.Designer.cs
+++ b/Forms/DatabaseDifferencesForm.Designer.cs
@@ -48,7 +48,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
-		toolStripMenuItemSaveAsReStructurizedText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
 		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
@@ -251,7 +251,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
 		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemTextFiles.AutoToolTip = true;
-		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructurizedText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
 		toolStripMenuItemTextFiles.Image = Resources.FatcowIcons16px.fatcow_file_extension_txt_16px;
 		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
 		toolStripMenuItemTextFiles.ShortcutKeyDisplayString = "";
@@ -269,7 +269,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
 		toolStripMenuItemSaveAsText.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsText.Size = new Size(212, 22);
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsText.Text = "Save as &text";
 		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
 		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
@@ -284,7 +284,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsLatex.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
 		toolStripMenuItemSaveAsLatex.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsLatex.Size = new Size(212, 22);
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
 		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
 		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
@@ -299,7 +299,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsMarkdown.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
 		toolStripMenuItemSaveAsMarkdown.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsMarkdown.Size = new Size(212, 22);
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
 		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
 		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
@@ -307,41 +307,41 @@ partial class DatabaseDifferencesForm
 		// 
 		// toolStripMenuItemSaveAsAsciiDoc
 		// 
-		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Save list as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Save list as AsciiDoc file";
 		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
 		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
 		toolStripMenuItemSaveAsAsciiDoc.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
-		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(212, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
-		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAdoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
 		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
 		// 
-		// toolStripMenuItemSaveAsReStructurizedText
+		// toolStripMenuItemSaveAsReStructuredText
 		// 
-		toolStripMenuItemSaveAsReStructurizedText.AccessibleDescription = "Save list as reStructuredText";
-		toolStripMenuItemSaveAsReStructurizedText.AccessibleName = "Save as reStructuredText";
-		toolStripMenuItemSaveAsReStructurizedText.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSaveAsReStructurizedText.AutoToolTip = true;
-		toolStripMenuItemSaveAsReStructurizedText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
-		toolStripMenuItemSaveAsReStructurizedText.Name = "toolStripMenuItemSaveAsReStructurizedText";
-		toolStripMenuItemSaveAsReStructurizedText.Size = new Size(212, 22);
-		toolStripMenuItemSaveAsReStructurizedText.Text = "Save as &reStructuredText";
-		toolStripMenuItemSaveAsReStructurizedText.Click += ToolStripMenuItemSaveAsRst_Click;
-		toolStripMenuItemSaveAsReStructurizedText.MouseEnter += Control_Enter;
-		toolStripMenuItemSaveAsReStructurizedText.MouseLeave += Control_Leave;
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Save list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsTextile
 		// 
-		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Save list as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Save list as Textile file";
 		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
 		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
 		toolStripMenuItemSaveAsTextile.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
-		toolStripMenuItemSaveAsTextile.Size = new Size(212, 22);
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
 		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
 		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
@@ -371,8 +371,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsWord.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
 		toolStripMenuItemSaveAsWord.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsWord.Size = new Size(179, 22);
-		toolStripMenuItemSaveAsWord.Text = "Save as &Word";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
 		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
 		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
@@ -386,8 +386,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsOdt.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
 		toolStripMenuItemSaveAsOdt.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsOdt.Size = new Size(179, 22);
-		toolStripMenuItemSaveAsOdt.Text = "Save as O&DT";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
 		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
 		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
@@ -401,8 +401,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsRtf.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
 		toolStripMenuItemSaveAsRtf.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsRtf.Size = new Size(179, 22);
-		toolStripMenuItemSaveAsRtf.Text = "Save as &RTF";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
 		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
 		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
@@ -415,22 +415,22 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
 		toolStripMenuItemSaveAsAbiword.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
-		toolStripMenuItemSaveAsAbiword.Size = new Size(179, 22);
-		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
 		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
 		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsWps
 		// 
-		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
 		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
 		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsWps.AutoToolTip = true;
 		toolStripMenuItemSaveAsWps.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
-		toolStripMenuItemSaveAsWps.Size = new Size(179, 22);
-		toolStripMenuItemSaveAsWps.Text = "Save as W&PS";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
 		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
 		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
@@ -459,8 +459,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsExcel.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
 		toolStripMenuItemSaveAsExcel.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsExcel.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsExcel.Text = "Save as Exce&l";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
 		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
 		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
@@ -474,8 +474,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsOds.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
 		toolStripMenuItemSaveAsOds.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsOds.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsOds.Text = "Save as OD&S";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
 		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
 		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
@@ -489,8 +489,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsCsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
 		toolStripMenuItemSaveAsCsv.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsCsv.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsCsv.Text = "Save as &CSV";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
 		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
 		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
@@ -504,8 +504,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsTsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
 		toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsTsv.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
 		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
 		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
@@ -519,8 +519,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsPsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
 		toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsPsv.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
 		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
 		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
@@ -533,8 +533,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsEt.AutoToolTip = true;
 		toolStripMenuItemSaveAsEt.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
-		toolStripMenuItemSaveAsEt.Size = new Size(142, 22);
-		toolStripMenuItemSaveAsEt.Text = "Save as &ET";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
 		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
 		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
@@ -563,7 +563,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsHtml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
 		toolStripMenuItemSaveAsHtml.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
 		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
 		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
@@ -578,8 +578,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsXml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
 		toolStripMenuItemSaveAsXml.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
-		toolStripMenuItemSaveAsXml.Text = "Save as X&ML";
+		toolStripMenuItemSaveAsXml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
 		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
 		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
@@ -592,7 +592,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
 		toolStripMenuItemSaveAsDocBook.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
-		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
 		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
 		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
@@ -622,7 +622,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsJson.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
 		toolStripMenuItemSaveAsJson.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
 		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
 		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
@@ -637,7 +637,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsYaml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
 		toolStripMenuItemSaveAsYaml.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
 		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
 		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
@@ -651,7 +651,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsToml.AutoToolTip = true;
 		toolStripMenuItemSaveAsToml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
-		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
 		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
 		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
@@ -682,7 +682,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
 		toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "";
 		toolStripMenuItemSaveAsSql.Size = new Size(136, 22);
-		toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
 		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
 		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
@@ -711,8 +711,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsPdf.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
 		toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsPdf.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
 		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
 		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
@@ -720,14 +720,14 @@ partial class DatabaseDifferencesForm
 		// toolStripMenuItemSaveAsPostScript
 		// 
 		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
-		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
 		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
 		toolStripMenuItemSaveAsPostScript.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
 		toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsPostScript.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
 		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
 		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
@@ -741,8 +741,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsEpub.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
 		toolStripMenuItemSaveAsEpub.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsEpub.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsEpub.Text = "Save as EPU&B";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
 		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
 		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
@@ -756,8 +756,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsMobi.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
 		toolStripMenuItemSaveAsMobi.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsMobi.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsMobi.Text = "Save as MOB&I";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
 		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
 		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
@@ -770,7 +770,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsXps.AutoToolTip = true;
 		toolStripMenuItemSaveAsXps.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
-		toolStripMenuItemSaveAsXps.Size = new Size(145, 22);
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
 		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
 		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
@@ -778,14 +778,14 @@ partial class DatabaseDifferencesForm
 		// 
 		// toolStripMenuItemSaveAsFictionBook2
 		// 
-		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FB2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
 		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
 		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
 		toolStripMenuItemSaveAsFictionBook2.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
-		toolStripMenuItemSaveAsFictionBook2.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FB2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
 		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFb2_Click;
 		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
@@ -798,8 +798,8 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsChm.AutoToolTip = true;
 		toolStripMenuItemSaveAsChm.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
-		toolStripMenuItemSaveAsChm.Size = new Size(145, 22);
-		toolStripMenuItemSaveAsChm.Text = "Save as CHM";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
 		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
 		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
@@ -1258,6 +1258,6 @@ partial class DatabaseDifferencesForm
 	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
 	private KryptonButton kryptonButtonGoto;
 	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
-	private ToolStripMenuItem toolStripMenuItemSaveAsReStructurizedText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
 	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
 }

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -180,7 +180,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 		// Check if there are any selected indices in the ListView, and if not, return early to prevent errors; if there is a selected index, retrieve the corresponding DifferenceResult and either show a message if the record was deleted or jump to the record in the main form if it still exists
 		if (listViewResults.SelectedIndices.Count == 0)
 		{
-			MessageBox.Show(text: "Please select a record to jump to.", caption: "No Record Selected", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			_ = MessageBox.Show(text: "Please select a record to jump to.", caption: "No Record Selected", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 			return;
 		}
 		// Get the first selected index from the ListView and check if it is within the bounds of the difference results list; if so, retrieve the corresponding DifferenceResult and determine whether to show a message about a deleted record or to jump to the record in the main form based on the type of difference
@@ -234,19 +234,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"{result.Index}\t{result.Designation}\t{result.Difference}");
 				}
 				// After successfully writing the results to the file, display a success message to the user
-				MessageBox.Show(text: "Results successfully saved to text file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to text file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to text file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to text file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -286,19 +286,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"{EscapeCsvField(field: indexValue)},{EscapeCsvField(field: result.Designation)},{EscapeCsvField(field: result.Difference)}");
 				}
 				// After successfully writing the results to the file, display a success message to the user
-				MessageBox.Show(text: "Results successfully saved to CSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to CSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to CSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to CSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -330,19 +330,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"{result.Index}\t{result.Designation}\t{result.Difference}");
 				}
 				// After successfully writing the results to the file, display a success message to the user
-				MessageBox.Show(text: "Results successfully saved to TSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to TSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to TSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to TSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -374,19 +374,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"{result.Index}|{result.Designation}|{result.Difference}");
 				}
 				// After successfully writing the results to the file, display a success message to the user
-				MessageBox.Show(text: "Results successfully saved to PSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to PSV file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PSV file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -416,19 +416,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				{
 					writer.WriteLine(value: $"| {result.Index} | {result.Designation} | {result.Difference} |");
 				}
-				MessageBox.Show(text: "Results successfully saved to Markdown file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to Markdown file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Markdown file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Markdown file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -491,19 +491,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</sheetData></worksheet>");
 				}
-				MessageBox.Show(text: "Results successfully saved to Excel file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to Excel file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Excel file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Excel file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -550,19 +550,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				writer.WriteLine(value: "    </table>");
 				writer.WriteLine(value: "</body>");
 				writer.WriteLine(value: "</html>");
-				MessageBox.Show(text: "Results successfully saved to HTML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to HTML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to HTML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to HTML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -599,19 +599,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					)
 				);
 				doc.Save(fileName: saveFileDialog.FileName);
-				MessageBox.Show(text: "Results successfully saved to XML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to XML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to XML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to XML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -636,19 +636,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				// Serialize the list of difference results to a JSON string using System.Text.Json, then write the JSON string to the specified file path; after successfully saving the file, show a success message to the user
 				string json = System.Text.Json.JsonSerializer.Serialize(value: differenceResults, options: jsonSerializerOptions);
 				File.WriteAllText(path: saveFileDialog.FileName, contents: json);
-				MessageBox.Show(text: "Results successfully saved to JSON file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to JSON file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to JSON file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to JSON file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -678,19 +678,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"  Designation: \"{result.Designation.Replace(oldValue: "\"", newValue: "\\\"")}\"");
 					writer.WriteLine(value: $"  Difference: \"{result.Difference.Replace(oldValue: "\"", newValue: "\\\"")}\"");
 				}
-				MessageBox.Show(text: "Results successfully saved to YAML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to YAML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to YAML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to YAML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -730,19 +730,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				writer.WriteLine(value: "\\bottomrule");
 				writer.WriteLine(value: "\\end{tabular}");
 				writer.WriteLine(value: "\\end{document}");
-				MessageBox.Show(text: "Results successfully saved to LaTeX file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to LaTeX file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to LaTeX file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to LaTeX file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -885,19 +885,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				}
 				writer.Write(value: $"trailer\n<< /Size {xrefs.Count} /Root {catalogId} 0 R >>\nstartxref\n{startXref}\n%%EOF\n");
 				writer.Flush();
-				MessageBox.Show(text: "Results successfully saved to PDF file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to PDF file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PDF file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PDF file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -927,19 +927,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				{
 					writer.WriteLine(value: $"INSERT INTO Differences (DifferenceIndex, Designation, Difference) VALUES ('{result.Index.Replace(oldValue: "'", newValue: "''")}', '{result.Designation.Replace(oldValue: "'", newValue: "''")}', '{result.Difference.Replace(oldValue: "'", newValue: "''")}');");
 				}
-				MessageBox.Show(text: "Results successfully saved to SQL file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to SQL file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to SQL file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to SQL file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -987,19 +987,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</w:tbl></w:body></w:document>");
 				}
-				MessageBox.Show(text: "Results successfully saved to Word file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to Word file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to Word file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to Word file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1036,19 +1036,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $@"\pard\tx1500\tx4500 {safeIndex}\tab {safeDesig}\tab {safeDiff}\par");
 				}
 				writer.WriteLine(value: "}");
-				MessageBox.Show(text: "Results successfully saved to RTF file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to RTF file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to RTF file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to RTF file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1097,19 +1097,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</table:table></office:text></office:body></office:document-content>");
 				}
-				MessageBox.Show(text: "Results successfully saved to ODT file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to ODT file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ODT file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ODT file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1158,19 +1158,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</table:table></office:spreadsheet></office:body></office:document-content>");
 				}
-				MessageBox.Show(text: "Results successfully saved to ODS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to ODS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ODS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ODS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1227,19 +1227,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 				}
 				writer.WriteLine(value: "showpage");
-				MessageBox.Show(text: "Results successfully saved to PostScript file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to PostScript file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to PostScript file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to PostScript file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1298,19 +1298,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</table></body></html>");
 				}
-				MessageBox.Show(text: "Results successfully saved to EPUB file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to EPUB file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to EPUB file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to EPUB file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1463,19 +1463,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				WriteBE32(v: 3);
 				WriteBE32(v: 1);
 				WriteBE32(v: 0xFFFFFFFF);
-				MessageBox.Show(text: "Results successfully saved to MOBI file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to MOBI file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to MOBI file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to MOBI file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1508,19 +1508,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"Difference = \"{result.Difference.Replace(oldValue: "\"", newValue: "\\\"")}\"");
 					writer.WriteLine();
 				}
-				MessageBox.Show(text: "Results successfully saved to TOML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to TOML file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to TOML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to TOML file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1633,19 +1633,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					using StreamWriter relsWriter = new(stream: pageRelsEntry.Open(), encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 					relsWriter.Write(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.microsoft.com/xps/2005/06/required-resource\" Target=\"/Resources/Fonts/arial.ttf\" /></Relationships>");
 				}
-				MessageBox.Show(text: "Results successfully saved to XPS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to XPS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to XPS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to XPS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1682,19 +1682,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $@"\pard\tx1500\tx4500 {safeIndex}\tab {safeDesig}\tab {safeDiff}\par");
 				}
 				writer.WriteLine(value: "}");
-				MessageBox.Show(text: "Results successfully saved to WPS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to WPS file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to WPS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to WPS file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1758,19 +1758,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					}
 					writer.Write(value: "</sheetData></worksheet>");
 				}
-				MessageBox.Show(text: "Results successfully saved to ET file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to ET file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ET file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ET file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1843,19 +1843,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					)
 				);
 				doc.Save(fileName: saveFileDialog.FileName);
-				MessageBox.Show(text: "Results successfully saved to FB2 file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to FB2 file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to FB2 file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to FB2 file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -1951,18 +1951,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					};
 					using Process? process = Process.Start(startInfo: startInfo);
 					process?.WaitForExit();
-					if (!File.Exists(path: chmFile))
-					{
-						MessageBox.Show(text: "Failed to compile CHM file.", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
-					}
-					else
-					{
-						MessageBox.Show(text: "Results successfully saved to CHM file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
-					}
+					_ = !File.Exists(path: chmFile)
+						? MessageBox.Show(text: "Failed to compile CHM file.", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error)
+						: MessageBox.Show(text: "Results successfully saved to CHM file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 				}
 				else
 				{
-					MessageBox.Show(text: "HTML Help Workshop (hhc.exe) is required to create CHM files but was not found. Please install it to use this feature.", caption: "Missing Dependency", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+					_ = MessageBox.Show(text: "HTML Help Workshop (hhc.exe) is required to create CHM files but was not found. Please install it to use this feature.", caption: "Missing Dependency", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 				}
 
 				if (Directory.Exists(path: tempDir))
@@ -1974,13 +1969,13 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to CHM file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to CHM file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2035,19 +2030,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					)
 				);
 				doc.Save(fileName: saveFileDialog.FileName);
-				MessageBox.Show(text: "Results successfully saved to DocBook file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to DocBook file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to DocBook file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to DocBook file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2097,19 +2092,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					)
 				);
 				doc.Save(fileName: saveFileDialog.FileName);
-				MessageBox.Show(text: "Results successfully saved to ABW file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to ABW file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			catch (IOException ex)
 			{
 				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 				logger.Error(exception: ex, message: "I/O error while saving results to ABW file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			catch (UnauthorizedAccessException ex)
 			{
 				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 				logger.Error(exception: ex, message: "Access denied while saving results to ABW file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2117,7 +2112,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// <summary>Exports the database difference results to an AsciiDoc (ADOC) file selected by the user.</summary>
 	/// <remarks>Prompts the user to choose a file location and name using a save file dialog. The exported ADOC file
 	/// includes formatted database difference entries. If an I/O error or access denial occurs during the save process, an error message is displayed to the user.</remarks>
-	private void SaveListViewResultsAsAdoc()
+	private void SaveListViewResultsAsAsciiDoc()
 	{
 		// Create and configure a SaveFileDialog to allow the user to choose where to save the ADOC file; if the user confirms the save operation, attempt to write the difference results to the specified file in ADOC format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
@@ -2141,19 +2136,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"|{result.Index}|{result.Designation}|{result.Difference}");
 				}
 				writer.WriteLine(value: "|===");
-				MessageBox.Show(text: "Results successfully saved to AsciiDoc file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to AsciiDoc file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 			catch (IOException ex)
 			{
 				logger.Error(exception: ex, message: "I/O error while saving results to ADOC file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 			catch (UnauthorizedAccessException ex)
 			{
 				logger.Error(exception: ex, message: "Access denied while saving results to ADOC file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2161,7 +2156,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// <summary>Exports the database difference results to a reStructuredText (RST) file selected by the user.</summary>
 	/// <remarks>Prompts the user to choose a file location and name using a save file dialog. The exported RST file
 	/// includes formatted database difference entries. If an I/O error or access denial occurs during the save process, an error message is displayed to the user.</remarks>
-	private void SaveListViewResultsAsRst()
+	private void SaveListViewResultsAsReStructuredText()
 	{
 		// Create and configure a SaveFileDialog to allow the user to choose where to save the RST file; if the user confirms the save operation, attempt to write the difference results to the specified file in RST format, handling any potential I/O errors or access issues that may arise during the process
 		using SaveFileDialog saveFileDialog = new()
@@ -2191,19 +2186,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 					writer.WriteLine(value: $"     - {result.Designation}");
 					writer.WriteLine(value: $"     - {result.Difference}");
 				}
-				MessageBox.Show(text: "Results successfully saved to reStructuredText file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to reStructuredText file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 			catch (IOException ex)
 			{
 				logger.Error(exception: ex, message: "I/O error while saving results to RST file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 			catch (UnauthorizedAccessException ex)
 			{
 				logger.Error(exception: ex, message: "Access denied while saving results to RST file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2232,19 +2227,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 				{
 					writer.WriteLine(value: $"| {result.Index} | {result.Designation} | {result.Difference} |");
 				}
-				MessageBox.Show(text: "Results successfully saved to Textile file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+				_ = MessageBox.Show(text: "Results successfully saved to Textile file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 			}
 			// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
 			catch (IOException ex)
 			{
 				logger.Error(exception: ex, message: "I/O error while saving results to Textile file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 			// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
 			catch (UnauthorizedAccessException ex)
 			{
 				logger.Error(exception: ex, message: "Access denied while saving results to Textile file '{FilePath}'.", args: saveFileDialog.FileName);
-				MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			}
 		}
 	}
@@ -2403,7 +2398,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 						 "a - Semi-Major Axis\n" +
 						 "H - Absolute Magnitude\n" +
 						 "G - Slope Parameter";
-		MessageBox.Show(text: message, caption: "Abbreviations", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: message, caption: "Abbreviations", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Handles the click event for the Krypton button and initiates navigation to a specific object.</summary>
@@ -2638,19 +2633,19 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 
 	/// <summary>Handles the click event for the 'Save As AsciiDoc' menu item and initiates saving the current list view results in AsciiDoc
 	/// format.</summary>
-	/// <remarks>This method invokes the SaveListViewResultsAsAdoc method to perform the save operation. Use this
+	/// <remarks>This method invokes the SaveListViewResultsAsAsciiDoc method to perform the save operation. Use this
 	/// event handler to enable users to export list view data in AsciiDoc format from the interface.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">The event data associated with the click event.</param>
-	private void ToolStripMenuItemSaveAsAdoc_Click(object sender, EventArgs e) => SaveListViewResultsAsAdoc();
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e) => SaveListViewResultsAsAsciiDoc();
 
 	/// <summary>Handles the click event for the 'Save As reStructuredText' menu item and initiates saving the current list view results in reStructuredText
 	/// format.</summary>
-	/// <remarks>This method invokes the SaveListViewResultsAsRst method to perform the save operation. Use this
+	/// <remarks>This method invokes the SaveListViewResultsAsReStructuredText method to perform the save operation. Use this
 	/// event handler to enable users to export list view data in reStructuredText format from the interface.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">The event data associated with the click event.</param>
-	private void ToolStripMenuItemSaveAsRst_Click(object sender, EventArgs e) => SaveListViewResultsAsRst();
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e) => SaveListViewResultsAsReStructuredText();
 
 	/// <summary>Handles the click event for the 'Save As Textile' menu item and initiates saving the current list view results in Textile
 	/// format.</summary>

--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -50,26 +50,44 @@ partial class ListReadableDesignationsForm
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
 		toolStripMenuItemCopyToClipboard = new ToolStripMenuItem();
 		contextMenuSaveList = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
 		toolStripDropDownButtonSaveList = new ToolStripDropDownButton();
 		kryptoPanelMain = new KryptonPanel();
 		listView = new ListView();
@@ -77,7 +95,7 @@ partial class ListReadableDesignationsForm
 		columnHeaderReadableDesignation = new ColumnHeader();
 		kryptonManager = new KryptonManager(components);
 		toolStripContainer = new ToolStripContainer();
-		kryptonToolStripList = new KryptonToolStrip();
+		kryptonToolStripGenerateList = new KryptonToolStrip();
 		toolStripButtonCreateList = new ToolStripButton();
 		toolStripSeparator1 = new ToolStripSeparator();
 		toolStripLabelMinimum = new ToolStripLabel();
@@ -96,7 +114,7 @@ partial class ListReadableDesignationsForm
 		toolStripContainer.ContentPanel.SuspendLayout();
 		toolStripContainer.TopToolStripPanel.SuspendLayout();
 		toolStripContainer.SuspendLayout();
-		kryptonToolStripList.SuspendLayout();
+		kryptonToolStripGenerateList.SuspendLayout();
 		kryptonToolStripSaveList.SuspendLayout();
 		SuspendLayout();
 		// 
@@ -119,6 +137,8 @@ partial class ListReadableDesignationsForm
 		kryptonStatusStrip.TabIndex = 1;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
+		kryptonStatusStrip.Enter += Control_Enter;
+		kryptonStatusStrip.Leave += Control_Leave;
 		kryptonStatusStrip.MouseEnter += Control_Enter;
 		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
@@ -174,14 +194,27 @@ partial class ListReadableDesignationsForm
 		contextMenuSaveList.AccessibleRole = AccessibleRole.MenuPopup;
 		contextMenuSaveList.AllowClickThrough = true;
 		contextMenuSaveList.Font = new Font("Segoe UI", 9F);
-		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi });
-		contextMenuSaveList.Name = "contextMenuStrip1";
-		contextMenuSaveList.OwnerItem = toolStripDropDownButtonSaveList;
-		contextMenuSaveList.Size = new Size(216, 444);
+		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveList.Name = "contextMenuSaveList";
+		contextMenuSaveList.Size = new Size(202, 158);
 		contextMenuSaveList.TabStop = true;
 		contextMenuSaveList.Text = "&Save list";
 		contextMenuSaveList.MouseEnter += Control_Enter;
 		contextMenuSaveList.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemTextFiles
+		// 
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.Image = FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsText
 		// 
@@ -191,10 +224,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsText.AutoToolTip = true;
 		toolStripMenuItemSaveAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
-		toolStripMenuItemSaveAsText.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsText.ShortcutKeys = Keys.Control | Keys.X;
-		toolStripMenuItemSaveAsText.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsText.Text = "Save as te&xt";
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as &text";
 		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
 		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
@@ -207,10 +238,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
 		toolStripMenuItemSaveAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
-		toolStripMenuItemSaveAsLatex.ShortcutKeyDisplayString = "Strg+E";
-		toolStripMenuItemSaveAsLatex.ShortcutKeys = Keys.Control | Keys.E;
-		toolStripMenuItemSaveAsLatex.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsLatex.Text = "Save as Lat&ex";
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
 		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
 		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
@@ -223,13 +252,67 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
 		toolStripMenuItemSaveAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
-		toolStripMenuItemSaveAsMarkdown.ShortcutKeyDisplayString = "Strg+K";
-		toolStripMenuItemSaveAsMarkdown.ShortcutKeys = Keys.Control | Keys.K;
-		toolStripMenuItemSaveAsMarkdown.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsMarkdown.Text = "Save as Mar&kdown";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
 		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
 		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAsciiDoc
+		// 
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Saves the list as AsciiDoc file";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
+		toolStripMenuItemSaveAsAsciiDoc.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsReStructuredText
+		// 
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Saves the list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTextile
+		// 
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Saves the list as Textile file";
+		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
+		toolStripMenuItemSaveAsTextile.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTextile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsWord
 		// 
@@ -239,10 +322,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsWord.AutoToolTip = true;
 		toolStripMenuItemSaveAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
-		toolStripMenuItemSaveAsWord.ShortcutKeyDisplayString = "Strg+W";
-		toolStripMenuItemSaveAsWord.ShortcutKeys = Keys.Control | Keys.W;
-		toolStripMenuItemSaveAsWord.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsWord.Text = "Save as &Word";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
 		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
 		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
@@ -255,10 +336,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
 		toolStripMenuItemSaveAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
-		toolStripMenuItemSaveAsOdt.ShortcutKeyDisplayString = "Strg+D";
-		toolStripMenuItemSaveAsOdt.ShortcutKeys = Keys.Control | Keys.D;
-		toolStripMenuItemSaveAsOdt.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsOdt.Text = "Save as O&DT";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
 		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
 		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
@@ -271,13 +350,53 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
 		toolStripMenuItemSaveAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
 		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
-		toolStripMenuItemSaveAsRtf.ShortcutKeyDisplayString = "Strg+R";
-		toolStripMenuItemSaveAsRtf.ShortcutKeys = Keys.Control | Keys.R;
-		toolStripMenuItemSaveAsRtf.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsRtf.Text = "Save as &RTF";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
 		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
 		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsExcel
 		// 
@@ -287,10 +406,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
 		toolStripMenuItemSaveAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
-		toolStripMenuItemSaveAsExcel.ShortcutKeyDisplayString = "Strg+L";
-		toolStripMenuItemSaveAsExcel.ShortcutKeys = Keys.Control | Keys.L;
-		toolStripMenuItemSaveAsExcel.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsExcel.Text = "Save as Exce&l";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
 		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
 		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
@@ -303,10 +420,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsOds.AutoToolTip = true;
 		toolStripMenuItemSaveAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
-		toolStripMenuItemSaveAsOds.ShortcutKeyDisplayString = "Strg+S";
-		toolStripMenuItemSaveAsOds.ShortcutKeys = Keys.Control | Keys.S;
-		toolStripMenuItemSaveAsOds.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsOds.Text = "Save as OD&S";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
 		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
 		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
@@ -319,10 +434,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
 		toolStripMenuItemSaveAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
-		toolStripMenuItemSaveAsCsv.ShortcutKeyDisplayString = "Strg+C";
-		toolStripMenuItemSaveAsCsv.ShortcutKeys = Keys.Control | Keys.C;
-		toolStripMenuItemSaveAsCsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsCsv.Text = "Save as &CSV";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
 		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
 		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
@@ -335,10 +448,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
 		toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
-		toolStripMenuItemSaveAsTsv.ShortcutKeyDisplayString = "Strg+T";
-		toolStripMenuItemSaveAsTsv.ShortcutKeys = Keys.Control | Keys.T;
-		toolStripMenuItemSaveAsTsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsTsv.Text = "Save as &TSV";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
 		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
 		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
@@ -351,13 +462,39 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
 		toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
 		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
-		toolStripMenuItemSaveAsPsv.ShortcutKeyDisplayString = "Strg+V";
-		toolStripMenuItemSaveAsPsv.ShortcutKeys = Keys.Control | Keys.V;
-		toolStripMenuItemSaveAsPsv.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPsv.Text = "Save as PS&V";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
 		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
 		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsHtml
 		// 
@@ -367,9 +504,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
 		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
-		toolStripMenuItemSaveAsHtml.ShortcutKeyDisplayString = "Strg+H";
-		toolStripMenuItemSaveAsHtml.ShortcutKeys = Keys.Control | Keys.H;
-		toolStripMenuItemSaveAsHtml.Size = new Size(215, 22);
+		toolStripMenuItemSaveAsHtml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
 		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
 		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
@@ -383,13 +518,39 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsXml.AutoToolTip = true;
 		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
-		toolStripMenuItemSaveAsXml.ShortcutKeyDisplayString = "Strg+M";
-		toolStripMenuItemSaveAsXml.ShortcutKeys = Keys.Control | Keys.M;
-		toolStripMenuItemSaveAsXml.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsXml.Text = "Save as X&ML";
+		toolStripMenuItemSaveAsXml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
 		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
 		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook file";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsToml });
+		toolStripMenuItemConfigurationFiles.Image = FatcowIcons16px.fatcow_file_extension_bat_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsJson
 		// 
@@ -399,9 +560,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsJson.AutoToolTip = true;
 		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
-		toolStripMenuItemSaveAsJson.ShortcutKeyDisplayString = "Strg+J";
-		toolStripMenuItemSaveAsJson.ShortcutKeys = Keys.Control | Keys.J;
-		toolStripMenuItemSaveAsJson.Size = new Size(215, 22);
+		toolStripMenuItemSaveAsJson.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
 		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
 		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
@@ -415,13 +574,39 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
 		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
-		toolStripMenuItemSaveAsYaml.ShortcutKeyDisplayString = "Strg+Y";
-		toolStripMenuItemSaveAsYaml.ShortcutKeys = Keys.Control | Keys.Y;
-		toolStripMenuItemSaveAsYaml.Size = new Size(215, 22);
+		toolStripMenuItemSaveAsYaml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
 		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
 		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql });
+		toolStripMenuItemDatabaseScripts.Image = FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsSql
 		// 
@@ -431,13 +616,25 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsSql.AutoToolTip = true;
 		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
 		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
-		toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "Strg+Q";
-		toolStripMenuItemSaveAsSql.ShortcutKeys = Keys.Control | Keys.Q;
-		toolStripMenuItemSaveAsSql.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsSql.Text = "Save as S&QL";
+		toolStripMenuItemSaveAsSql.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
 		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
 		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, toolStripMenuItemSaveAsXps, toolStripMenuItemSaveAsFictionBook2, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsPdf
 		// 
@@ -447,10 +644,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
 		toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
-		toolStripMenuItemSaveAsPdf.ShortcutKeyDisplayString = "Strg+F";
-		toolStripMenuItemSaveAsPdf.ShortcutKeys = Keys.Control | Keys.F;
-		toolStripMenuItemSaveAsPdf.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPdf.Text = "Save as PD&F";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
 		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
 		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
@@ -458,15 +653,13 @@ partial class ListReadableDesignationsForm
 		// toolStripMenuItemSaveAsPostScript
 		// 
 		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
-		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PS";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
 		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
 		toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
-		toolStripMenuItemSaveAsPostScript.ShortcutKeyDisplayString = "Strg+P";
-		toolStripMenuItemSaveAsPostScript.ShortcutKeys = Keys.Control | Keys.P;
-		toolStripMenuItemSaveAsPostScript.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsPostScript.Text = "Save as &PS";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
 		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
 		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
@@ -479,10 +672,8 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
 		toolStripMenuItemSaveAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
-		toolStripMenuItemSaveAsEpub.ShortcutKeyDisplayString = "Strg+B";
-		toolStripMenuItemSaveAsEpub.ShortcutKeys = Keys.Control | Keys.B;
-		toolStripMenuItemSaveAsEpub.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsEpub.Text = "Save as EPU&B";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
 		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
 		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
@@ -495,13 +686,53 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
 		toolStripMenuItemSaveAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
 		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
-		toolStripMenuItemSaveAsMobi.ShortcutKeyDisplayString = "Strg+I";
-		toolStripMenuItemSaveAsMobi.ShortcutKeys = Keys.Control | Keys.I;
-		toolStripMenuItemSaveAsMobi.Size = new Size(215, 22);
-		toolStripMenuItemSaveAsMobi.Text = "Save as MOB&I";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
 		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
 		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXps
+		// 
+		toolStripMenuItemSaveAsXps.AccessibleDescription = "Saves the list as XPS file";
+		toolStripMenuItemSaveAsXps.AccessibleName = "Save as XPS";
+		toolStripMenuItemSaveAsXps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXps.AutoToolTip = true;
+		toolStripMenuItemSaveAsXps.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsFictionBook2
+		// 
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
+		toolStripMenuItemSaveAsFictionBook2.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
 		// 
 		// toolStripDropDownButtonSaveList
 		// 
@@ -514,6 +745,8 @@ partial class ListReadableDesignationsForm
 		toolStripDropDownButtonSaveList.Name = "toolStripDropDownButtonSaveList";
 		toolStripDropDownButtonSaveList.Size = new Size(78, 22);
 		toolStripDropDownButtonSaveList.Text = "&Save list";
+		toolStripDropDownButtonSaveList.MouseEnter += Control_Enter;
+		toolStripDropDownButtonSaveList.MouseLeave += Control_Leave;
 		// 
 		// kryptoPanelMain
 		// 
@@ -603,7 +836,7 @@ partial class ListReadableDesignationsForm
 		// 
 		// toolStripContainer.TopToolStripPanel
 		// 
-		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripList);
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripGenerateList);
 		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripSaveList);
 		toolStripContainer.Enter += Control_Enter;
 		toolStripContainer.Leave += Control_Leave;
@@ -612,25 +845,25 @@ partial class ListReadableDesignationsForm
 		// 
 		// kryptonToolStripList
 		// 
-		kryptonToolStripList.AccessibleDescription = "Toolbar of generating list";
-		kryptonToolStripList.AccessibleName = "Toolbar of generating list";
-		kryptonToolStripList.AccessibleRole = AccessibleRole.ToolBar;
-		kryptonToolStripList.AllowClickThrough = true;
-		kryptonToolStripList.AllowItemReorder = true;
-		kryptonToolStripList.Dock = DockStyle.None;
-		kryptonToolStripList.Font = new Font("Segoe UI", 9F);
-		kryptonToolStripList.Items.AddRange(new ToolStripItem[] { toolStripButtonCreateList, toolStripSeparator1, toolStripLabelMinimum, toolStripNumericUpDownMinimum, toolStripLabelMaximum, toolStripNumericUpDownMaximum });
-		kryptonToolStripList.Location = new Point(0, 0);
-		kryptonToolStripList.Name = "kryptonToolStripList";
-		kryptonToolStripList.Size = new Size(341, 26);
-		kryptonToolStripList.Stretch = true;
-		kryptonToolStripList.TabIndex = 0;
-		kryptonToolStripList.TabStop = true;
-		kryptonToolStripList.Text = "Toolbar of generating list";
-		kryptonToolStripList.Enter += Control_Enter;
-		kryptonToolStripList.Leave += Control_Leave;
-		kryptonToolStripList.MouseEnter += Control_Enter;
-		kryptonToolStripList.MouseLeave += Control_Leave;
+		kryptonToolStripGenerateList.AccessibleDescription = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleName = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripGenerateList.AllowClickThrough = true;
+		kryptonToolStripGenerateList.AllowItemReorder = true;
+		kryptonToolStripGenerateList.Dock = DockStyle.None;
+		kryptonToolStripGenerateList.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripGenerateList.Items.AddRange(new ToolStripItem[] { toolStripButtonCreateList, toolStripSeparator1, toolStripLabelMinimum, toolStripNumericUpDownMinimum, toolStripLabelMaximum, toolStripNumericUpDownMaximum });
+		kryptonToolStripGenerateList.Location = new Point(0, 0);
+		kryptonToolStripGenerateList.Name = "kryptonToolStripList";
+		kryptonToolStripGenerateList.Size = new Size(341, 26);
+		kryptonToolStripGenerateList.Stretch = true;
+		kryptonToolStripGenerateList.TabIndex = 0;
+		kryptonToolStripGenerateList.TabStop = true;
+		kryptonToolStripGenerateList.Text = "Toolbar of generating list";
+		kryptonToolStripGenerateList.Enter += Control_Enter;
+		kryptonToolStripGenerateList.Leave += Control_Leave;
+		kryptonToolStripGenerateList.MouseEnter += Control_Enter;
+		kryptonToolStripGenerateList.MouseLeave += Control_Leave;
 		// 
 		// toolStripButtonCreateList
 		// 
@@ -679,6 +912,8 @@ partial class ListReadableDesignationsForm
 		toolStripNumericUpDownMinimum.Size = new Size(41, 23);
 		toolStripNumericUpDownMinimum.Text = "0";
 		toolStripNumericUpDownMinimum.TextAlign = HorizontalAlignment.Center;
+		toolStripNumericUpDownMinimum.Enter += Control_Enter;
+		toolStripNumericUpDownMinimum.MouseLeave += Control_Leave;
 		toolStripNumericUpDownMinimum.MouseEnter += Control_Enter;
 		toolStripNumericUpDownMinimum.MouseLeave += Control_Leave;
 		// 
@@ -705,6 +940,8 @@ partial class ListReadableDesignationsForm
 		toolStripNumericUpDownMaximum.Size = new Size(41, 23);
 		toolStripNumericUpDownMaximum.Text = "0";
 		toolStripNumericUpDownMaximum.TextAlign = HorizontalAlignment.Center;
+		toolStripNumericUpDownMaximum.Enter += Control_Enter;
+		toolStripNumericUpDownMaximum.Leave += Control_Leave;
 		toolStripNumericUpDownMaximum.MouseEnter += Control_Enter;
 		toolStripNumericUpDownMaximum.MouseLeave += Control_Leave;
 		// 
@@ -724,6 +961,8 @@ partial class ListReadableDesignationsForm
 		kryptonToolStripSaveList.Stretch = true;
 		kryptonToolStripSaveList.TabIndex = 1;
 		kryptonToolStripSaveList.TabStop = true;
+		kryptonToolStripSaveList.Enter += Control_Enter;
+		kryptonToolStripSaveList.Leave += Control_Leave;
 		kryptonToolStripSaveList.MouseEnter += Control_Enter;
 		kryptonToolStripSaveList.MouseLeave += Control_Leave;
 		// 
@@ -783,8 +1022,8 @@ partial class ListReadableDesignationsForm
 		toolStripContainer.TopToolStripPanel.PerformLayout();
 		toolStripContainer.ResumeLayout(false);
 		toolStripContainer.PerformLayout();
-		kryptonToolStripList.ResumeLayout(false);
-		kryptonToolStripList.PerformLayout();
+		kryptonToolStripGenerateList.ResumeLayout(false);
+		kryptonToolStripGenerateList.PerformLayout();
 		kryptonToolStripSaveList.ResumeLayout(false);
 		kryptonToolStripSaveList.PerformLayout();
 		ResumeLayout(false);
@@ -801,29 +1040,21 @@ partial class ListReadableDesignationsForm
 	private ContextMenuStrip contextMenuSaveList;
 	private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
 	private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
-	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
-	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
 	private KryptonManager kryptonManager;
 	private ContextMenuStrip contextMenuCopyToClipboard;
 	private ToolStripMenuItem toolStripMenuItemCopyToClipboard;
-	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
 	private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
-	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
 	private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
 	private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
-	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
-	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
 	private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
-	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
 	private ToolStripMenuItem toolStripMenuItemSaveAsWord;
 	private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
 	private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
 	private ToolStripMenuItem toolStripMenuItemSaveAsOds;
-	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
 	private ToolStripMenuItem toolStripMenuItemSaveAsText;
 	private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
 	private ToolStripContainer toolStripContainer;
-	private KryptonToolStrip kryptonToolStripList;
+	private KryptonToolStrip kryptonToolStripGenerateList;
 	private ToolStripButton toolStripButtonCreateList;
 	private KryptonToolStrip kryptonToolStripSaveList;
 	private ToolStripButton toolStripButtonLoad;
@@ -834,4 +1065,30 @@ partial class ListReadableDesignationsForm
 	private Helpers.ToolStripNumericUpDown toolStripNumericUpDownMaximum;
 	private ToolStripSeparator toolStripSeparator2;
 	private ToolStripDropDownButton toolStripDropDownButtonSaveList;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
 }

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -242,7 +242,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		if (!TryParsePlanetoidRecord(record: currentData, recordIndex: dbIndex, parsedIndex: out string strIndex, parsedDesignation: out string strDesignation))
 		{
 			// If parsing fails, show an error message and return
-			MessageBox.Show(text: "Invalid record format.", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			_ = MessageBox.Show(text: "Invalid record format.", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 			return;
 		}
 		// Jump to the record in the main form
@@ -485,6 +485,671 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			}
 		}
 		return builder.ToString();
+	}
+
+	/// <summary>Saves the list as an AsciiDoc document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As AsciiDoc" menu item.</remarks>
+	private void SaveListViewResultsAsAsciiDoc()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogAsciiDoc = new()
+		{
+			Filter = "AsciiDoc files (*.adoc)|*.adoc|All files (*.*)|*.*",
+			DefaultExt = "adoc",
+			Title = "Save list as AsciiDoc"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogAsciiDoc, ext: saveFileDialogAsciiDoc.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the AsciiDoc file
+		using StreamWriter writer = new(path: saveFileDialogAsciiDoc.FileName, append: false, encoding: Encoding.UTF8);
+		// Document title
+		writer.WriteLine(value: "= List of Readable Designations");
+		writer.WriteLine();
+		// Configure table
+		writer.WriteLine(value: "[options=\"header\"]");
+		writer.WriteLine(value: "|===");
+		writer.WriteLine(value: "|Index|Designation");
+		// Iterate data
+		foreach ((string index, string name) in GetExportData())
+		{
+			string safeName = name.Replace(oldValue: "|", newValue: "\\|"); // Escape pipes in AsciiDoc tables
+			writer.WriteLine(value: $"|{index}|{safeName}");
+		}
+		writer.WriteLine(value: "|===");
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a reStructuredText document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As reStructuredText" menu item.</remarks>
+	private void SaveListViewResultsAsReStructuredText()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogRst = new()
+		{
+			Filter = "reStructuredText files (*.rst)|*.rst|All files (*.*)|*.*",
+			DefaultExt = "rst",
+			Title = "Save list as reStructuredText"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogRst, ext: saveFileDialogRst.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the reStructuredText file
+		using StreamWriter writer = new(path: saveFileDialogRst.FileName, append: false, encoding: Encoding.UTF8);
+		// Document title
+		string title = "List of Readable Designations";
+		writer.WriteLine(value: new string(c: '=', count: title.Length));
+		writer.WriteLine(value: title);
+		writer.WriteLine(value: new string(c: '=', count: title.Length));
+		writer.WriteLine();
+		// Iterate data to determine max column widths
+		int maxIndexLength = "Index".Length;
+		int maxNameLength = "Designation".Length;
+		List<(string Index, string Name)> exportData = GetExportData().ToList();
+		foreach ((string index, string name) in exportData)
+		{
+			if (index.Length > maxIndexLength)
+			{
+				maxIndexLength = index.Length;
+			}
+
+			if (name.Length > maxNameLength)
+			{
+				maxNameLength = name.Length;
+			}
+		}
+		// Add some padding
+		maxIndexLength += 2;
+		maxNameLength += 2;
+		// Helper to create separators
+		string separator = $"+{new string(c: '-', count: maxIndexLength)}+{new string(c: '-', count: maxNameLength)}+";
+		string headerSeparator = $"+{new string(c: '=', count: maxIndexLength)}+{new string(c: '=', count: maxNameLength)}+";
+		// Write table header
+		writer.WriteLine(value: separator);
+		writer.WriteLine(value: $"| {"Index".PadRight(totalWidth: maxIndexLength - 1)}| {"Designation".PadRight(totalWidth: maxNameLength - 1)}|");
+		writer.WriteLine(value: headerSeparator);
+		// Write table rows
+		foreach ((string index, string name) in exportData)
+		{
+			writer.WriteLine(value: $"| {index.PadRight(totalWidth: maxIndexLength - 1)}| {name.PadRight(totalWidth: maxNameLength - 1)}|");
+			writer.WriteLine(value: separator);
+		}
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a Textile document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As Textile" menu item.</remarks>
+	private void SaveListViewResultsAsTextile()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogTextile = new()
+		{
+			Filter = "Textile files (*.textile)|*.textile|All files (*.*)|*.*",
+			DefaultExt = "textile",
+			Title = "Save list as Textile"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogTextile, ext: saveFileDialogTextile.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the Textile file
+		using StreamWriter writer = new(path: saveFileDialogTextile.FileName, append: false, encoding: Encoding.UTF8);
+		// Document title
+		writer.WriteLine(value: "h1. List of Readable Designations");
+		writer.WriteLine();
+		// Write table header
+		writer.WriteLine(value: "|_. Index |_. Designation |");
+		// Write table rows
+		foreach ((string index, string name) in GetExportData())
+		{
+			// Escape table cell dividers
+			string safeName = name.Replace(oldValue: "|", newValue: "&#124;");
+			string safeIndex = index.Replace(oldValue: "|", newValue: "&#124;");
+
+			writer.WriteLine(value: $"| {safeIndex} | {safeName} |");
+		}
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as an AbiWord document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As AbiWord" menu item.</remarks>
+	private void SaveListViewResultsAsAbiword()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogAbiword = new()
+		{
+			Filter = "AbiWord documents (*.abw)|*.abw|All files (*.*)|*.*",
+			DefaultExt = "abw",
+			Title = "Save list as AbiWord"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogAbiword, ext: saveFileDialogAbiword.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the AbiWord file
+		using StreamWriter writer = new(path: saveFileDialogAbiword.FileName, append: false, encoding: Encoding.UTF8);
+		writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		writer.WriteLine(value: "<!DOCTYPE abiword PUBLIC \"-//ABISOURCE//DTD AWML 1.0 Strict//EN\" \"http://www.abisource.com/awml.dtd\">");
+		writer.WriteLine(value: "<abiword xmlns:awml=\"http://www.abisource.com/awml.dtd\" version=\"1.9.2\" fileformat=\"1.0\" xmlns=\"http://www.abisource.com/awml.dtd\">");
+		writer.WriteLine(value: "  <section>");
+		writer.WriteLine(value: "    <p style=\"Heading 1\">List of Readable Designations</p>");
+		writer.WriteLine(value: "    <table>");
+		int row = 0;
+		void WriteCell(string text, int col, int r)
+		{
+			string safeText = System.Net.WebUtility.HtmlEncode(value: text) ?? string.Empty;
+			writer.WriteLine(value: $"      <cell left-attach=\"{col}\" right-attach=\"{col + 1}\" top-attach=\"{r}\" bottom-attach=\"{r + 1}\">");
+			writer.WriteLine(value: $"        <p>{safeText}</p>");
+			writer.WriteLine(value: "      </cell>");
+		}
+		WriteCell(text: "Index", col: 0, r: row);
+		WriteCell(text: "Designation", col: 1, r: row);
+		row++;
+		foreach ((string index, string name) in GetExportData())
+		{
+			WriteCell(text: index, col: 0, r: row);
+			WriteCell(text: name, col: 1, r: row);
+			row++;
+		}
+		writer.WriteLine(value: "    </table>");
+		writer.WriteLine(value: "  </section>");
+		writer.WriteLine(value: "</abiword>");
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a WPS document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As WPS" menu item. It exports the data as HTML since WPS Office natively supports it.</remarks>
+	private void SaveListViewResultsAsWps()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogWps = new()
+		{
+			Filter = "WPS Writer documents (*.wps)|*.wps|All files (*.*)|*.*",
+			DefaultExt = "wps",
+			Title = "Save list as WPS"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogWps, ext: saveFileDialogWps.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the WPS file (using HTML format internally for compatibility with WPS Office)
+		using StreamWriter writer = new(path: saveFileDialogWps.FileName, append: false, encoding: Encoding.UTF8);
+		writer.WriteLine(value: "<!DOCTYPE html>");
+		writer.WriteLine(value: "<html>");
+		writer.WriteLine(value: "<head>");
+		writer.WriteLine(value: "<meta charset=\"utf-8\">");
+		writer.WriteLine(value: "<title>List of Readable Designations</title>");
+		writer.WriteLine(value: "<style>table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid black; padding: 5px; text-align: left; }</style>");
+		writer.WriteLine(value: "</head>");
+		writer.WriteLine(value: "<body>");
+		writer.WriteLine(value: "<h1>List of Readable Designations</h1>");
+		writer.WriteLine(value: "<table>");
+		writer.WriteLine(value: "<tr><th>Index</th><th>Designation</th></tr>");
+		foreach ((string index, string name) in GetExportData())
+		{
+			string safeIndex = System.Net.WebUtility.HtmlEncode(value: index) ?? string.Empty;
+			string safeName = System.Net.WebUtility.HtmlEncode(value: name) ?? string.Empty;
+			writer.WriteLine(value: $"<tr><td>{safeIndex}</td><td>{safeName}</td></tr>");
+		}
+		writer.WriteLine(value: "</table>");
+		writer.WriteLine(value: "</body>");
+		writer.WriteLine(value: "</html>");
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as an ET spreadsheet document (WPS Spreadsheets).</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As ET" menu item. It exports the data as CSV since WPS Spreadsheets natively supports it.</remarks>
+	private void SaveListViewResultsAsEt()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogEt = new()
+		{
+			Filter = "WPS Spreadsheets (*.et)|*.et|All files (*.*)|*.*",
+			DefaultExt = "et",
+			Title = "Save list as ET"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogEt, ext: saveFileDialogEt.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the ET file (using CSV format internally for compatibility with WPS Spreadsheets)
+		using StreamWriter writer = new(path: saveFileDialogEt.FileName, append: false, encoding: Encoding.UTF8);
+		writer.WriteLine(value: "Index,Designation");
+		foreach ((string index, string name) in GetExportData())
+		{
+			// Escape quotes in CSV
+			string safeIndex = index.Replace(oldValue: "\"", newValue: "\"\"");
+			string safeName = name.Replace(oldValue: "\"", newValue: "\"\"");
+			writer.WriteLine(value: $"\"{safeIndex}\",\"{safeName}\"");
+		}
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a DocBook document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As DocBook" menu item.</remarks>
+	private void SaveListViewResultsAsDocBook()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogDocBook = new()
+		{
+			Filter = "DocBook files (*.xml)|*.xml|All files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save list as DocBook"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogDocBook, ext: saveFileDialogDocBook.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the DocBook file
+		XmlWriterSettings settings = new() { Indent = true };
+		using XmlWriter writer = XmlWriter.Create(outputFileName: saveFileDialogDocBook.FileName, settings: settings);
+		// Write XML document
+		writer.WriteStartDocument();
+		// DocBook Article root
+		writer.WriteStartElement(localName: "article", ns: "http://docbook.org/ns/docbook");
+		writer.WriteAttributeString(localName: "version", value: "5.0");
+		// Title
+		writer.WriteStartElement(localName: "title");
+		writer.WriteString(text: "List of Readable Designations");
+		writer.WriteEndElement();
+		// Section
+		writer.WriteStartElement(localName: "section");
+		// Table
+		writer.WriteStartElement(localName: "table");
+		writer.WriteAttributeString(localName: "frame", value: "all");
+		writer.WriteStartElement(localName: "title");
+		writer.WriteString(text: "Planetoid Designations");
+		writer.WriteEndElement();
+		writer.WriteStartElement(localName: "tgroup");
+		writer.WriteAttributeString(localName: "cols", value: "2");
+		writer.WriteStartElement(localName: "colspec");
+		writer.WriteAttributeString(localName: "colname", value: "c1");
+		writer.WriteEndElement();
+		writer.WriteStartElement(localName: "colspec");
+		writer.WriteAttributeString(localName: "colname", value: "c2");
+		writer.WriteEndElement();
+		// Table Header
+		writer.WriteStartElement(localName: "thead");
+		writer.WriteStartElement(localName: "row");
+		writer.WriteStartElement(localName: "entry");
+		writer.WriteString(text: "Index");
+		writer.WriteEndElement();
+		writer.WriteStartElement(localName: "entry");
+		writer.WriteString(text: "Designation");
+		writer.WriteEndElement();
+		writer.WriteEndElement(); // row
+		writer.WriteEndElement(); // thead
+								  // Table Body
+		writer.WriteStartElement(localName: "tbody");
+		foreach ((string index, string name) in GetExportData())
+		{
+			writer.WriteStartElement(localName: "row");
+			writer.WriteStartElement(localName: "entry");
+			writer.WriteString(text: index);
+			writer.WriteEndElement();
+			writer.WriteStartElement(localName: "entry");
+			writer.WriteString(text: name);
+			writer.WriteEndElement();
+			writer.WriteEndElement(); // row
+		}
+		writer.WriteEndElement(); // tbody
+		writer.WriteEndElement(); // tgroup
+		writer.WriteEndElement(); // table
+		writer.WriteEndElement(); // section
+		writer.WriteEndElement(); // article
+		writer.WriteEndDocument();
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a TOML document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As TOML" menu item.</remarks>
+	private void SaveListViewResultsAsToml()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogToml = new()
+		{
+			Filter = "TOML files (*.toml)|*.toml|All files (*.*)|*.*",
+			DefaultExt = "toml",
+			Title = "Save list as TOML"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogToml, ext: saveFileDialogToml.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the TOML file
+		using StreamWriter writer = new(path: saveFileDialogToml.FileName, append: false, encoding: Encoding.UTF8);
+		writer.WriteLine(value: "title = \"List of Readable Designations\"");
+		writer.WriteLine(value: $"created_at = {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
+		writer.WriteLine();
+		foreach ((string index, string name) in GetExportData())
+		{
+			string safeIndex = index.Replace(oldValue: "\\", newValue: "\\\\").Replace(oldValue: "\"", newValue: "\\\"");
+			string safeName = name.Replace(oldValue: "\\", newValue: "\\\\").Replace(oldValue: "\"", newValue: "\\\"");
+			writer.WriteLine(value: "[[planetoids]]");
+			writer.WriteLine(value: $"index = \"{safeIndex}\"");
+			writer.WriteLine(value: $"designation = \"{safeName}\"");
+			writer.WriteLine();
+		}
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as an XPS document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As XPS" menu item.</remarks>
+	private void SaveListViewResultsAsXps()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogXps = new()
+		{
+			Filter = "XML Paper Specification files (*.xps)|*.xps|All files (*.*)|*.*",
+			DefaultExt = "xps",
+			Title = "Save list as XPS"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogXps, ext: saveFileDialogXps.DefaultExt))
+		{
+			return;
+		}
+		// Create the XPS file (which is a ZIP archive)
+		using FileStream fs = new(path: saveFileDialogXps.FileName, mode: FileMode.Create);
+		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
+
+		// 1. [Content_Types].xml
+		ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: contentTypesEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+			writer.WriteLine(value: "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
+			writer.WriteLine(value: "  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" />");
+			writer.WriteLine(value: "  <Default Extension=\"fdoc\" ContentType=\"application/vnd.ms-package.xps-fixeddocument+xml\" />");
+			writer.WriteLine(value: "  <Default Extension=\"fseq\" ContentType=\"application/vnd.ms-package.xps-fixeddocumentsequence+xml\" />");
+			writer.WriteLine(value: "  <Default Extension=\"fpage\" ContentType=\"application/vnd.ms-package.xps-fixedpage+xml\" />");
+			writer.WriteLine(value: "</Types>");
+		}
+		// 2. _rels/.rels
+		ZipArchiveEntry rootRelsEntry = archive.CreateEntry(entryName: "_rels/.rels", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: rootRelsEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+			writer.WriteLine(value: "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+			writer.WriteLine(value: "  <Relationship Id=\"rId1\" Type=\"http://schemas.microsoft.com/xps/2005/06/fixedrepresentation\" Target=\"/FixedDocumentSequence.fseq\" />");
+			writer.WriteLine(value: "</Relationships>");
+		}
+		// 3. FixedDocumentSequence.fseq
+		ZipArchiveEntry fseqEntry = archive.CreateEntry(entryName: "FixedDocumentSequence.fseq", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: fseqEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<FixedDocumentSequence xmlns=\"http://schemas.microsoft.com/xps/2005/06\">");
+			writer.WriteLine(value: "  <DocumentReference Source=\"/Documents/1/FixedDocument.fdoc\" />");
+			writer.WriteLine(value: "</FixedDocumentSequence>");
+		}
+		// 4. FixedDocumentSequence.fseq.rels
+		ZipArchiveEntry fseqRelsEntry = archive.CreateEntry(entryName: "_rels/FixedDocumentSequence.fseq.rels", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: fseqRelsEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+			writer.WriteLine(value: "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+			writer.WriteLine(value: "  <Relationship Id=\"rdoc1\" Type=\"http://schemas.microsoft.com/xps/2005/06/required-resource\" Target=\"/Documents/1/FixedDocument.fdoc\" />");
+			writer.WriteLine(value: "</Relationships>");
+		}
+		// 5. FixedDocument.fdoc
+		ZipArchiveEntry fdocEntry = archive.CreateEntry(entryName: "Documents/1/FixedDocument.fdoc", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: fdocEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<FixedDocument xmlns=\"http://schemas.microsoft.com/xps/2005/06\">");
+			writer.WriteLine(value: "  <PageContent Source=\"/Documents/1/Pages/1.fpage\" />");
+			writer.WriteLine(value: "</FixedDocument>");
+		}
+		// 6. FixedDocument.fdoc.rels
+		ZipArchiveEntry fdocRelsEntry = archive.CreateEntry(entryName: "Documents/1/_rels/FixedDocument.fdoc.rels", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: fdocRelsEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+			writer.WriteLine(value: "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+			writer.WriteLine(value: "  <Relationship Id=\"rpage1\" Type=\"http://schemas.microsoft.com/xps/2005/06/required-resource\" Target=\"/Documents/1/Pages/1.fpage\" />");
+			writer.WriteLine(value: "</Relationships>");
+		}
+		// 7. Pages/1.fpage
+		ZipArchiveEntry fpageEntry = archive.CreateEntry(entryName: "Documents/1/Pages/1.fpage", compressionLevel: CompressionLevel.Optimal);
+		using (StreamWriter writer = new(stream: fpageEntry.Open(), encoding: Encoding.UTF8))
+		{
+			writer.WriteLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
+			writer.WriteLine(value: "  <Glyphs Fill=\"#ff000000\" FontUri=\"\" FontRenderingEmSize=\"16\" OriginX=\"96\" OriginY=\"96\" UnicodeString=\"List of Readable Designations\" />");
+			// We iterate through the data. Warning: Since this is a very simple XPS generator, we write everything on 1 page and just increase Y.
+			// A real XPS would need pagination, font embedding, etc. But for this requirement, a simple text dump without font file is a minimalistic approach 
+			// (some viewers might fail if FontUri is empty, but XPS supports standard core fonts by fallback in some viewers like Edge/IE).
+			int currentY = 120;
+			foreach ((string index, string name) in GetExportData())
+			{
+				string safeIndex = System.Net.WebUtility.HtmlEncode(value: index) ?? string.Empty;
+				string safeName = System.Net.WebUtility.HtmlEncode(value: name) ?? string.Empty;
+				writer.WriteLine(value: $"  <Glyphs Fill=\"#ff000000\" FontUri=\"\" FontRenderingEmSize=\"12\" OriginX=\"96\" OriginY=\"{currentY}\" UnicodeString=\"{safeIndex}\" />");
+				writer.WriteLine(value: $"  <Glyphs Fill=\"#ff000000\" FontUri=\"\" FontRenderingEmSize=\"12\" OriginX=\"192\" OriginY=\"{currentY}\" UnicodeString=\"{safeName}\" />");
+				currentY += 16;
+			}
+			writer.WriteLine(value: "</FixedPage>");
+		}
+		// Note on XPS minimal compliance: A truly compliant XPS demands an interleaved generic TTF/ODTTF font and its rels binding.
+		// However, without external packages, providing a full TTF stream manually is huge. The above is the minimum markup structure.
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a FictionBook2 document.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As FictionBook2" menu item.</remarks>
+	private void SaveListViewResultsAsFictionBook2()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogFb2 = new()
+		{
+			Filter = "FictionBook2 files (*.fb2)|*.fb2|All files (*.*)|*.*",
+			DefaultExt = "fb2",
+			Title = "Save list as FictionBook2"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogFb2, ext: saveFileDialogFb2.DefaultExt))
+		{
+			return;
+		}
+		// Write the data to the FictionBook2 file
+		XmlWriterSettings settings = new() { Indent = true, Encoding = Encoding.UTF8 };
+		using XmlWriter writer = XmlWriter.Create(outputFileName: saveFileDialogFb2.FileName, settings: settings);
+		string fb2Ns = "http://www.gribuser.ru/xml/fictionbook/2.0";
+		writer.WriteStartDocument();
+		writer.WriteStartElement(localName: "FictionBook", ns: fb2Ns);
+		writer.WriteAttributeString(prefix: "xmlns", localName: "l", ns: null, value: "http://www.w3.org/1999/xlink");
+		// description
+		writer.WriteStartElement(localName: "description", ns: fb2Ns);
+		// title-info
+		writer.WriteStartElement(localName: "title-info", ns: fb2Ns);
+		writer.WriteElementString(localName: "genre", ns: fb2Ns, value: "reference");
+		writer.WriteStartElement(localName: "author", ns: fb2Ns);
+		writer.WriteElementString(localName: "first-name", ns: fb2Ns, value: "Planetoid-DB");
+		writer.WriteElementString(localName: "last-name", ns: fb2Ns, value: "");
+		writer.WriteEndElement(); // author
+		writer.WriteElementString(localName: "book-title", ns: fb2Ns, value: "List of Readable Designations");
+		writer.WriteElementString(localName: "lang", ns: fb2Ns, value: "en");
+		writer.WriteEndElement(); // title-info
+								  // document-info
+		writer.WriteStartElement(localName: "document-info", ns: fb2Ns);
+		writer.WriteStartElement(localName: "author", ns: fb2Ns);
+		writer.WriteElementString(localName: "first-name", ns: fb2Ns, value: "Planetoid-DB");
+		writer.WriteElementString(localName: "last-name", ns: fb2Ns, value: "");
+		writer.WriteEndElement(); // author
+		writer.WriteElementString(localName: "program-used", ns: fb2Ns, value: "Planetoid-DB");
+		writer.WriteStartElement(localName: "date", ns: fb2Ns);
+		writer.WriteAttributeString(localName: "value", value: DateTime.Now.ToString(format: "yyyy-MM-dd"));
+		writer.WriteString(text: DateTime.Now.ToString(format: "yyyy-MM-dd"));
+		writer.WriteEndElement(); // date
+		writer.WriteElementString(localName: "id", ns: fb2Ns, value: Guid.NewGuid().ToString());
+		writer.WriteElementString(localName: "version", ns: fb2Ns, value: "1.0");
+		writer.WriteEndElement(); // document-info
+		writer.WriteEndElement(); // description
+								  // body
+		writer.WriteStartElement(localName: "body", ns: fb2Ns);
+		writer.WriteStartElement(localName: "title", ns: fb2Ns);
+		writer.WriteStartElement(localName: "p", ns: fb2Ns);
+		writer.WriteString(text: "List of Readable Designations");
+		writer.WriteEndElement(); // p
+		writer.WriteEndElement(); // title
+		writer.WriteStartElement(localName: "section", ns: fb2Ns);
+		writer.WriteStartElement(localName: "table", ns: fb2Ns);
+		writer.WriteStartElement(localName: "tr", ns: fb2Ns);
+		writer.WriteStartElement(localName: "th", ns: fb2Ns);
+		writer.WriteString(text: "Index");
+		writer.WriteEndElement(); // th
+		writer.WriteStartElement(localName: "th", ns: fb2Ns);
+		writer.WriteString(text: "Designation");
+		writer.WriteEndElement(); // th
+		writer.WriteEndElement(); // tr
+		foreach ((string index, string name) in GetExportData())
+		{
+			writer.WriteStartElement(localName: "tr", ns: fb2Ns);
+			writer.WriteStartElement(localName: "td", ns: fb2Ns);
+			writer.WriteString(text: index);
+			writer.WriteEndElement(); // td
+			writer.WriteStartElement(localName: "td", ns: fb2Ns);
+			writer.WriteString(text: name);
+			writer.WriteEndElement(); // td
+			writer.WriteEndElement(); // tr
+		}
+		writer.WriteEndElement(); // table
+		writer.WriteEndElement(); // section
+		writer.WriteEndElement(); // body
+		writer.WriteEndElement(); // FictionBook
+		writer.WriteEndDocument();
+		// Show success message
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+	}
+
+	/// <summary>Saves the list as a Compiled HTML Help (CHM) document.</summary>
+	/// <remarks>This method generates the necessary HTML and project files, then uses Microsoft HTML Help Workshop to compile them.</remarks>
+	private void SaveListViewResultsAsChm()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogChm = new()
+		{
+			Filter = "Compiled HTML Help files (*.chm)|*.chm|All files (*.*)|*.*",
+			DefaultExt = "chm",
+			Title = "Save list as CHM"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogChm, ext: saveFileDialogChm.DefaultExt))
+		{
+			return;
+		}
+		// Find hhc.exe
+		string hhcPath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.ProgramFilesX86), path2: @"HTML Help Workshop\hhc.exe");
+		if (!File.Exists(path: hhcPath))
+		{
+			_ = MessageBox.Show(text: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			return;
+		}
+		// Create a temporary directory
+		string tempDir = Path.Combine(path1: Path.GetTempPath(), path2: Guid.NewGuid().ToString());
+		Directory.CreateDirectory(path: tempDir);
+		try
+		{
+			string htmlPath = Path.Combine(path1: tempDir, path2: "index.html");
+			string hhcFilePath = Path.Combine(path1: tempDir, path2: "toc.hhc");
+			string hhpPath = Path.Combine(path1: tempDir, path2: "project.hhp");
+			string chmTempPath = Path.Combine(path1: tempDir, path2: "project.chm");
+			// 1. Generate HTML
+			using (StreamWriter writer = new(path: htmlPath, append: false, encoding: Encoding.UTF8))
+			{
+				writer.WriteLine(value: "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>List of Readable Designations</title><style>table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid #000; padding: 5px; text-align: left; }</style></head><body>");
+				writer.WriteLine(value: "<h1>List of Readable Designations</h1>");
+				writer.WriteLine(value: "<table><tr><th>Index</th><th>Designation</th></tr>");
+				foreach ((string index, string name) in GetExportData())
+				{
+					string safeIndex = System.Net.WebUtility.HtmlEncode(value: index) ?? string.Empty;
+					string safeName = System.Net.WebUtility.HtmlEncode(value: name) ?? string.Empty;
+					writer.WriteLine(value: $"<tr><td>{safeIndex}</td><td>{safeName}</td></tr>");
+				}
+				writer.WriteLine(value: "</table></body></html>");
+			}
+			// 2. Generate TOC (.hhc)
+			using (StreamWriter writer = new(path: hhcFilePath, append: false, encoding: Encoding.ASCII))
+			{
+				writer.WriteLine(value: "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML//EN\">");
+				writer.WriteLine(value: "<HTML><HEAD><meta name=\"GENERATOR\" content=\"Planetoid-DB\"></HEAD><BODY>");
+				writer.WriteLine(value: "<OBJECT type=\"text/site properties\"><param name=\"ImageType\" value=\"Folder\"></OBJECT>");
+				writer.WriteLine(value: "<UL>");
+				writer.WriteLine(value: "<LI><OBJECT type=\"text/sitemap\">");
+				writer.WriteLine(value: "<param name=\"Name\" value=\"List of Readable Designations\">");
+				writer.WriteLine(value: "<param name=\"Local\" value=\"index.html\">");
+				writer.WriteLine(value: "</OBJECT>");
+				writer.WriteLine(value: "</UL></BODY></HTML>");
+			}
+			// 3. Generate Project (.hhp)
+			using (StreamWriter writer = new(path: hhpPath, append: false, encoding: Encoding.ASCII))
+			{
+				writer.WriteLine(value: "[OPTIONS]");
+				writer.WriteLine(value: "Compatibility=1.1 or later");
+				writer.WriteLine(value: "Compiled file=project.chm");
+				writer.WriteLine(value: "Contents file=toc.hhc");
+				writer.WriteLine(value: "Default topic=index.html");
+				writer.WriteLine(value: "Display compile progress=No");
+				writer.WriteLine(value: "Language=0x409 English (United States)");
+				writer.WriteLine(value: "Title=List of Readable Designations");
+				writer.WriteLine(value: "");
+				writer.WriteLine(value: "[FILES]");
+				writer.WriteLine(value: "index.html");
+			}
+			// 4. Compile using hhc.exe
+			ProcessStartInfo startInfo = new()
+			{
+				FileName = hhcPath,
+				Arguments = $"\"{hhpPath}\"",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				UseShellExecute = false
+			};
+			using (Process? process = Process.Start(startInfo: startInfo))
+			{
+				process?.WaitForExit();
+			}
+			// 5. Copy the CHM to the destination
+			if (File.Exists(path: chmTempPath))
+			{
+				File.Copy(sourceFileName: chmTempPath, destFileName: saveFileDialogChm.FileName, overwrite: true);
+				_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+			}
+			else
+			{
+				_ = MessageBox.Show(text: "Failed to compile the CHM file.", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.Error(exception: ex, message: "Error saving as CHM.");
+			_ = MessageBox.Show(text: $"Error saving as CHM: {ex.Message}", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+		}
+		finally
+		{
+			// Clean up temporary directory
+			if (Directory.Exists(path: tempDir))
+			{
+				Directory.Delete(path: tempDir, recursive: true);
+			}
+		}
 	}
 
 	#endregion
@@ -759,11 +1424,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// <remarks>When the Load button is clicked, this method calls the SelectPlanetoidInMainForm method to navigate to the selected planetoid record in the main form. After initiating the selection, it closes the current form to return control to the main form, and sets the dialog result to <see cref="DialogResult.OK"/> to signal a successful selection.</remarks>
 	private void ToolStripButtonLoad_Click(object sender, EventArgs e)
 	{
-		// Check if any item is selected
-		if (listView.SelectedItems.Count == 0)
-		{
-			return;
-		}
 		// Select the planetoid in the main form
 		SelectPlanetoidInMainForm();
 		// Set the dialog result to OK and close the form
@@ -795,7 +1455,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		{
 			streamWriter.WriteLine(value: $"{index}; {name}");
 		}
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an HTML file.</summary>
@@ -828,7 +1488,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		}
 		// Write HTML footer
 		w.WriteLine(value: "</body></html>");
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an XML file.</summary>
@@ -866,7 +1526,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// End XML document
 		writer.WriteEndElement();
 		writer.WriteEndDocument();
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a JSON file.</summary>
@@ -892,7 +1552,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Serialize to JSON and write to file
 		string jsonString = JsonSerializer.Serialize(value: exportList, options: new() { WriteIndented = true });
 		File.WriteAllText(path: saveFileDialogJson.FileName, contents: jsonString);
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a SQL script.
@@ -941,7 +1601,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		}
 		// Commit transaction
 		streamWriter.WriteLine(value: $"COMMIT;");
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a Markdown table.
@@ -974,7 +1634,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		{
 			streamWriter.WriteLine(value: $"| {index} | {EscapeMarkdownCell(value: name)} |");
 		}
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the list in YAML format.
@@ -1012,7 +1672,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			// Quotes are important if the name contains special characters
 			streamWriter.WriteLine(value: $"      name: \"{name}\"");
 		}
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the list as a TSV (Tab-Separated Values) file.
@@ -1044,7 +1704,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		{
 			streamWriter.WriteLine(value: $"{index}\t{name}");
 		}
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the list as a PSV (Pipe-Separated Values) file.
@@ -1076,7 +1736,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		{
 			streamWriter.WriteLine(value: $"{index}|{name}");
 		}
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the list as a LaTeX document.</summary>
@@ -1123,7 +1783,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		w.WriteLine(value: "\\caption{List of Readable Designations}");
 		w.WriteLine(value: "\\end{table}");
 		w.WriteLine(value: "\\end{document}");
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a PostScript (.ps) file.</summary>
@@ -1207,7 +1867,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		writer.WriteLine(value: "%%Trailer");
 		writer.WriteLine(value: $"%%Pages: {pageNumber}");
 		writer.WriteLine(value: "%%EOF");
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an uncompressed PDF file.</summary>
@@ -1381,7 +2041,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		w.WriteLine(value: "startxref");
 		w.WriteLine(value: xrefOffset);
 		w.WriteLine(value: "%%EOF");
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an EPUB file.</summary>
@@ -1397,24 +2057,20 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "epub",
 			Title = "Save list as EPUB"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogEpub, ext: saveFileDialogEpub.DefaultExt))
 		{
 			return;
 		}
-
 		// Create the EPUB file
 		using FileStream fs = new(path: saveFileDialogEpub.FileName, mode: FileMode.Create);
 		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
-
 		// 1. mimetype (must be first and uncompressed)
 		ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype", compressionLevel: CompressionLevel.NoCompression);
 		using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: Encoding.ASCII))
 		{
 			writer.Write(value: "application/epub+zip");
 		}
-
 		// 2. META-INF/container.xml
 		ZipArchiveEntry containerEntry = archive.CreateEntry(entryName: "META-INF/container.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: containerEntry.Open(), encoding: Encoding.UTF8))
@@ -1426,7 +2082,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  </rootfiles>");
 			writer.WriteLine(value: "</container>");
 		}
-
 		// 3. OEBPS/content.opf
 		ZipArchiveEntry opfEntry = archive.CreateEntry(entryName: "OEBPS/content.opf", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: opfEntry.Open(), encoding: Encoding.UTF8))
@@ -1450,7 +2105,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  </spine>");
 			writer.WriteLine(value: "</package>");
 		}
-
 		// 4. OEBPS/toc.ncx
 		ZipArchiveEntry ncxEntry = archive.CreateEntry(entryName: "OEBPS/toc.ncx", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: ncxEntry.Open(), encoding: Encoding.UTF8))
@@ -1496,7 +2150,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "      <tr><th>Index</th><th>Designation</th></tr>");
 			writer.WriteLine(value: "    </thead>");
 			writer.WriteLine(value: "    <tbody>");
-
 			// Use GetExportData() to retrieve items
 			foreach ((string index, string name) in GetExportData())
 			{
@@ -1504,14 +2157,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 				string safeName = System.Net.WebUtility.HtmlEncode(value: name) ?? string.Empty;
 				writer.WriteLine(value: $"      <tr><td>{safeIndex}</td><td>{safeName}</td></tr>");
 			}
-
 			writer.WriteLine(value: "    </tbody>");
 			writer.WriteLine(value: "  </table>");
 			writer.WriteLine(value: "</body>");
 			writer.WriteLine(value: "</html>");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a Word document.</summary>
@@ -1527,17 +2178,14 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "docx",
 			Title = "Save list as Word"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogWord, ext: saveFileDialogWord.DefaultExt))
 		{
 			return;
 		}
-
 		// Create the Word file
 		using FileStream fs = new(path: saveFileDialogWord.FileName, mode: FileMode.Create);
 		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
-
 		// 1. [Content_Types].xml
 		ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: contentTypesEntry.Open(), encoding: Encoding.UTF8))
@@ -1549,7 +2197,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  <Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>");
 			writer.WriteLine(value: "</Types>");
 		}
-
 		// 2. _rels/.rels
 		ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: relsEntry.Open(), encoding: Encoding.UTF8))
@@ -1559,7 +2206,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\"/>");
 			writer.WriteLine(value: "</Relationships>");
 		}
-
 		// 3. word/document.xml
 		ZipArchiveEntry documentEntry = archive.CreateEntry(entryName: "word/document.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: documentEntry.Open(), encoding: Encoding.UTF8))
@@ -1588,7 +2234,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "        <w:tc><w:p><w:r><w:t>Index</w:t></w:r></w:p></w:tc>");
 			writer.WriteLine(value: "        <w:tc><w:p><w:r><w:t>Designation</w:t></w:r></w:p></w:tc>");
 			writer.WriteLine(value: "      </w:tr>");
-
 			// Data Rows
 			foreach ((string index, string name) in GetExportData())
 			{
@@ -1604,8 +2249,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  </w:body>");
 			writer.WriteLine(value: "</w:document>");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an Excel file.</summary>
@@ -1621,17 +2265,14 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "xlsx",
 			Title = "Save list as Excel"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogExcel, ext: saveFileDialogExcel.DefaultExt))
 		{
 			return;
 		}
-
 		// Create the Excel file
 		using FileStream fs = new(path: saveFileDialogExcel.FileName, mode: FileMode.Create);
 		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
-
 		// 1. [Content_Types].xml
 		ZipArchiveEntry contentTypesEntry = archive.CreateEntry(entryName: "[Content_Types].xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: contentTypesEntry.Open(), encoding: Encoding.UTF8))
@@ -1644,7 +2285,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  <Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>");
 			writer.WriteLine(value: "</Types>");
 		}
-
 		// 2. _rels/.rels
 		ZipArchiveEntry relsEntry = archive.CreateEntry(entryName: "_rels/.rels", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: relsEntry.Open(), encoding: Encoding.UTF8))
@@ -1654,7 +2294,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>");
 			writer.WriteLine(value: "</Relationships>");
 		}
-
 		// 3. xl/workbook.xml
 		ZipArchiveEntry workbookEntry = archive.CreateEntry(entryName: "xl/workbook.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: workbookEntry.Open(), encoding: Encoding.UTF8))
@@ -1666,7 +2305,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  </sheets>");
 			writer.WriteLine(value: "</workbook>");
 		}
-
 		// 4. xl/_rels/workbook.xml.rels
 		ZipArchiveEntry workbookRelsEntry = archive.CreateEntry(entryName: "xl/_rels/workbook.xml.rels", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: workbookRelsEntry.Open(), encoding: Encoding.UTF8))
@@ -1676,7 +2314,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>");
 			writer.WriteLine(value: "</Relationships>");
 		}
-
 		// 5. xl/worksheets/sheet1.xml
 		ZipArchiveEntry sheetEntry = archive.CreateEntry(entryName: "xl/worksheets/sheet1.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: sheetEntry.Open(), encoding: Encoding.UTF8))
@@ -1684,13 +2321,11 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
 			writer.WriteLine(value: "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
 			writer.WriteLine(value: "  <sheetData>");
-
 			// Header
 			writer.WriteLine(value: "    <row>");
 			writer.WriteLine(value: "      <c t=\"inlineStr\"><is><t>Index</t></is></c>");
 			writer.WriteLine(value: "      <c t=\"inlineStr\"><is><t>Designation</t></is></c>");
 			writer.WriteLine(value: "    </row>");
-
 			// Data
 			foreach ((string index, string name) in GetExportData())
 			{
@@ -1706,8 +2341,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "  </sheetData>");
 			writer.WriteLine(value: "</worksheet>");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an ODT file.</summary>
@@ -1723,24 +2357,20 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "odt",
 			Title = "Save list as ODT"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogOdt, ext: saveFileDialogOdt.DefaultExt))
 		{
 			return;
 		}
-
 		// Create the ODT file
 		using FileStream fs = new(path: saveFileDialogOdt.FileName, mode: FileMode.Create);
 		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
-
 		// 1. mimetype (must be first and uncompressed)
 		ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype", compressionLevel: CompressionLevel.NoCompression);
 		using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: Encoding.ASCII))
 		{
 			writer.Write(value: "application/vnd.oasis.opendocument.text");
 		}
-
 		// 2. META-INF/manifest.xml
 		ZipArchiveEntry manifestEntry = archive.CreateEntry(entryName: "META-INF/manifest.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: manifestEntry.Open(), encoding: Encoding.UTF8))
@@ -1752,7 +2382,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: " <manifest:file-entry manifest:full-path=\"META-INF/manifest.xml\" manifest:media-type=\"text/xml\"/>");
 			writer.WriteLine(value: "</manifest:manifest>");
 		}
-
 		// 3. content.xml
 		ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "content.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: contentEntry.Open(), encoding: Encoding.UTF8))
@@ -1761,14 +2390,11 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" office:version=\"1.2\">");
 			writer.WriteLine(value: "  <office:body>");
 			writer.WriteLine(value: "    <office:text>");
-
 			// Title
 			writer.WriteLine(value: "      <text:h text:outline-level=\"1\">List of Readable Designations</text:h>");
-
 			// Table
 			writer.WriteLine(value: "      <table:table>");
 			writer.WriteLine(value: "        <table:table-column table:number-columns-repeated=\"2\"/>");
-
 			// Header Row
 			writer.WriteLine(value: "        <table:table-header-rows>");
 			writer.WriteLine(value: "          <table:table-row>");
@@ -1776,7 +2402,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "            <table:table-cell><text:p>Designation</text:p></table:table-cell>");
 			writer.WriteLine(value: "          </table:table-row>");
 			writer.WriteLine(value: "        </table:table-header-rows>");
-
 			// Data Rows
 			foreach ((string index, string name) in GetExportData())
 			{
@@ -1788,14 +2413,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 				writer.WriteLine(value: $"          <table:table-cell><text:p>{safeName}</text:p></table:table-cell>");
 				writer.WriteLine(value: "        </table:table-row>");
 			}
-
 			writer.WriteLine(value: "      </table:table>");
 			writer.WriteLine(value: "    </office:text>");
 			writer.WriteLine(value: "  </office:body>");
 			writer.WriteLine(value: "</office:document-content>");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an ODS file.</summary>
@@ -1811,24 +2434,20 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "ods",
 			Title = "Save list as ODS"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogOds, ext: saveFileDialogOds.DefaultExt))
 		{
 			return;
 		}
-
 		// Create the ODS file
 		using FileStream fs = new(path: saveFileDialogOds.FileName, mode: FileMode.Create);
 		using ZipArchive archive = new(stream: fs, mode: ZipArchiveMode.Create);
-
 		// 1. mimetype (must be first and uncompressed)
 		ZipArchiveEntry mimetypeEntry = archive.CreateEntry(entryName: "mimetype", compressionLevel: CompressionLevel.NoCompression);
 		using (StreamWriter writer = new(stream: mimetypeEntry.Open(), encoding: Encoding.ASCII))
 		{
 			writer.Write(value: "application/vnd.oasis.opendocument.spreadsheet");
 		}
-
 		// 2. META-INF/manifest.xml
 		ZipArchiveEntry manifestEntry = archive.CreateEntry(entryName: "META-INF/manifest.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: manifestEntry.Open(), encoding: Encoding.UTF8))
@@ -1840,7 +2459,6 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: " <manifest:file-entry manifest:full-path=\"META-INF/manifest.xml\" manifest:media-type=\"text/xml\"/>");
 			writer.WriteLine(value: "</manifest:manifest>");
 		}
-
 		// 3. content.xml
 		ZipArchiveEntry contentEntry = archive.CreateEntry(entryName: "content.xml", compressionLevel: CompressionLevel.Optimal);
 		using (StreamWriter writer = new(stream: contentEntry.Open(), encoding: Encoding.UTF8))
@@ -1851,13 +2469,11 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.WriteLine(value: "    <office:spreadsheet>");
 			writer.WriteLine(value: "      <table:table table:name=\"Planetoids\">");
 			writer.WriteLine(value: "        <table:table-column table:number-columns-repeated=\"2\"/>");
-
 			// Header Row
 			writer.WriteLine(value: "        <table:table-row>");
 			writer.WriteLine(value: "          <table:table-cell office:value-type=\"string\"><text:p>Index</text:p></table:table-cell>");
 			writer.WriteLine(value: "          <table:table-cell office:value-type=\"string\"><text:p>Designation</text:p></table:table-cell>");
 			writer.WriteLine(value: "        </table:table-row>");
-
 			// Data Rows
 			foreach ((string index, string name) in GetExportData())
 			{
@@ -1869,14 +2485,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 				writer.WriteLine(value: $"          <table:table-cell office:value-type=\"string\"><text:p>{safeName}</text:p></table:table-cell>");
 				writer.WriteLine(value: "        </table:table-row>");
 			}
-
 			writer.WriteLine(value: "      </table:table>");
 			writer.WriteLine(value: "    </office:spreadsheet>");
 			writer.WriteLine(value: "  </office:body>");
 			writer.WriteLine(value: "</office:document-content>");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a simplified MOBI file.</summary>
@@ -1892,16 +2506,14 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "mobi",
 			Title = "Save list as MOBI"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogMobi, ext: saveFileDialogMobi.DefaultExt))
 		{
 			return;
 		}
-
 		// 1. Generate Content (HTML)
 		StringBuilder html = new();
-		html.Append(value: "<html><head><title>Planetoid List</title></head><body>");
+		html.Append(value: "<html><head><meta charset=\"UTF-8\"><title>Planetoid List</title></head><body>");
 		html.Append(value: "<h1>List of Readable Designations</h1>");
 		// Mobi does not support all HTML tags, but basic tables often work in newer readers or are flattened.
 		html.Append(value: "<table>");
@@ -1912,9 +2524,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			html.Append(value: $"<tr><td>{encodedIndex}</td><td>{encodedName}</td></tr>");
 		}
 		html.Append(value: "</table></body></html>");
-
 		byte[] bodyData = Encoding.UTF8.GetBytes(s: html.ToString());
-
 		// 2. Chunk data (4096 bytes max per record is standard for PalmDoc)
 		List<byte[]> textRecords = [];
 		for (int i = 0; i < bodyData.Length; i += 4096)
@@ -1924,14 +2534,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			Array.Copy(sourceArray: bodyData, sourceIndex: i, destinationArray: chunk, destinationIndex: 0, length: len);
 			textRecords.Add(item: chunk);
 		}
-
 		// 3. Construct Headers
 		// PDB Header: 78 bytes
 		// Record List: 8 * NumRecords + 2 padding
 		// Record 0: Header Record (PalmDOC + Mobi Header)
 		// Records 1..N: Text
 		// Record N+1: EOF (Optional/Standard)
-
 		// Define a minimal Header Record (Record 0)
 		// PalmDOC Header (16 bytes) + Mobi Header (min 232 bytes)
 		// Using array for simplicity in binary writing
@@ -1948,9 +2556,8 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (short)4096)); // Record Size
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (short)0)); // Encryption Type
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (short)0)); // Unknown
-
-			// -- Mobi Header --
-			// Identifier "MOBI"
+																					  // -- Mobi Header --
+																					  // Identifier "MOBI"
 			hw.Write(buffer: Encoding.ASCII.GetBytes(s: "MOBI"));
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 232)); // Header Length
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 2)); // Mobi Type: 2 = Book
@@ -1958,41 +2565,32 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 0x12345678)); // UniqueID ID
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 6)); // File Version
 																			   // ... other fields are zeroed by default new byte[] ...;
-
-			// First Non-Book Index (offset 80 in Mobi Header -> 16+80 = 96)
-			// Points to EOF record usually or FLIS
+																			   // First Non-Book Index (offset 80 in Mobi Header -> 16+80 = 96)
+																			   // Points to EOF record usually or FLIS
 			ms.Seek(offset: 96, loc: SeekOrigin.Begin);
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: textRecords.Count + 1)); // We have Header(0) + Text(1..N). So next is N+1.
-
-			// Full Name Offset (offset 84 in Mobi Header -> 100)
+																								   // Full Name Offset (offset 84 in Mobi Header -> 100)
 			ms.Seek(offset: 100, loc: SeekOrigin.Begin);
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 0)); // No Full Name in this minimal version
 																			   // Min Version (offset 104 -> 120)
 			ms.Seek(offset: 120, loc: SeekOrigin.Begin);
 			hw.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: 6));
-
 			// ...
 		}
-
 		// EOF Record (minimal content)
 		byte[] eofRecord = [0xe9, 0x8e, 0x0d, 0x0a];
-
 		// Total Records: Header + TextRecords + EOF
 		int totalRecords = 1 + textRecords.Count + 1;
-
 		using FileStream fs = new(path: saveFileDialogMobi.FileName, mode: FileMode.Create);
 		using BinaryWriter w = new(output: fs);
-
 		// --- PDB Header (78 bytes) ---
 		string dbName = "Planetoids";
 		byte[] nameBytes = new byte[32];
 		Encoding.ASCII.GetBytes(s: dbName).CopyTo(array: nameBytes, index: 0);
 		w.Write(buffer: nameBytes);
-
 		w.Write(value: (short)0); // Attributes
 		w.Write(value: (short)0); // Version
-
-		// Dates (seconds since 1904-01-01)
+								  // Dates (seconds since 1904-01-01)
 		uint secondsSince1904 = (uint)(DateTime.UtcNow - new DateTime(year: 1904, month: 1, day: 1)).TotalSeconds;
 		w.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (int)secondsSince1904)); // Creation
 		w.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (int)secondsSince1904)); // Modification
@@ -2000,24 +2598,18 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		w.Write(value: 0); // ModNum
 		w.Write(value: 0); // AppInfoId
 		w.Write(value: 0); // SortInfoId
-
 		w.Write(buffer: Encoding.ASCII.GetBytes(s: "BOOK")); // Type
 		w.Write(buffer: Encoding.ASCII.GetBytes(s: "MOBI")); // Creator
-
 		w.Write(value: 0); // UniqueIDSeed
 		w.Write(value: 0); // NextRecordListID
-
 		w.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: (short)totalRecords)); // NumRecords
-
-		// --- Record List (8 bytes per record) ---
-		// Start of data is: 78 + (totalRecords * 8) + 2 (padding)
+																							// --- Record List (8 bytes per record) ---
+																							// Start of data is: 78 + (totalRecords * 8) + 2 (padding)
 		int currentOffset = 78 + (totalRecords * 8) + 2;
-
 		// 1. Header Record Info
 		w.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: currentOffset));
 		w.Write(value: 0); // Attributes/ID
 		currentOffset += headerRecord.Length;
-
 		// 2. Text Records Info
 		foreach (byte[] rec in textRecords)
 		{
@@ -2025,29 +2617,23 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			w.Write(value: 0);
 			currentOffset += rec.Length;
 		}
-
 		// 3. EOF Record Info
 		w.Write(value: System.Net.IPAddress.HostToNetworkOrder(host: currentOffset));
 		w.Write(value: 0);
 		currentOffset += eofRecord.Length;
-
 		// Padding (2 bytes)
 		w.Write(value: (short)0);
-
 		// --- Record Data ---
 		// 1. Header
 		w.Write(buffer: headerRecord);
-
 		// 2. Text
 		foreach (byte[] rec in textRecords)
 		{
 			w.Write(buffer: rec); // 4096 chunks
 		}
-
 		// 3. EOF
 		w.Write(buffer: eofRecord);
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as an RTF file.</summary>
@@ -2063,24 +2649,19 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "rtf",
 			Title = "Save list as RTF"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogRtf, ext: saveFileDialogRtf.DefaultExt))
 		{
 			return;
 		}
-
 		// Write the data to the RTF file using ASCII encoding
 		using StreamWriter writer = new(path: saveFileDialogRtf.FileName, append: false, encoding: Encoding.ASCII);
-
 		// Write RTF header
 		writer.WriteLine(value: "{\\rtf1\\ansi\\deff0");
 		writer.WriteLine(value: "{\\fonttbl{\\f0 Arial;}}");
 		writer.WriteLine(value: "\\f0\\fs20"); // Font Arial, Size 10pt
-
-		// Title
+											   // Title
 		writer.WriteLine(value: "{\\pard\\b\\fs24 List of Readable Designations\\par\\par}");
-
 		// Iterate data
 		foreach ((string index, string name) in GetExportData())
 		{
@@ -2088,25 +2669,20 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			writer.Write(value: "\\trowd\\trgaph108\\trleft-108");
 			writer.Write(value: "\\cellx1440"); // Cell 1 width (approx 1 inch)
 			writer.Write(value: "\\cellx5760"); // Cell 2 width (approx 3 inches more -> 4 inches total)
-
-			// Cell 1 content
+												// Cell 1 content
 			writer.Write(value: "\\pard\\intbl ");
 			writer.Write(value: EscapeRtf(input: index));
 			writer.Write(value: "\\cell");
-
 			// Cell 2 content
 			writer.Write(value: "\\pard\\intbl ");
 			writer.Write(value: EscapeRtf(input: name));
 			writer.Write(value: "\\cell");
-
 			// End row
 			writer.WriteLine(value: "\\row");
 		}
-
 		// Close RTF
 		writer.WriteLine(value: "}");
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
 
 	/// <summary>Saves the current list as a text file.</summary>
@@ -2122,24 +2698,98 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			DefaultExt = "txt",
 			Title = "Save list as Text"
 		};
-
 		// Prepare the save dialog
 		if (!PrepareSaveDialog(dialog: saveFileDialogText, ext: saveFileDialogText.DefaultExt))
 		{
 			return;
 		}
-
 		// Write the data to the text file
 		using StreamWriter writer = new(path: saveFileDialogText.FileName, append: false, encoding: Encoding.UTF8);
-
 		// Iterate data
 		foreach ((string index, string name) in GetExportData())
 		{
 			writer.WriteLine(value: $"{index}: {name}");
 		}
-
-		MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
 	}
+
+	/// <summary>Handles the click event for the 'Save As AsciiDoc' menu item and initiates saving the ListView results in AsciiDoc
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables users to export the current ListView results as an AsciiDoc-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e) => SaveListViewResultsAsAsciiDoc();
+
+	/// <summary>Handles the click event for the 'Save As reStructuredText' menu item and initiates saving the current ListView
+	/// results in reStructuredText format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables users to export the current ListView results as a reStructuredText-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e) => SaveListViewResultsAsReStructuredText();
+
+	/// <summary>Handles the click event of the 'Save As Textile' menu item and initiates saving the ListView results in Textile
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables
+	/// users to export the current ListView results as a Textile-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e) => SaveListViewResultsAsTextile();
+
+	/// <summary>Handles the click event for the 'Save As Abiword' menu item and initiates saving the current list view results in
+	/// Abiword format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As Abiword" menu item, this event handler is invoked. It calls the SaveListViewResultsAsAbiword method, which generates an HTML file with a .abw extension that can be opened in Abiword. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e) => SaveListViewResultsAsAbiword();
+
+	/// <summary>Handles the Click event of the Save As WPS menu item and initiates saving the current ListView results in WPS
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the Save As WPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As WPS" menu item, this event handler is invoked. It calls the SaveListViewResultsAsWps method, which generates an HTML file with a .wps extension that can be opened in WPS Writer. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e) => SaveListViewResultsAsWps();
+
+	/// <summary>Handles the Click event of the 'Save As Et' menu item and initiates saving the current ListView results in the Et
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As Et" menu item, this event handler is invoked. It calls the SaveListViewResultsAsEt method, which exports the data in a format compatible with WPS Spreadsheets (using CSV internally). If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e) => SaveListViewResultsAsEt();
+
+	/// <summary>Handles the click event for the 'Save As DocBook' menu item, initiating the process to save the current list view
+	/// results in DocBook format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As DocBook" menu item, this event handler is invoked. It calls the SaveListViewResultsAsDocBook method, which generates an XML document conforming to the DocBook schema, containing the list of readable designations. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e) => SaveListViewResultsAsDocBook();
+
+	/// <summary>Handles the click event for the 'Save As TOML' menu item and initiates saving the current results in TOML format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As TOML" menu item, this event handler is invoked. It calls the SaveListViewResultsAsToml method, which generates the necessary TOML structure for the current results and saves it as a .toml file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e) => SaveListViewResultsAsToml();
+
+	/// <summary>Handles the Click event of the Save As XPS menu item and initiates saving the current ListView results as an XPS
+	/// document.</summary>
+	/// <param name="sender">The source of the event, typically the Save As XPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As XPS" menu item, this event handler is invoked. It calls the SaveListViewResultsAsXps method, which generates the necessary XML structure for an XPS document and saves it as a .xps file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e) => SaveListViewResultsAsXps();
+
+	/// <summary>Handles the Click event of the Save As FictionBook2 menu item and initiates saving the current results in
+	/// FictionBook2 format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As FictionBook2" menu item, this event handler is invoked. It calls the SaveListViewResultsAsFictionBook2 method, which generates an XML document conforming to the FictionBook2 schema, containing the list of readable designations. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e) => SaveListViewResultsAsFictionBook2();
+
+	/// <summary>Handles the Click event of the Save As CHM menu item and initiates saving the current ListView results as a CHM
+	/// file.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As CHM" menu item, this event handler is invoked. It calls the SaveListViewResultsAsChm method, which generates the necessary HTML and project files, then uses Microsoft HTML Help Workshop to compile them into a CHM file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e) => SaveListViewResultsAsChm();
+
 
 	#endregion
 


### PR DESCRIPTION
This PR expands and reorganizes the “Save list” export options (grouped by document type) and adds several new export formats, while also cleaning up some UI/accessibility wiring and standardizing `MessageBox.Show` call handling.

**Changes:**
- Restructures the “Save list” context menu into grouped submenus and adds new export targets (e.g., AsciiDoc, reStructuredText, Textile, DocBook, TOML, XPS, CHM, WPS/ET).
- Implements new exporters in `ListReadableDesignationsForm` for the added formats.
- Renames/fixes reStructuredText-related identifiers and standardizes discarding `MessageBox.Show` return values.