### PR TITLE
Added saving format SQLite

### DIFF
--- a/Forms/DatabaseDifferencesForm.Designer.cs
+++ b/Forms/DatabaseDifferencesForm.Designer.cs
@@ -73,6 +73,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
 		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
 		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
@@ -239,7 +240,7 @@ partial class DatabaseDifferencesForm
 		contextMenuSaveList.Font = new Font("Segoe UI", 9F);
 		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
 		contextMenuSaveList.Name = "contextMenuSaveList";
-		contextMenuSaveList.Size = new Size(202, 158);
+		contextMenuSaveList.Size = new Size(202, 180);
 		contextMenuSaveList.TabStop = true;
 		contextMenuSaveList.Text = "&Save list";
 		contextMenuSaveList.MouseEnter += Control_Enter;
@@ -663,7 +664,7 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
 		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
-		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql });
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
 		toolStripMenuItemDatabaseScripts.Image = Resources.FatcowIcons16px.fatcow_file_extension_ptb_16px;
 		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
 		toolStripMenuItemDatabaseScripts.ShortcutKeyDisplayString = "";
@@ -681,11 +682,25 @@ partial class DatabaseDifferencesForm
 		toolStripMenuItemSaveAsSql.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
 		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
 		toolStripMenuItemSaveAsSql.ShortcutKeyDisplayString = "";
-		toolStripMenuItemSaveAsSql.Size = new Size(136, 22);
-		toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
+		toolStripMenuItemSaveAsSql.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
 		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
 		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemPortableDocuments
 		// 
@@ -1260,4 +1275,5 @@ partial class DatabaseDifferencesForm
 	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
 	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
 	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
 }

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -9,6 +9,7 @@ using Planetoid_DB.Forms;
 using Planetoid_DB.Helpers;
 
 using System.ComponentModel;
+using System.Data;
 using System.Diagnostics;
 using System.Xml.Linq;
 
@@ -2294,6 +2295,159 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 		}
 	}
 
