### PR TITLE
Added package System.Data.SQLite 2.0.2

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -859,6 +859,7 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="Krypton.Toolkit.Suite.Extended.Ultimate" Version="95.25.5.145" />
     <PackageReference Include="Krypton.Workspace" Version="100.26.1.19" />
     <PackageReference Include="NLog" Version="6.1.1" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a new NuGet dependency to the WinForms application project, presumably to enable SQLite-backed storage/access in Planetoid-DB.

**Changes:**
- Add a `System.Data.SQLite` `PackageReference` to the main project file.