+	/// <summary>Saves the results displayed in the list view to a user-specified SQLite database file, creating a table and inserting each difference as a row.</summary>
+	/// <remarks>The method prompts the user to select a file location and name for the SQLite file. It utilizes the built-in Windows sqlite3.exe to generate the database. It handles potential I/O and access errors, displaying appropriate messages to the user.</remarks>
+	private void SaveListViewResultsAsSqliteNative()
+	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the SQLite file; if the user confirms the save operation, attempt to write the difference results to the specified file in SQLite format, handling any potential I/O errors or access issues that may arise during the process
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQLite Database Files (*.sqlite3;*.sqlite;*.db)|*.sqlite3;*.sqlite;*.db|All Files (*.*)|*.*",
+			FileName = fileName
+		};
+		if (saveFileDialog.ShowDialog() == DialogResult.OK)
+		{
+			// Attempt to write the difference results to the selected file in SQLite format, handling any I/O exceptions or unauthorized access exceptions that may occur during the file writing process; if successful, display a confirmation message to the user
+			try
+			{
+				// Locate the built-in sqlite3.exe tool on the system to generate the database without external packages; if the tool is found, start a process to execute SQL commands via standard input, which will create the database, table, and insert the difference results
+				string sqlitePath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.System), path2: "sqlite3.exe");
+				if (!File.Exists(path: sqlitePath))
+				{
+					_ = MessageBox.Show(text: "The built-in sqlite3.exe tool is not available on this system. Cannot generate SQLite file without external packages.", caption: "Missing Dependency", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+					return;
+				}
+				if (File.Exists(path: saveFileDialog.FileName))
+				{
+					File.Delete(path: saveFileDialog.FileName);
+				}
+				ProcessStartInfo startInfo = new()
+				{
+					FileName = sqlitePath,
+					Arguments = $"\"{saveFileDialog.FileName}\"",
+					CreateNoWindow = true,
+					UseShellExecute = false,
+					RedirectStandardInput = true,
+					WindowStyle = ProcessWindowStyle.Hidden
+				};
+				using Process? process = Process.Start(startInfo: startInfo);
+				if (process != null)
+				{
+					// Open a StreamWriter to the standard input of the sqlite3 process and write the necessary SQL commands to create a table and insert each difference result as a row; ensure that any single quotes in the data are properly escaped to prevent SQL syntax errors
+					using (StreamWriter sw = process.StandardInput)
+					{
+						sw.WriteLine(value: "PRAGMA encoding=\"UTF-8\";");
+						sw.WriteLine(value: "CREATE TABLE Differences (DifferenceIndex TEXT, Designation VARCHAR(255), Difference TEXT);");
+						sw.WriteLine(value: "BEGIN TRANSACTION;");
+						foreach (DifferenceResult result in differenceResults)
+						{
+							string safeIndex = result.Index.Replace(oldValue: "'", newValue: "''");
+							string safeDesig = result.Designation.Replace(oldValue: "'", newValue: "''");
+							string safeDiff = result.Difference.Replace(oldValue: "'", newValue: "''");
+							sw.WriteLine(value: $"INSERT INTO Differences (DifferenceIndex, Designation, Difference) VALUES ('{safeIndex}', '{safeDesig}', '{safeDiff}');");
+						}
+						sw.WriteLine(value: "COMMIT;");
+					}
+					process.WaitForExit();
+				}
+				_ = File.Exists(path: saveFileDialog.FileName)
+					? MessageBox.Show(text: "Results successfully saved to SQLite file.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information)
+					: MessageBox.Show(text: "Failed to generate the SQLite database.", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+			catch (IOException ex)
+			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
+				logger.Error(exception: ex, message: "I/O error while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
+				logger.Error(exception: ex, message: "Access denied while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+			catch (Exception ex)
+			{
+				// Catch any other exceptions that may occur during the process execution or generation, ensuring the application handles unexpected issues gracefully
+				logger.Error(exception: ex, message: "Unexpected error while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"An unexpected error occurred: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+		}
+	}
+
+	/// <summary>Saves the results displayed in the list view to a user-specified SQLite database file using the System.Data.SQLite provider natively.</summary>
+	/// <remarks>The method prompts the user to select a file location and name for the SQLite file. It uses System.Data.SQLite to create the database, generate a table, and insert each difference as a row.</remarks>
+	private void SaveListViewResultsAsSqlite()
+	{
+		// Create and configure a SaveFileDialog to allow the user to choose where to save the SQLite file; if the user confirms the save operation, attempt to write the difference results to the specified file in SQLite format using the System.Data.SQLite provider, handling any potential I/O errors or access issues that may arise during the process
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQLite Database Files (*.sqlite3;*.sqlite;*.db)|*.sqlite3;*.sqlite;*.db|All Files (*.*)|*.*",
+			FileName = fileName
+		};
+		// If the user confirms the save operation, attempt to create a new SQLite database file, create a table for the differences, and insert each difference result as a row using the System.Data.SQLite provider; handle any I/O exceptions or unauthorized access exceptions that may occur during the process, and display appropriate messages to the user based on the outcome
+		if (saveFileDialog.ShowDialog() == DialogResult.OK)
+		{
+			try
+			{
+				if (File.Exists(path: saveFileDialog.FileName))
+				{
+					File.Delete(path: saveFileDialog.FileName);
+				}
+				// Create a new SQLite database file using System.Data.SQLite, then open a connection to the database, create a table named "Differences" with appropriate columns, and insert each difference result as a row in the table; after successfully inserting the data, display a success message to the user
+				System.Data.SQLite.SQLiteConnection.CreateFile(databaseFileName: saveFileDialog.FileName);
+				string connectionString = $"Data Source={saveFileDialog.FileName};Version=3;";
+				using (System.Data.SQLite.SQLiteConnection connection = new(connectionString: connectionString))
+				{
+					connection.Open();
+					using (System.Data.SQLite.SQLiteCommand command = new(commandText: "CREATE TABLE Differences (DifferenceIndex TEXT, Designation VARCHAR(255), Difference TEXT)", connection: connection))
+					{
+						command.ExecuteNonQuery();
+					}
+					// Use a transaction to ensure that all inserts are performed atomically, improving performance and ensuring data integrity; prepare an insert command with parameters for the difference index, designation, and difference, and execute the command for each difference result in the list
+					using (System.Data.SQLite.SQLiteTransaction transaction = connection.BeginTransaction())
+					{
+						using (System.Data.SQLite.SQLiteCommand insertCommand = new(commandText: "INSERT INTO Differences (DifferenceIndex, Designation, Difference) VALUES (@Index, @Designation, @Difference)", connection: connection, transaction: transaction))
+						{
+							System.Data.SQLite.SQLiteParameter paramIndex = insertCommand.Parameters.Add(parameterName: "@Index", parameterType: DbType.String);
+							System.Data.SQLite.SQLiteParameter paramDesig = insertCommand.Parameters.Add(parameterName: "@Designation", parameterType: DbType.String);
+							System.Data.SQLite.SQLiteParameter paramDiff = insertCommand.Parameters.Add(parameterName: "@Difference", parameterType: DbType.String);
+							foreach (DifferenceResult result in differenceResults)
+							{
+								paramIndex.Value = result.Index;
+								paramDesig.Value = result.Designation;
+								paramDiff.Value = result.Difference;
+								insertCommand.ExecuteNonQuery();
+							}
+						}
+						transaction.Commit();
+					}
+					connection.Close();
+				}
+				// After successfully saving the results to the SQLite file, display a confirmation message to the user indicating that the operation was successful
+				_ = MessageBox.Show(text: "Results successfully saved to SQLite file natively.", caption: "Success", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+			}
+			catch (IOException ex)
+			{
+				// Catch any IOException that occurs during the file writing process, log the error, and display an error message to the user indicating that an I/O error occurred
+				logger.Error(exception: ex, message: "I/O error while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"An I/O error occurred while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				// Catch any UnauthorizedAccessException that occurs during the file writing process, log the error, and display an error message to the user indicating that access was denied
+				logger.Error(exception: ex, message: "Access denied while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"Access denied while saving the file: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+			catch (Exception ex)
+			{
+				// Catch any other exceptions that may occur during the process, ensuring the application handles unexpected issues gracefully
+				logger.Error(exception: ex, message: "Unexpected error while saving results to SQLite file '{FilePath}'.", args: saveFileDialog.FileName);
+				_ = MessageBox.Show(text: $"An unexpected error occurred: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+			}
+		}
+	}
+
 	#endregion
 
 	#region Form event handlers
@@ -2715,6 +2869,15 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">The event data associated with the click event.</param>
 	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e) => SaveListViewResultsAsTextile();
+
+	/// <summary>Handles the click event for the 'Save As SQLite' menu item and initiates saving the current list view results in SQLite
+	/// format.</summary>
+	/// <remarks>This method invokes the SaveListViewResultsAsSqlite method to perform the save operation. Use this
+	/// event handler to enable users to export list view data as a SQLite database.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e) => SaveListViewResultsAsSqlite();
+
 	#endregion
 
 	#region BackgroundWorker event handlers

--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -80,6 +80,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
 		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
 		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
@@ -196,7 +197,8 @@ partial class ListReadableDesignationsForm
 		contextMenuSaveList.Font = new Font("Segoe UI", 9F);
 		contextMenuSaveList.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
 		contextMenuSaveList.Name = "contextMenuSaveList";
-		contextMenuSaveList.Size = new Size(202, 158);
+		contextMenuSaveList.OwnerItem = toolStripDropDownButtonSaveList;
+		contextMenuSaveList.Size = new Size(202, 180);
 		contextMenuSaveList.TabStop = true;
 		contextMenuSaveList.Text = "&Save list";
 		contextMenuSaveList.MouseEnter += Control_Enter;
@@ -504,7 +506,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
 		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
-		toolStripMenuItemSaveAsHtml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
 		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
 		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
 		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
@@ -518,7 +520,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsXml.AutoToolTip = true;
 		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
-		toolStripMenuItemSaveAsXml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
 		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
 		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
 		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
@@ -532,7 +534,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
 		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
-		toolStripMenuItemSaveAsDocBook.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
 		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
 		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
 		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
@@ -560,7 +562,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsJson.AutoToolTip = true;
 		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
-		toolStripMenuItemSaveAsJson.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
 		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
 		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
 		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
@@ -574,7 +576,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
 		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
-		toolStripMenuItemSaveAsYaml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
 		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
 		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
 		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
@@ -588,7 +590,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsToml.AutoToolTip = true;
 		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
-		toolStripMenuItemSaveAsToml.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
 		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
 		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
 		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
@@ -600,7 +602,7 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
 		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
-		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql });
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
 		toolStripMenuItemDatabaseScripts.Image = FatcowIcons16px.fatcow_file_extension_ptb_16px;
 		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
 		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
@@ -617,10 +619,24 @@ partial class ListReadableDesignationsForm
 		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
 		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
 		toolStripMenuItemSaveAsSql.Size = new Size(180, 22);
-		toolStripMenuItemSaveAsSql.Text = "Save as &SQL";
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
 		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
 		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
 		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuPopup;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(180, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemPortableDocuments
 		// 
@@ -843,7 +859,7 @@ partial class ListReadableDesignationsForm
 		toolStripContainer.MouseEnter += Control_Enter;
 		toolStripContainer.MouseLeave += Control_Leave;
 		// 
-		// kryptonToolStripList
+		// kryptonToolStripGenerateList
 		// 
 		kryptonToolStripGenerateList.AccessibleDescription = "Toolbar of generating list";
 		kryptonToolStripGenerateList.AccessibleName = "Toolbar of generating list";
@@ -912,10 +928,10 @@ partial class ListReadableDesignationsForm
 		toolStripNumericUpDownMinimum.Size = new Size(41, 23);
 		toolStripNumericUpDownMinimum.Text = "0";
 		toolStripNumericUpDownMinimum.TextAlign = HorizontalAlignment.Center;
-		toolStripNumericUpDownMinimum.Enter += Control_Enter;
-		toolStripNumericUpDownMinimum.Leave += Control_Leave;
 		toolStripNumericUpDownMinimum.MouseEnter += Control_Enter;
 		toolStripNumericUpDownMinimum.MouseLeave += Control_Leave;
+		toolStripNumericUpDownMinimum.Enter += Control_Enter;
+		toolStripNumericUpDownMinimum.Leave += Control_Leave;
 		// 
 		// toolStripLabelMaximum
 		// 
@@ -940,10 +956,10 @@ partial class ListReadableDesignationsForm
 		toolStripNumericUpDownMaximum.Size = new Size(41, 23);
 		toolStripNumericUpDownMaximum.Text = "0";
 		toolStripNumericUpDownMaximum.TextAlign = HorizontalAlignment.Center;
-		toolStripNumericUpDownMaximum.Enter += Control_Enter;
-		toolStripNumericUpDownMaximum.Leave += Control_Leave;
 		toolStripNumericUpDownMaximum.MouseEnter += Control_Enter;
 		toolStripNumericUpDownMaximum.MouseLeave += Control_Leave;
+		toolStripNumericUpDownMaximum.Enter += Control_Enter;
+		toolStripNumericUpDownMaximum.Leave += Control_Leave;
 		// 
 		// kryptonToolStripSaveList
 		// 
@@ -1091,4 +1107,5 @@ partial class ListReadableDesignationsForm
 	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
 	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
 	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
 }

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -7,6 +7,7 @@ using NLog;
 
 using Planetoid_DB.Forms;
 
+using System.Data.SQLite;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
@@ -1149,6 +1150,73 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			{
 				Directory.Delete(path: tempDir, recursive: true);
 			}
+		}
+	}
+
+	/// <summary>Saves the list as a SQLite database natively.</summary>
+	/// <remarks>This method is invoked when the user selects the "Save As SQLite" menu item. It exports the data as a SQLite database.</remarks>
+	private void SaveListViewResultsAsSqlite()
+	{
+		// Create a SaveFileDialog manually
+		using SaveFileDialog saveFileDialogSqlite = new()
+		{
+			Filter = "SQLite Database Files (*.sqlite3;*.sqlite;*.db)|*.sqlite3;*.sqlite;*.db|All Files (*.*)|*.*",
+			DefaultExt = "sqlite3",
+			Title = "Save list as SQLite"
+		};
+		// Prepare the save dialog
+		if (!PrepareSaveDialog(dialog: saveFileDialogSqlite, ext: saveFileDialogSqlite.DefaultExt))
+		{
+			return;
+		}
+		// Create the SQLite database and insert data
+		try
+		{
+			// If the file already exists, delete it to create a new one
+			if (File.Exists(path: saveFileDialogSqlite.FileName))
+			{
+				File.Delete(path: saveFileDialogSqlite.FileName);
+			}
+			// Create the SQLite database file
+			SQLiteConnection.CreateFile(databaseFileName: saveFileDialogSqlite.FileName);
+			string connectionString = $"Data Source={saveFileDialogSqlite.FileName};Version=3;";
+			// Open the connection and create the table, then insert data
+			using (SQLiteConnection connection = new(connectionString: connectionString))
+			{
+				connection.Open();
+				// Create the Designations table
+				using (SQLiteCommand command = new(commandText: "CREATE TABLE Designations (IndexText TEXT, Designation VARCHAR(255))", connection: connection))
+				{
+					command.ExecuteNonQuery();
+				}
+				// Insert data using a transaction for better performance
+				using (SQLiteTransaction transaction = connection.BeginTransaction())
+				{
+					// Prepare the insert command with parameters
+					using (SQLiteCommand insertCommand = new(commandText: "INSERT INTO Designations (IndexText, Designation) VALUES (@Index, @Designation)", connection: connection, transaction: transaction))
+					{
+						SQLiteParameter paramIndex = insertCommand.Parameters.Add(parameterName: "@Index", parameterType: System.Data.DbType.String);
+						SQLiteParameter paramDesig = insertCommand.Parameters.Add(parameterName: "@Designation", parameterType: System.Data.DbType.String);
+						// Iterate through the data and insert into the database
+						foreach ((string index, string name) in GetExportData())
+						{
+							paramIndex.Value = index;
+							paramDesig.Value = name;
+							insertCommand.ExecuteNonQuery();
+						}
+					}
+					transaction.Commit();
+				}
+				connection.Close();
+			}
+			// Show success message
+			_ = MessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+		}
+		catch (Exception ex)
+		{
+			// Log the error and show an error message
+			logger.Error(exception: ex, message: "Error saving as SQLite.");
+			_ = MessageBox.Show(text: $"Error saving as SQLite: {ex.Message}", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
 		}
 	}
 
@@ -2790,6 +2858,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// <remarks>When the user clicks the "Save As CHM" menu item, this event handler is invoked. It calls the SaveListViewResultsAsChm method, which generates the necessary HTML and project files, then uses Microsoft HTML Help Workshop to compile them into a CHM file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
 	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e) => SaveListViewResultsAsChm();
 
+	/// <summary>Handles the Click event of the Save As SQLite menu item and initiates saving the current ListView results as a SQLite
+	/// file.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As SQLite" menu item, this event handler is invoked. It calls the SaveListViewResultsAsSqlite method.</remarks>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e) => SaveListViewResultsAsSqlite();
 
 	#endregion
 

--- a/Forms/ListReadableDesignationsForm.resx
+++ b/Forms/ListReadableDesignationsForm.resx
@@ -118,22 +118,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>543, 17</value>
+    <value>749, 17</value>
   </metadata>
   <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>326, 17</value>
+    <value>532, 17</value>
   </metadata>
   <metadata name="contextMenuSaveList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>159, 17</value>
+    <value>365, 17</value>
   </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>223, 17</value>
+  </metadata>
+  <metadata name="kryptonToolStripGenerateList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="kryptonToolStripList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>694, 17</value>
-  </metadata>
   <metadata name="kryptonToolStripSaveList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>841, 17</value>
+    <value>900, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>55</value>


### PR DESCRIPTION
Adds a new export option to save list results directly as a SQLite database, exposed via the “Database scripts” menu in relevant forms.

**Changes:**
- Implement SQLite export routines that create a `.sqlite3/.sqlite/.db` file and insert current list rows into a table.
- Add “Save as SQLite” menu items and wire click handlers for the new export option.
- Update WinForms designer/resx metadata to reflect the new UI elements.