### PR TITLE
Redesigned GUI in `OrbitalResonancesOfAllMinorPlanetsForm`

### DIFF
--- a/Forms/OrbitalResonancesOfAllMinorPlanetsForm.Designer.cs
+++ b/Forms/OrbitalResonancesOfAllMinorPlanetsForm.Designer.cs
@@ -46,17 +46,6 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		components = new Container();
 		ComponentResourceManager resources = new ComponentResourceManager(typeof(OrbitalResonancesOfAllMinorPlanetsForm));
 		kryptonPanelMain = new KryptonPanel();
-		btnStart = new KryptonButton();
-		btnCancel = new KryptonButton();
-		checkBoxMercury = new KryptonCheckBox();
-		checkBoxVenus = new KryptonCheckBox();
-		checkBoxEarth = new KryptonCheckBox();
-		checkBoxMars = new KryptonCheckBox();
-		checkBoxJupiter = new KryptonCheckBox();
-		checkBoxSaturn = new KryptonCheckBox();
-		checkBoxUranus = new KryptonCheckBox();
-		checkBoxNeptune = new KryptonCheckBox();
-		kryptonProgressBar = new KryptonProgressBar();
 		listView = new ListView();
 		columnHeaderPlanetoid = new ColumnHeader();
 		columnHeaderPlanet = new ColumnHeader();
@@ -66,15 +55,78 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		columnHeaderResonance = new ColumnHeader();
 		columnHeaderDeviation = new ColumnHeader();
 		columnHeaderIsResonance = new ColumnHeader();
-		contextMenuCopyToClipboard = new ContextMenuStrip(components);
-		toolStripMenuItemCopyToClipboard = new ToolStripMenuItem();
+		contextMenuSaveToFile = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
+		toolStripDropDownButtonSaveToFile = new ToolStripDropDownButton();
 		kryptonStatusStrip = new KryptonStatusStrip();
 		labelInformation = new ToolStripStatusLabel();
 		kryptonManager = new KryptonManager(components);
+		toolStripContainer = new ToolStripContainer();
+		toolStripIcons = new ToolStrip();
+		toolStripButtonStart = new ToolStripButton();
+		toolStripButtonCancel = new ToolStripButton();
+		toolStripSeparator4 = new ToolStripSeparator();
+		toolStripLabelPlanets = new ToolStripLabel();
+		toolStripButtonMercury = new ToolStripButton();
+		toolStripButtonVenus = new ToolStripButton();
+		toolStripButtonEarth = new ToolStripButton();
+		toolStripButtonMars = new ToolStripButton();
+		toolStripButtonJupiter = new ToolStripButton();
+		toolStripButtonSaturn = new ToolStripButton();
+		toolStripButtonUranus = new ToolStripButton();
+		toolStripButtonNeptune = new ToolStripButton();
+		toolStripSeparator5 = new ToolStripSeparator();
+		toolStripProgress = new ToolStrip();
+		toolStripLabelProgress = new ToolStripLabel();
+		kryptonProgressBar = new KryptonProgressBarToolStripItem();
 		((ISupportInitialize)kryptonPanelMain).BeginInit();
 		kryptonPanelMain.SuspendLayout();
-		contextMenuCopyToClipboard.SuspendLayout();
+		contextMenuSaveToFile.SuspendLayout();
 		kryptonStatusStrip.SuspendLayout();
+		toolStripContainer.BottomToolStripPanel.SuspendLayout();
+		toolStripContainer.ContentPanel.SuspendLayout();
+		toolStripContainer.TopToolStripPanel.SuspendLayout();
+		toolStripContainer.SuspendLayout();
+		toolStripIcons.SuspendLayout();
+		toolStripProgress.SuspendLayout();
 		SuspendLayout();
 		// 
 		// kryptonPanelMain
@@ -82,183 +134,19 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		kryptonPanelMain.AccessibleDescription = "Groups the data";
 		kryptonPanelMain.AccessibleName = "Panel";
 		kryptonPanelMain.AccessibleRole = AccessibleRole.Pane;
-		kryptonPanelMain.Controls.Add(btnStart);
-		kryptonPanelMain.Controls.Add(btnCancel);
-		kryptonPanelMain.Controls.Add(checkBoxMercury);
-		kryptonPanelMain.Controls.Add(checkBoxVenus);
-		kryptonPanelMain.Controls.Add(checkBoxEarth);
-		kryptonPanelMain.Controls.Add(checkBoxMars);
-		kryptonPanelMain.Controls.Add(checkBoxJupiter);
-		kryptonPanelMain.Controls.Add(checkBoxSaturn);
-		kryptonPanelMain.Controls.Add(checkBoxUranus);
-		kryptonPanelMain.Controls.Add(checkBoxNeptune);
-		kryptonPanelMain.Controls.Add(kryptonProgressBar);
 		kryptonPanelMain.Controls.Add(listView);
-		kryptonPanelMain.Controls.Add(kryptonStatusStrip);
 		kryptonPanelMain.Dock = DockStyle.Fill;
 		kryptonPanelMain.Location = new Point(0, 0);
 		kryptonPanelMain.Name = "kryptonPanelMain";
 		kryptonPanelMain.PanelBackStyle = PaletteBackStyle.FormMain;
-		kryptonPanelMain.Size = new Size(918, 620);
+		kryptonPanelMain.Size = new Size(915, 411);
 		kryptonPanelMain.TabIndex = 0;
 		kryptonPanelMain.TabStop = true;
-		// 
-		// btnStart
-		// 
-		btnStart.AccessibleDescription = "Starts the orbital resonance search for all minor planets";
-		btnStart.AccessibleName = "Start search";
-		btnStart.AccessibleRole = AccessibleRole.PushButton;
-		btnStart.Location = new Point(12, 12);
-		btnStart.Name = "btnStart";
-		btnStart.Size = new Size(90, 25);
-		btnStart.TabIndex = 0;
-		btnStart.Values.DropDownArrowColor = Color.Empty;
-		btnStart.Values.Text = "&Start Search";
-		btnStart.Click += BtnStart_Click;
-		btnStart.MouseEnter += Control_Enter;
-		btnStart.MouseLeave += Control_Leave;
-		// 
-		// btnCancel
-		// 
-		btnCancel.AccessibleDescription = "Cancels the orbital resonance search";
-		btnCancel.AccessibleName = "Cancel search";
-		btnCancel.AccessibleRole = AccessibleRole.PushButton;
-		btnCancel.Enabled = false;
-		btnCancel.Location = new Point(108, 12);
-		btnCancel.Name = "btnCancel";
-		btnCancel.Size = new Size(90, 25);
-		btnCancel.TabIndex = 1;
-		btnCancel.Values.DropDownArrowColor = Color.Empty;
-		btnCancel.Values.Text = "&Cancel";
-		btnCancel.Click += BtnCancel_Click;
-		btnCancel.MouseEnter += Control_Enter;
-		btnCancel.MouseLeave += Control_Leave;
-		// 
-		// checkBoxMercury
-		// 
-		checkBoxMercury.AccessibleDescription = "Includes Mercury in the resonance search";
-		checkBoxMercury.AccessibleName = "Mercury";
-		checkBoxMercury.Checked = true;
-		checkBoxMercury.CheckState = CheckState.Checked;
-		checkBoxMercury.Location = new Point(225, 14);
-		checkBoxMercury.Name = "checkBoxMercury";
-		checkBoxMercury.Size = new Size(110, 20);
-		checkBoxMercury.TabIndex = 2;
-		checkBoxMercury.Values.Text = "Mercury";
-		checkBoxMercury.MouseEnter += Control_Enter;
-		checkBoxMercury.MouseLeave += Control_Leave;
-		// 
-		// checkBoxVenus
-		// 
-		checkBoxVenus.AccessibleDescription = "Includes Venus in the resonance search";
-		checkBoxVenus.AccessibleName = "Venus";
-		checkBoxVenus.Checked = true;
-		checkBoxVenus.CheckState = CheckState.Checked;
-		checkBoxVenus.Location = new Point(341, 14);
-		checkBoxVenus.Name = "checkBoxVenus";
-		checkBoxVenus.Size = new Size(90, 20);
-		checkBoxVenus.TabIndex = 3;
-		checkBoxVenus.Values.Text = "Venus";
-		checkBoxVenus.MouseEnter += Control_Enter;
-		checkBoxVenus.MouseLeave += Control_Leave;
-		// 
-		// checkBoxEarth
-		// 
-		checkBoxEarth.AccessibleDescription = "Includes Earth in the resonance search";
-		checkBoxEarth.AccessibleName = "Earth";
-		checkBoxEarth.Checked = true;
-		checkBoxEarth.CheckState = CheckState.Checked;
-		checkBoxEarth.Location = new Point(437, 14);
-		checkBoxEarth.Name = "checkBoxEarth";
-		checkBoxEarth.Size = new Size(85, 20);
-		checkBoxEarth.TabIndex = 4;
-		checkBoxEarth.Values.Text = "Earth";
-		checkBoxEarth.MouseEnter += Control_Enter;
-		checkBoxEarth.MouseLeave += Control_Leave;
-		// 
-		// checkBoxMars
-		// 
-		checkBoxMars.AccessibleDescription = "Includes Mars in the resonance search";
-		checkBoxMars.AccessibleName = "Mars";
-		checkBoxMars.Checked = true;
-		checkBoxMars.CheckState = CheckState.Checked;
-		checkBoxMars.Location = new Point(528, 14);
-		checkBoxMars.Name = "checkBoxMars";
-		checkBoxMars.Size = new Size(85, 20);
-		checkBoxMars.TabIndex = 5;
-		checkBoxMars.Values.Text = "Mars";
-		checkBoxMars.MouseEnter += Control_Enter;
-		checkBoxMars.MouseLeave += Control_Leave;
-		// 
-		// checkBoxJupiter
-		// 
-		checkBoxJupiter.AccessibleDescription = "Includes Jupiter in the resonance search";
-		checkBoxJupiter.AccessibleName = "Jupiter";
-		checkBoxJupiter.Checked = true;
-		checkBoxJupiter.CheckState = CheckState.Checked;
-		checkBoxJupiter.Location = new Point(225, 40);
-		checkBoxJupiter.Name = "checkBoxJupiter";
-		checkBoxJupiter.Size = new Size(110, 20);
-		checkBoxJupiter.TabIndex = 6;
-		checkBoxJupiter.Values.Text = "Jupiter";
-		checkBoxJupiter.MouseEnter += Control_Enter;
-		checkBoxJupiter.MouseLeave += Control_Leave;
-		// 
-		// checkBoxSaturn
-		// 
-		checkBoxSaturn.AccessibleDescription = "Includes Saturn in the resonance search";
-		checkBoxSaturn.AccessibleName = "Saturn";
-		checkBoxSaturn.Checked = true;
-		checkBoxSaturn.CheckState = CheckState.Checked;
-		checkBoxSaturn.Location = new Point(341, 40);
-		checkBoxSaturn.Name = "checkBoxSaturn";
-		checkBoxSaturn.Size = new Size(90, 20);
-		checkBoxSaturn.TabIndex = 7;
-		checkBoxSaturn.Values.Text = "Saturn";
-		checkBoxSaturn.MouseEnter += Control_Enter;
-		checkBoxSaturn.MouseLeave += Control_Leave;
-		// 
-		// checkBoxUranus
-		// 
-		checkBoxUranus.AccessibleDescription = "Includes Uranus in the resonance search";
-		checkBoxUranus.AccessibleName = "Uranus";
-		checkBoxUranus.Checked = true;
-		checkBoxUranus.CheckState = CheckState.Checked;
-		checkBoxUranus.Location = new Point(437, 40);
-		checkBoxUranus.Name = "checkBoxUranus";
-		checkBoxUranus.Size = new Size(90, 20);
-		checkBoxUranus.TabIndex = 8;
-		checkBoxUranus.Values.Text = "Uranus";
-		checkBoxUranus.MouseEnter += Control_Enter;
-		checkBoxUranus.MouseLeave += Control_Leave;
-		// 
-		// checkBoxNeptune
-		// 
-		checkBoxNeptune.AccessibleDescription = "Includes Neptune in the resonance search";
-		checkBoxNeptune.AccessibleName = "Neptune";
-		checkBoxNeptune.Checked = true;
-		checkBoxNeptune.CheckState = CheckState.Checked;
-		checkBoxNeptune.Location = new Point(528, 40);
-		checkBoxNeptune.Name = "checkBoxNeptune";
-		checkBoxNeptune.Size = new Size(100, 20);
-		checkBoxNeptune.TabIndex = 9;
-		checkBoxNeptune.Values.Text = "Neptune";
-		checkBoxNeptune.MouseEnter += Control_Enter;
-		checkBoxNeptune.MouseLeave += Control_Leave;
-		// 
-		// kryptonProgressBar
-		// 
-		kryptonProgressBar.AccessibleDescription = "Shows the progress of the orbital resonance search";
-		kryptonProgressBar.AccessibleName = "Search progress";
-		kryptonProgressBar.AccessibleRole = AccessibleRole.ProgressBar;
-		kryptonProgressBar.Location = new Point(12, 72);
-		kryptonProgressBar.Name = "kryptonProgressBar";
-		kryptonProgressBar.Size = new Size(840, 23);
-		kryptonProgressBar.TabIndex = 10;
-		kryptonProgressBar.Text = "0%";
-		kryptonProgressBar.TextBackdropColor = Color.Empty;
-		kryptonProgressBar.TextShadowColor = Color.Empty;
-		kryptonProgressBar.Values.Text = "0%";
+		kryptonPanelMain.Text = "Main Panel";
+		kryptonPanelMain.Enter += Control_Enter;
+		kryptonPanelMain.Leave += Control_Leave;
+		kryptonPanelMain.MouseEnter += Control_Enter;
+		kryptonPanelMain.MouseLeave += Control_Leave;
 		// 
 		// listView
 		// 
@@ -266,21 +154,23 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		listView.AccessibleName = "Orbital resonances of all minor planets list";
 		listView.AccessibleRole = AccessibleRole.List;
 		listView.AllowColumnReorder = true;
-		listView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
 		listView.Columns.AddRange(new ColumnHeader[] { columnHeaderPlanetoid, columnHeaderPlanet, columnHeaderPlanetPeriod, columnHeaderPlanetoidPeriod, columnHeaderRatio, columnHeaderResonance, columnHeaderDeviation, columnHeaderIsResonance });
-		listView.ContextMenuStrip = contextMenuCopyToClipboard;
+		listView.ContextMenuStrip = contextMenuSaveToFile;
+		listView.Dock = DockStyle.Fill;
 		listView.Font = new Font("Segoe UI", 9F);
 		listView.FullRowSelect = true;
 		listView.GridLines = true;
-		listView.Location = new Point(12, 103);
+		listView.Location = new Point(0, 0);
 		listView.Name = "listView";
 		listView.ShowItemToolTips = true;
-		listView.Size = new Size(894, 493);
-		listView.TabIndex = 12;
+		listView.Size = new Size(915, 411);
+		listView.TabIndex = 0;
 		listView.UseCompatibleStateImageBehavior = false;
 		listView.View = View.Details;
 		listView.VirtualMode = true;
+		listView.ColumnClick += ListView_ColumnClick;
 		listView.RetrieveVirtualItem += ListView_RetrieveVirtualItem;
+		listView.DoubleClick += ListView_DoubleClick;
 		listView.Enter += Control_Enter;
 		listView.Leave += Control_Leave;
 		listView.MouseEnter += Control_Enter;
@@ -332,36 +222,581 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		columnHeaderIsResonance.TextAlign = HorizontalAlignment.Center;
 		columnHeaderIsResonance.Width = 90;
 		// 
-		// contextMenuCopyToClipboard
+		// contextMenuSaveToFile
 		// 
-		contextMenuCopyToClipboard.AccessibleDescription = "Shows the context menu for copying information to the clipboard";
-		contextMenuCopyToClipboard.AccessibleName = "Context menu for copying information to the clipboard";
-		contextMenuCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
-		contextMenuCopyToClipboard.AllowClickThrough = true;
-		contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
-		contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { toolStripMenuItemCopyToClipboard });
-		contextMenuCopyToClipboard.Name = "contextMenuCopyToClipboard";
-		contextMenuCopyToClipboard.Size = new Size(214, 26);
-		contextMenuCopyToClipboard.TabStop = true;
-		contextMenuCopyToClipboard.Text = "Copy to clipboard";
-		contextMenuCopyToClipboard.MouseEnter += Control_Enter;
-		contextMenuCopyToClipboard.MouseLeave += Control_Leave;
+		contextMenuSaveToFile.AccessibleDescription = "Save the list as file";
+		contextMenuSaveToFile.AccessibleName = "Save list";
+		contextMenuSaveToFile.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuSaveToFile.AllowClickThrough = true;
+		contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
+		contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveToFile.Name = "contextMenuSaveList";
+		contextMenuSaveToFile.OwnerItem = toolStripDropDownButtonSaveToFile;
+		contextMenuSaveToFile.Size = new Size(202, 158);
+		contextMenuSaveToFile.TabStop = true;
+		contextMenuSaveToFile.Text = "&Save list";
+		contextMenuSaveToFile.MouseEnter += Control_Enter;
+		contextMenuSaveToFile.MouseLeave += Control_Leave;
 		// 
-		// toolStripMenuItemCopyToClipboard
+		// toolStripMenuItemTextFiles
 		// 
-		toolStripMenuItemCopyToClipboard.AccessibleDescription = "Copies the selected row to the clipboard";
-		toolStripMenuItemCopyToClipboard.AccessibleName = "Copy to clipboard";
-		toolStripMenuItemCopyToClipboard.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemCopyToClipboard.AutoToolTip = true;
-		toolStripMenuItemCopyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
-		toolStripMenuItemCopyToClipboard.Name = "toolStripMenuItemCopyToClipboard";
-		toolStripMenuItemCopyToClipboard.ShortcutKeyDisplayString = "Strg+C";
-		toolStripMenuItemCopyToClipboard.ShortcutKeys = Keys.Control | Keys.C;
-		toolStripMenuItemCopyToClipboard.Size = new Size(213, 22);
-		toolStripMenuItemCopyToClipboard.Text = "&Copy to clipboard";
-		toolStripMenuItemCopyToClipboard.Click += ToolStripMenuItemCopyToClipboard_Click;
-		toolStripMenuItemCopyToClipboard.MouseEnter += Control_Enter;
-		toolStripMenuItemCopyToClipboard.MouseLeave += Control_Leave;
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.Image = FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsText
+		// 
+		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsText.AutoToolTip = true;
+		toolStripMenuItemSaveAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as &text";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsLatex
+		// 
+		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
+		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+		toolStripMenuItemSaveAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMarkdown
+		// 
+		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
+		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+		toolStripMenuItemSaveAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAsciiDoc
+		// 
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Saves the list as AsciiDoc file";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
+		toolStripMenuItemSaveAsAsciiDoc.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsReStructuredText
+		// 
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Saves the list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTextile
+		// 
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Saves the list as Textile file";
+		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
+		toolStripMenuItemSaveAsTextile.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTextile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWord
+		// 
+		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
+		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWord.AutoToolTip = true;
+		toolStripMenuItemSaveAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOdt
+		// 
+		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
+		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+		toolStripMenuItemSaveAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsRtf
+		// 
+		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
+		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+		toolStripMenuItemSaveAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsExcel
+		// 
+		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
+		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+		toolStripMenuItemSaveAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOds
+		// 
+		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
+		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOds.AutoToolTip = true;
+		toolStripMenuItemSaveAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsCsv
+		// 
+		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
+		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTsv
+		// 
+		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
+		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPsv
+		// 
+		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
+		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsHtml
+		// 
+		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
+		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXml
+		// 
+		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
+		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXml.AutoToolTip = true;
+		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook file";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsToml });
+		toolStripMenuItemConfigurationFiles.Image = FatcowIcons16px.fatcow_file_extension_bat_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsJson
+		// 
+		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
+		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsJson.AutoToolTip = true;
+		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsYaml
+		// 
+		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
+		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
+		toolStripMenuItemDatabaseScripts.Image = FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSql
+		// 
+		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
+		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSql.AutoToolTip = true;
+		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+		toolStripMenuItemSaveAsSql.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, toolStripMenuItemSaveAsXps, toolStripMenuItemSaveAsFictionBook2, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPdf
+		// 
+		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
+		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+		toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPostScript
+		// 
+		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
+		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+		toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEpub
+		// 
+		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
+		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+		toolStripMenuItemSaveAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMobi
+		// 
+		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
+		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+		toolStripMenuItemSaveAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXps
+		// 
+		toolStripMenuItemSaveAsXps.AccessibleDescription = "Saves the list as XPS file";
+		toolStripMenuItemSaveAsXps.AccessibleName = "Save as XPS";
+		toolStripMenuItemSaveAsXps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXps.AutoToolTip = true;
+		toolStripMenuItemSaveAsXps.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsFictionBook2
+		// 
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
+		toolStripMenuItemSaveAsFictionBook2.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonSaveToFile
+		// 
+		toolStripDropDownButtonSaveToFile.AccessibleDescription = "Saves information to file";
+		toolStripDropDownButtonSaveToFile.AccessibleName = "Save to file";
+		toolStripDropDownButtonSaveToFile.AccessibleRole = AccessibleRole.ButtonDropDown;
+		toolStripDropDownButtonSaveToFile.DropDown = contextMenuSaveToFile;
+		toolStripDropDownButtonSaveToFile.Image = FatcowIcons16px.fatcow_diskette_16px;
+		toolStripDropDownButtonSaveToFile.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonSaveToFile.Name = "toolStripDropDownButtonSaveToFile";
+		toolStripDropDownButtonSaveToFile.Size = new Size(93, 22);
+		toolStripDropDownButtonSaveToFile.Text = "&Save to file";
+		toolStripDropDownButtonSaveToFile.MouseEnter += Control_Enter;
+		toolStripDropDownButtonSaveToFile.MouseLeave += Control_Leave;
 		// 
 		// kryptonStatusStrip
 		// 
@@ -370,19 +805,24 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		kryptonStatusStrip.AccessibleRole = AccessibleRole.StatusBar;
 		kryptonStatusStrip.AllowClickThrough = true;
 		kryptonStatusStrip.AllowItemReorder = true;
+		kryptonStatusStrip.Dock = DockStyle.None;
 		kryptonStatusStrip.Font = new Font("Segoe UI", 9F);
 		kryptonStatusStrip.Items.AddRange(new ToolStripItem[] { labelInformation });
-		kryptonStatusStrip.Location = new Point(0, 598);
+		kryptonStatusStrip.Location = new Point(0, 0);
 		kryptonStatusStrip.Name = "kryptonStatusStrip";
 		kryptonStatusStrip.Padding = new Padding(1, 0, 16, 0);
 		kryptonStatusStrip.ProgressBars = null;
 		kryptonStatusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
 		kryptonStatusStrip.ShowItemToolTips = true;
-		kryptonStatusStrip.Size = new Size(918, 22);
+		kryptonStatusStrip.Size = new Size(915, 22);
 		kryptonStatusStrip.SizingGrip = false;
-		kryptonStatusStrip.TabIndex = 13;
+		kryptonStatusStrip.TabIndex = 0;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
+		kryptonStatusStrip.Enter += Control_Enter;
+		kryptonStatusStrip.Leave += Control_Leave;
+		kryptonStatusStrip.MouseEnter += Control_Enter;
+		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
 		// labelInformation
 		// 
@@ -395,12 +835,311 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		labelInformation.Size = new Size(144, 17);
 		labelInformation.Text = "some information here";
 		labelInformation.ToolTipText = "Shows some information";
+		labelInformation.MouseEnter += Control_Enter;
+		labelInformation.MouseLeave += Control_Leave;
 		// 
 		// kryptonManager
 		// 
 		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+		// 
+		// toolStripContainer
+		// 
+		toolStripContainer.AccessibleDescription = "Container to arrange the toolbars";
+		toolStripContainer.AccessibleName = "Container to arrange the toolbars";
+		toolStripContainer.AccessibleRole = AccessibleRole.Grouping;
+		// 
+		// toolStripContainer.BottomToolStripPanel
+		// 
+		toolStripContainer.BottomToolStripPanel.Controls.Add(kryptonStatusStrip);
+		// 
+		// toolStripContainer.ContentPanel
+		// 
+		toolStripContainer.ContentPanel.Controls.Add(kryptonPanelMain);
+		toolStripContainer.ContentPanel.Size = new Size(915, 411);
+		toolStripContainer.Dock = DockStyle.Fill;
+		toolStripContainer.Location = new Point(0, 0);
+		toolStripContainer.Name = "toolStripContainer";
+		toolStripContainer.Size = new Size(915, 484);
+		toolStripContainer.TabIndex = 2;
+		toolStripContainer.Text = "toolStripContainer";
+		// 
+		// toolStripContainer.TopToolStripPanel
+		// 
+		toolStripContainer.TopToolStripPanel.Controls.Add(toolStripIcons);
+		toolStripContainer.TopToolStripPanel.Controls.Add(toolStripProgress);
+		toolStripContainer.Enter += Control_Enter;
+		toolStripContainer.Leave += Control_Leave;
+		toolStripContainer.MouseEnter += Control_Enter;
+		toolStripContainer.MouseLeave += Control_Leave;
+		// 
+		// toolStripIcons
+		// 
+		toolStripIcons.AccessibleDescription = "Toolbar of starting and cancelling";
+		toolStripIcons.AccessibleName = "Toolbar of starting and cancelling";
+		toolStripIcons.AccessibleRole = AccessibleRole.ToolBar;
+		toolStripIcons.AllowClickThrough = true;
+		toolStripIcons.AllowItemReorder = true;
+		toolStripIcons.BackColor = Color.Transparent;
+		toolStripIcons.Dock = DockStyle.None;
+		toolStripIcons.Font = new Font("Segoe UI", 9F);
+		toolStripIcons.Items.AddRange(new ToolStripItem[] { toolStripButtonStart, toolStripButtonCancel, toolStripSeparator4, toolStripLabelPlanets, toolStripButtonMercury, toolStripButtonVenus, toolStripButtonEarth, toolStripButtonMars, toolStripButtonJupiter, toolStripButtonSaturn, toolStripButtonUranus, toolStripButtonNeptune, toolStripSeparator5, toolStripDropDownButtonSaveToFile });
+		toolStripIcons.Location = new Point(0, 0);
+		toolStripIcons.Name = "toolStripIcons";
+		toolStripIcons.Size = new Size(915, 25);
+		toolStripIcons.Stretch = true;
+		toolStripIcons.TabIndex = 0;
+		toolStripIcons.TabStop = true;
+		toolStripIcons.Text = "Toolbar of starting and cancelling";
+		toolStripIcons.Enter += Control_Enter;
+		toolStripIcons.Leave += Control_Leave;
+		toolStripIcons.MouseEnter += Control_Enter;
+		toolStripIcons.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonStart
+		// 
+		toolStripButtonStart.AccessibleDescription = "Starts the search and list";
+		toolStripButtonStart.AccessibleName = "Start search";
+		toolStripButtonStart.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonStart.Image = FatcowIcons16px.fatcow_table_16px;
+		toolStripButtonStart.ImageTransparentColor = Color.Magenta;
+		toolStripButtonStart.Name = "toolStripButtonStart";
+		toolStripButtonStart.Size = new Size(88, 22);
+		toolStripButtonStart.Text = "S&tart search";
+		toolStripButtonStart.Click += ButtonStart_Click;
+		toolStripButtonStart.MouseEnter += Control_Enter;
+		toolStripButtonStart.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonCancel
+		// 
+		toolStripButtonCancel.AccessibleDescription = "Cancels the search";
+		toolStripButtonCancel.AccessibleName = "Cancel";
+		toolStripButtonCancel.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonCancel.Image = FatcowIcons16px.fatcow_cancel_16px;
+		toolStripButtonCancel.ImageTransparentColor = Color.Magenta;
+		toolStripButtonCancel.Name = "toolStripButtonCancel";
+		toolStripButtonCancel.Size = new Size(63, 22);
+		toolStripButtonCancel.Text = "&Cancel";
+		toolStripButtonCancel.Click += ButtonCancel_Click;
+		toolStripButtonCancel.MouseEnter += Control_Enter;
+		toolStripButtonCancel.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator4
+		// 
+		toolStripSeparator4.AccessibleDescription = "Just a separator";
+		toolStripSeparator4.AccessibleName = "Just a separator";
+		toolStripSeparator4.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator4.Name = "toolStripSeparator4";
+		toolStripSeparator4.Size = new Size(6, 25);
+		toolStripSeparator4.MouseEnter += Control_Enter;
+		toolStripSeparator4.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelPlanets
+		// 
+		toolStripLabelPlanets.AccessibleDescription = "Shows the planets to comparing";
+		toolStripLabelPlanets.AccessibleName = "Planets";
+		toolStripLabelPlanets.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelPlanets.AutoToolTip = true;
+		toolStripLabelPlanets.Name = "toolStripLabelPlanets";
+		toolStripLabelPlanets.Size = new Size(45, 22);
+		toolStripLabelPlanets.Text = "&Planets";
+		toolStripLabelPlanets.MouseEnter += Control_Enter;
+		toolStripLabelPlanets.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonMercury
+		// 
+		toolStripButtonMercury.AccessibleDescription = "Enables or disables the planet Mercury";
+		toolStripButtonMercury.AccessibleName = "Mercury";
+		toolStripButtonMercury.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonMercury.Checked = true;
+		toolStripButtonMercury.CheckOnClick = true;
+		toolStripButtonMercury.CheckState = CheckState.Checked;
+		toolStripButtonMercury.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonMercury.Image = (Image)resources.GetObject("toolStripButtonMercury.Image");
+		toolStripButtonMercury.ImageTransparentColor = Color.Magenta;
+		toolStripButtonMercury.Name = "toolStripButtonMercury";
+		toolStripButtonMercury.Size = new Size(55, 22);
+		toolStripButtonMercury.Text = "&Mercury";
+		toolStripButtonMercury.MouseEnter += Control_Enter;
+		toolStripButtonMercury.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonVenus
+		// 
+		toolStripButtonVenus.AccessibleDescription = "Enables or disables the planet Venus";
+		toolStripButtonVenus.AccessibleName = "Venus";
+		toolStripButtonVenus.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonVenus.Checked = true;
+		toolStripButtonVenus.CheckOnClick = true;
+		toolStripButtonVenus.CheckState = CheckState.Checked;
+		toolStripButtonVenus.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonVenus.Image = (Image)resources.GetObject("toolStripButtonVenus.Image");
+		toolStripButtonVenus.ImageTransparentColor = Color.Magenta;
+		toolStripButtonVenus.Name = "toolStripButtonVenus";
+		toolStripButtonVenus.Size = new Size(42, 22);
+		toolStripButtonVenus.Text = "&Venus";
+		// 
+		// toolStripButtonEarth
+		// 
+		toolStripButtonEarth.AccessibleDescription = "Enables or disables the planet Earth";
+		toolStripButtonEarth.AccessibleName = "Earth";
+		toolStripButtonEarth.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonEarth.Checked = true;
+		toolStripButtonEarth.CheckOnClick = true;
+		toolStripButtonEarth.CheckState = CheckState.Checked;
+		toolStripButtonEarth.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonEarth.Image = (Image)resources.GetObject("toolStripButtonEarth.Image");
+		toolStripButtonEarth.ImageTransparentColor = Color.Magenta;
+		toolStripButtonEarth.Name = "toolStripButtonEarth";
+		toolStripButtonEarth.Size = new Size(38, 22);
+		toolStripButtonEarth.Text = "&Earth";
+		toolStripButtonEarth.MouseEnter += Control_Enter;
+		toolStripButtonEarth.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonMars
+		// 
+		toolStripButtonMars.AccessibleDescription = "Enables or disables the planet Mars";
+		toolStripButtonMars.AccessibleName = "Mars";
+		toolStripButtonMars.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonMars.Checked = true;
+		toolStripButtonMars.CheckOnClick = true;
+		toolStripButtonMars.CheckState = CheckState.Checked;
+		toolStripButtonMars.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonMars.Image = (Image)resources.GetObject("toolStripButtonMars.Image");
+		toolStripButtonMars.ImageTransparentColor = Color.Magenta;
+		toolStripButtonMars.Name = "toolStripButtonMars";
+		toolStripButtonMars.Size = new Size(37, 22);
+		toolStripButtonMars.Text = "M&ars";
+		toolStripButtonMars.MouseEnter += Control_Enter;
+		toolStripButtonMars.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonJupiter
+		// 
+		toolStripButtonJupiter.AccessibleDescription = "Enables or disables the planet Jupiter";
+		toolStripButtonJupiter.AccessibleName = "Jupiter";
+		toolStripButtonJupiter.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonJupiter.Checked = true;
+		toolStripButtonJupiter.CheckOnClick = true;
+		toolStripButtonJupiter.CheckState = CheckState.Checked;
+		toolStripButtonJupiter.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonJupiter.Image = (Image)resources.GetObject("toolStripButtonJupiter.Image");
+		toolStripButtonJupiter.ImageTransparentColor = Color.Magenta;
+		toolStripButtonJupiter.Name = "toolStripButtonJupiter";
+		toolStripButtonJupiter.Size = new Size(46, 22);
+		toolStripButtonJupiter.Text = "&Jupiter";
+		toolStripButtonJupiter.MouseEnter += Control_Enter;
+		toolStripButtonJupiter.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonSaturn
+		// 
+		toolStripButtonSaturn.AccessibleDescription = "Enables or disables the planet Saturn";
+		toolStripButtonSaturn.AccessibleName = "Saturn";
+		toolStripButtonSaturn.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonSaturn.Checked = true;
+		toolStripButtonSaturn.CheckOnClick = true;
+		toolStripButtonSaturn.CheckState = CheckState.Checked;
+		toolStripButtonSaturn.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonSaturn.Image = (Image)resources.GetObject("toolStripButtonSaturn.Image");
+		toolStripButtonSaturn.ImageTransparentColor = Color.Magenta;
+		toolStripButtonSaturn.Name = "toolStripButtonSaturn";
+		toolStripButtonSaturn.Size = new Size(45, 22);
+		toolStripButtonSaturn.Text = "Satur&n";
+		toolStripButtonSaturn.MouseEnter += Control_Enter;
+		toolStripButtonSaturn.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonUranus
+		// 
+		toolStripButtonUranus.AccessibleDescription = "Enables or disables the planet Uranus";
+		toolStripButtonUranus.AccessibleName = "Uranus";
+		toolStripButtonUranus.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonUranus.Checked = true;
+		toolStripButtonUranus.CheckOnClick = true;
+		toolStripButtonUranus.CheckState = CheckState.Checked;
+		toolStripButtonUranus.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonUranus.Image = (Image)resources.GetObject("toolStripButtonUranus.Image");
+		toolStripButtonUranus.ImageTransparentColor = Color.Magenta;
+		toolStripButtonUranus.Name = "toolStripButtonUranus";
+		toolStripButtonUranus.Size = new Size(48, 22);
+		toolStripButtonUranus.Text = "&Uranus";
+		toolStripButtonUranus.MouseEnter += Control_Enter;
+		toolStripButtonUranus.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonNeptune
+		// 
+		toolStripButtonNeptune.AccessibleDescription = "Enables or disables the planet Neptune";
+		toolStripButtonNeptune.AccessibleName = "Neptune";
+		toolStripButtonNeptune.AccessibleRole = AccessibleRole.CheckButton;
+		toolStripButtonNeptune.Checked = true;
+		toolStripButtonNeptune.CheckOnClick = true;
+		toolStripButtonNeptune.CheckState = CheckState.Checked;
+		toolStripButtonNeptune.DisplayStyle = ToolStripItemDisplayStyle.Text;
+		toolStripButtonNeptune.Image = (Image)resources.GetObject("toolStripButtonNeptune.Image");
+		toolStripButtonNeptune.ImageTransparentColor = Color.Magenta;
+		toolStripButtonNeptune.Name = "toolStripButtonNeptune";
+		toolStripButtonNeptune.Size = new Size(57, 22);
+		toolStripButtonNeptune.Text = "Nept&une";
+		toolStripButtonNeptune.MouseEnter += Control_Enter;
+		toolStripButtonNeptune.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator5
+		// 
+		toolStripSeparator5.AccessibleDescription = "Just a separator";
+		toolStripSeparator5.AccessibleName = "Just a separator";
+		toolStripSeparator5.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator5.Name = "toolStripSeparator5";
+		toolStripSeparator5.Size = new Size(6, 25);
+		toolStripSeparator5.MouseEnter += Control_Enter;
+		toolStripSeparator5.MouseLeave += Control_Leave;
+		// 
+		// toolStripProgress
+		// 
+		toolStripProgress.AccessibleDescription = "Toolbar of copying, printing and exporting";
+		toolStripProgress.AccessibleName = "Toolbar of copying, printing and exporting";
+		toolStripProgress.AccessibleRole = AccessibleRole.ToolBar;
+		toolStripProgress.AllowClickThrough = true;
+		toolStripProgress.AllowItemReorder = true;
+		toolStripProgress.BackColor = Color.Transparent;
+		toolStripProgress.Dock = DockStyle.None;
+		toolStripProgress.Font = new Font("Segoe UI", 9F);
+		toolStripProgress.Items.AddRange(new ToolStripItem[] { toolStripLabelProgress, kryptonProgressBar });
+		toolStripProgress.Location = new Point(0, 25);
+		toolStripProgress.Name = "toolStripProgress";
+		toolStripProgress.Size = new Size(915, 26);
+		toolStripProgress.Stretch = true;
+		toolStripProgress.TabIndex = 1;
+		toolStripProgress.TabStop = true;
+		toolStripProgress.Text = "Toolbar of copying, printing and exporting";
+		toolStripProgress.Enter += Control_Enter;
+		toolStripProgress.Leave += Control_Leave;
+		toolStripProgress.MouseEnter += Control_Enter;
+		toolStripProgress.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelProgress
+		// 
+		toolStripLabelProgress.AccessibleDescription = "Shows the progress of comparing";
+		toolStripLabelProgress.AccessibleName = "Progress";
+		toolStripLabelProgress.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelProgress.AutoToolTip = true;
+		toolStripLabelProgress.Name = "toolStripLabelProgress";
+		toolStripLabelProgress.Size = new Size(52, 23);
+		toolStripLabelProgress.Text = "Pro&gress";
+		toolStripLabelProgress.MouseEnter += Control_Enter;
+		toolStripLabelProgress.MouseLeave += Control_Leave;
+		// 
+		// kryptonProgressBar
+		// 
+		kryptonProgressBar.AccessibleDescription = "Shows the progress";
+		kryptonProgressBar.AccessibleName = "Progress";
+		kryptonProgressBar.AccessibleRole = AccessibleRole.ProgressBar;
+		kryptonProgressBar.AutoToolTip = true;
+		kryptonProgressBar.Name = "kryptonProgressBar";
+		kryptonProgressBar.Size = new Size(800, 23);
+		kryptonProgressBar.StateCommon.Back.Color1 = Color.Green;
+		kryptonProgressBar.StateDisabled.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.StateNormal.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.Values.Text = "";
+		kryptonProgressBar.Enter += Control_Enter;
+		kryptonProgressBar.Leave += Control_Leave;
 		// 
 		// OrbitalResonancesOfAllMinorPlanetsForm
 		// 
@@ -409,15 +1148,14 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		AccessibleRole = AccessibleRole.Dialog;
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
-		ClientSize = new Size(918, 620);
+		ClientSize = new Size(915, 484);
 		ControlBox = false;
-		Controls.Add(kryptonPanelMain);
+		Controls.Add(toolStripContainer);
 		FormBorderStyle = FormBorderStyle.FixedToolWindow;
 		Icon = (Icon)resources.GetObject("$this.Icon");
 		Margin = new Padding(4, 3, 4, 3);
 		MaximizeBox = false;
 		MinimizeBox = false;
-		MinimumSize = new Size(920, 620);
 		Name = "OrbitalResonancesOfAllMinorPlanetsForm";
 		StartPosition = FormStartPosition.CenterParent;
 		Text = "Orbital resonances of all minor planets";
@@ -425,27 +1163,26 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 		Load += OrbitalResonancesOfAllMinorPlanetsForm_Load;
 		((ISupportInitialize)kryptonPanelMain).EndInit();
 		kryptonPanelMain.ResumeLayout(false);
-		kryptonPanelMain.PerformLayout();
-		contextMenuCopyToClipboard.ResumeLayout(false);
+		contextMenuSaveToFile.ResumeLayout(false);
 		kryptonStatusStrip.ResumeLayout(false);
 		kryptonStatusStrip.PerformLayout();
+		toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
+		toolStripContainer.BottomToolStripPanel.PerformLayout();
+		toolStripContainer.ContentPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.PerformLayout();
+		toolStripContainer.ResumeLayout(false);
+		toolStripContainer.PerformLayout();
+		toolStripIcons.ResumeLayout(false);
+		toolStripIcons.PerformLayout();
+		toolStripProgress.ResumeLayout(false);
+		toolStripProgress.PerformLayout();
 		ResumeLayout(false);
 	}
 
 	#endregion
 
 	private KryptonPanel kryptonPanelMain;
-	private KryptonButton btnStart;
-	private KryptonButton btnCancel;
-	private KryptonCheckBox checkBoxMercury;
-	private KryptonCheckBox checkBoxVenus;
-	private KryptonCheckBox checkBoxEarth;
-	private KryptonCheckBox checkBoxMars;
-	private KryptonCheckBox checkBoxJupiter;
-	private KryptonCheckBox checkBoxSaturn;
-	private KryptonCheckBox checkBoxUranus;
-	private KryptonCheckBox checkBoxNeptune;
-	private KryptonProgressBar kryptonProgressBar;
 	private ListView listView;
 	private ColumnHeader columnHeaderPlanetoid;
 	private ColumnHeader columnHeaderPlanet;
@@ -455,9 +1192,66 @@ partial class OrbitalResonancesOfAllMinorPlanetsForm
 	private ColumnHeader columnHeaderResonance;
 	private ColumnHeader columnHeaderDeviation;
 	private ColumnHeader columnHeaderIsResonance;
-	private ContextMenuStrip contextMenuCopyToClipboard;
-	private ToolStripMenuItem toolStripMenuItemCopyToClipboard;
 	private KryptonStatusStrip kryptonStatusStrip;
 	private ToolStripStatusLabel labelInformation;
 	private KryptonManager kryptonManager;
+	private ToolStripContainer toolStripContainer;
+	private ToolStrip toolStripProgress;
+	private ToolStrip toolStripIcons;
+	private ToolStripButton toolStripButtonCancel;
+	private ToolStripButton toolStripButtonStart;
+	private ToolStripSeparator toolStripSeparator4;
+	private ToolStripButton toolStripButtonMercury;
+	private ToolStripButton toolStripButtonVenus;
+	private ToolStripButton toolStripButtonEarth;
+	private ToolStripButton toolStripButtonMars;
+	private ToolStripButton toolStripButtonJupiter;
+	private ToolStripButton toolStripButtonSaturn;
+	private ToolStripButton toolStripButtonUranus;
+	private ToolStripButton toolStripButtonNeptune;
+	private ToolStripSeparator toolStripSeparator5;
+	private ToolStripDropDownButton toolStripDropDownButtonSaveToFile;
+	private ToolStripLabel toolStripLabelPlanets;
+	private ToolStripLabel toolStripLabelProgress;
+	private KryptonProgressBarToolStripItem kryptonProgressBar;
+	private ContextMenuStrip contextMenuSaveToFile;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWord;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOds;
+	private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
 }

--- a/Forms/OrbitalResonancesOfAllMinorPlanetsForm.cs
+++ b/Forms/OrbitalResonancesOfAllMinorPlanetsForm.cs
@@ -20,6 +20,24 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 	/// <remarks>This logger is used throughout the form to log important events and errors.</remarks>
 	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
+	/// <summary>Cache for displaying planetoid records</summary>
+	/// <remarks>This field is used to cache planetoid records for display purposes.</remarks>
+	private readonly List<PlanetoidRecord> displayCache = [];
+
+	/// <summary>Stores the index of the currently sorted column.</summary>
+	/// <remarks>This field stores the index of the currently sorted column.</remarks>
+	private readonly int sortColumn = -1;
+
+	/// <summary>The value indicates how items in the currently sorted column are ordered:
+	/// <list type="bullet">
+	/// <item><description><see cref="SortOrder.None"/>: No sorting is applied.</description></item>
+	/// <item><description><see cref="SortOrder.Ascending"/>: Items are sorted in ascending order.</description></item>
+	/// <item><description><see cref="SortOrder.Descending"/>: Items are sorted in descending order.</description></item>
+	/// </list>
+	/// This field is typically updated when the user clicks a column header in the list view to toggle the sort order.</summary>
+	/// <remarks>This field stores the current sort order of the list view.</remarks>
+	private readonly SortOrder sortOrder = SortOrder.None;
+
 	/// <summary>The deviation threshold in percent below which an orbital ratio is considered a near-resonance.</summary>
 	/// <remarks>This value is used to determine if a computed orbital resonance is significant.</remarks>
 	private const double ResonanceThresholdPercent = 1.0;
@@ -65,48 +83,63 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 	/// <remarks>This method is primarily intended for debugging purposes.</remarks>
 	private string GetDebuggerDisplay() => ToString();
 
-	/// <summary>Returns the list of planet names currently selected via the planet checkboxes.</summary>
+	/// <summary>Prepares the save dialog for exporting data.</summary>
+	/// <param name="dialog">The file dialog to prepare.</param>
+	/// <param name="ext">The file extension.</param>
+	/// <returns>True if the dialog was shown successfully; otherwise, false.</returns>
+	/// <remarks>This method is used to prepare the save dialog for exporting data.</remarks>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"OrbitalResonancesOfAllMinorPlanets_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
+	/// <summary>Returns the list of planet names currently selected via the planet checkbuttons.</summary>
 	/// <returns>A list of planet name strings that are checked.</returns>
 	/// <remarks>Planet names match those used in <see cref="DerivedElements.CalculateOrbitalResonances"/>.</remarks>
 	private List<string> GetSelectedPlanets()
 	{
 		List<string> selected = [];
-		if (checkBoxMercury.Checked)
+		if (toolStripButtonMercury.Checked)
 		{
 			selected.Add(item: "Mercury");
 		}
 
-		if (checkBoxVenus.Checked)
+		if (toolStripButtonVenus.Checked)
 		{
 			selected.Add(item: "Venus");
 		}
 
-		if (checkBoxEarth.Checked)
+		if (toolStripButtonEarth.Checked)
 		{
 			selected.Add(item: "Earth");
 		}
 
-		if (checkBoxMars.Checked)
+		if (toolStripButtonMars.Checked)
 		{
 			selected.Add(item: "Mars");
 		}
 
-		if (checkBoxJupiter.Checked)
+		if (toolStripButtonJupiter.Checked)
 		{
 			selected.Add(item: "Jupiter");
 		}
 
-		if (checkBoxSaturn.Checked)
+		if (toolStripButtonSaturn.Checked)
 		{
 			selected.Add(item: "Saturn");
 		}
 
-		if (checkBoxUranus.Checked)
+		if (toolStripButtonUranus.Checked)
 		{
 			selected.Add(item: "Uranus");
 		}
 
-		if (checkBoxNeptune.Checked)
+		if (toolStripButtonNeptune.Checked)
 		{
 			selected.Add(item: "Neptune");
 		}
@@ -123,6 +156,42 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 		kryptonProgressBar.Value = clampedPercent;
 		kryptonProgressBar.Text = $"{clampedPercent}%";
 		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: (ulong)clampedPercent, progressMax: 100);
+	}
+
+	/// <summary>Processes one raw MPCORB database record and appends matching resonance results to <paramref name="results"/>.</summary>
+	/// <param name="line">The raw MPCORB record string.</param>
+	/// <param name="selectedPlanets">The planet names to include in the resonance comparison.</param>
+	/// <param name="results">The list to which matching <see cref="ResonanceResult"/> items are appended.</param>
+	/// <remarks>Lines that are too short or have an invalid semi-major axis are silently skipped.
+	/// Only resonances whose planet name is in <paramref name="selectedPlanets"/> are added.</remarks>
+	private static void ProcessPlanetoidLine(string line, List<string> selectedPlanets, List<ResonanceResult> results)
+	{
+		if (line.Length < 103)
+		{
+			return;
+		}
+		string semiMajorAxisText = line.Substring(startIndex: 92, length: 11).Trim();
+		if (!double.TryParse(s: semiMajorAxisText, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double semiMajorAxis) || semiMajorAxis <= 0)
+		{
+			return;
+		}
+		string designation = line.Length >= 194
+			? line.Substring(startIndex: 166, length: 28).Trim()
+			: line[..7].Trim();
+		if (string.IsNullOrEmpty(value: designation))
+		{
+			designation = line[..7].Trim();
+		}
+		// Collect all resonances for the selected planets. Any near-resonance
+		// classification (e.g. Yes/No indicators) is handled at a higher level.
+		List<DerivedElements.OrbitalResonance> resonances = DerivedElements.CalculateOrbitalResonances(semiMajorAxis: semiMajorAxis);
+		foreach (DerivedElements.OrbitalResonance resonance in resonances)
+		{
+			if (selectedPlanets.Contains(item: resonance.PlanetName))
+			{
+				results.Add(item: new ResonanceResult(PlanetoidName: designation, Resonance: resonance));
+			}
+		}
 	}
 
 	#endregion
@@ -194,7 +263,7 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
 	/// <remarks>The search runs on a background thread. Progress is reported via the progress bar.
 	/// The user can cancel at any time using the Cancel button.</remarks>
-	private async void BtnStart_Click(object sender, EventArgs e)
+	private async void ButtonStart_Click(object sender, EventArgs e)
 	{
 		List<string> selectedPlanets = GetSelectedPlanets();
 		if (selectedPlanets.Count == 0)
@@ -215,8 +284,8 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 				icon: MessageBoxIcon.Information);
 			return;
 		}
-		btnStart.Enabled = false;
-		btnCancel.Enabled = true;
+		toolStripButtonStart.Enabled = false;
+		toolStripButtonCancel.Enabled = true;
 		_results = [];
 		listView.VirtualListSize = 0;
 		UpdateProgress(percent: 0);
@@ -260,8 +329,8 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 					_results = localResults;
 					listView.VirtualListSize = _results.Count;
 					listView.Refresh();
-					btnStart.Enabled = true;
-					btnCancel.Enabled = false;
+					toolStripButtonStart.Enabled = true;
+					toolStripButtonCancel.Enabled = false;
 				}
 			}
 			catch (ObjectDisposedException)
@@ -285,12 +354,12 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 	/// <param name="sender">Event source (the button).</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
 	/// <remarks>The search can be cancelled by the user at any time using the Cancel button.</remarks>
-	private void BtnCancel_Click(object sender, EventArgs e)
+	private void ButtonCancel_Click(object sender, EventArgs e)
 	{
 		if (_cancellationTokenSource != null)
 		{
 			_cancellationTokenSource.Cancel();
-			btnCancel.Enabled = false;
+			toolStripButtonCancel.Enabled = false;
 		}
 	}
 
@@ -327,44 +396,687 @@ public partial class OrbitalResonancesOfAllMinorPlanetsForm : BaseKryptonForm
 		CopyToClipboard(text: text);
 	}
 
+	/// <summary>Saves the current list as a CSV file.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As CSV" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsCsv_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the CSV file to save the list view results; if the user confirms the save operation, call the SaveAsCsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Comma-Separated Values (*.csv)|*.csv|All Files (*.*)|*.*",
+			DefaultExt = "csv",
+			Title = "Save as CSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsCsv(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an HTML file.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As HTML" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsHtml_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the HTML file to save the list view results; if the user confirms the save operation, call the SaveAsHtml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "HTML files (*.html)|*.html|All Files (*.*)|*.*",
+			DefaultExt = "html",
+			Title = "Save as HTML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsHtml(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an XML file.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As XML" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsXml_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the XML file to save the list view results; if the user confirms the save operation, call the SaveAsXml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "XML files (*.xml)|*.xml|All Files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save as XML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsXml(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a JSON file.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As JSON" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsJson_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the JSON file to save the list view results; if the user confirms the save operation, call the SaveAsJson method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "JSON files (*.json)|*.json|All Files (*.*)|*.*",
+			DefaultExt = "json",
+			Title = "Save as JSON"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsJson(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a SQL script.
+	/// Exports the list as a series of SQL INSERT statements.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As SQL" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsSql_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the SQL file to save the list view results; if the user confirms the save operation, call the SaveAsSql method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQL scripts (*.sql)|*.sql|All Files (*.*)|*.*",
+			DefaultExt = "sql",
+			Title = "Save as SQL"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsSql(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a Markdown table.
+	/// Ideal for documentation, GitHub Readmes, or Wikis.</summary>
+	/// <param name="e">Event arguments.</param>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <remarks>This method is invoked when the user selects the "Save As Markdown" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Markdown file to save the list view results; if the user confirms the save operation, call the SaveAsMarkdown method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Markdown files (*.md)|*.md|All Files (*.*)|*.*",
+			DefaultExt = "md",
+			Title = "Save as Markdown"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsMarkdown(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the list in YAML format.
+	/// A human-readable data serialization standard.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As YAML" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsYaml_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the YAML file to save the list view results; if the user confirms the save operation, call the SaveAsYaml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "YAML files (*.yaml)|*.yaml|All Files (*.*)|*.*",
+			DefaultExt = "yaml",
+			Title = "Save as YAML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsYaml(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the list as a TSV (Tab-Separated Values) file.
+	/// Ideal for spreadsheet applications.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As TSV" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsTsv_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the TSV file to save the list view results; if the user confirms the save operation, call the SaveAsTsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Tab-Separated Values (*.tsv)|*.tsv|All Files (*.*)|*.*",
+			DefaultExt = "tsv",
+			Title = "Save as TSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsTsv(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the list as a PSV (Pipe-Separated Values) file.
+	/// Ideal for spreadsheet applications.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As PSV" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsPsv_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PSV file to save the list view results; if the user confirms the save operation, call the SaveAsPsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Pipe-Separated Values (*.psv)|*.psv|All Files (*.*)|*.*",
+			DefaultExt = "psv",
+			Title = "Save as PSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsPsv(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the list as a LaTeX document.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As LaTeX" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsLatex_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the LaTeX file to save the list view results; if the user confirms the save operation, call the SaveAsLatex method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "LaTeX files (*.tex)|*.tex|All Files (*.*)|*.*",
+			DefaultExt = "tex",
+			Title = "Save as LaTeX"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsLatex(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a PostScript (.ps) file.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As PostScript" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PostScript file to save the list view results; if the user confirms the save operation, call the SaveAsPostScript method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "PostScript files (*.ps)|*.ps|All Files (*.*)|*.*",
+			DefaultExt = "ps",
+			Title = "Save as PostScript"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsPostScript(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an uncompressed PDF file.</summary>
+	/// <param name="sender">Event source (the menu item).</param>
+	/// <param name="e">Event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As PDF" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsPdf_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PDF file to save the list view results; if the user confirms the save operation, call the SaveAsPdf method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "PDF files (*.pdf)|*.pdf|All Files (*.*)|*.*",
+			DefaultExt = "pdf",
+			Title = "Save as PDF"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsPdf(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an EPUB file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As EPUB" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsEpub_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the EPUB file to save the list view results; if the user confirms the save operation, call the SaveAsEpub method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "EPUB files (*.epub)|*.epub|All Files (*.*)|*.*",
+			DefaultExt = "epub",
+			Title = "Save as EPUB"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsEpub(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a Word document.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As Word" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsWord_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Word file to save the list view results; if the user confirms the save operation, call the SaveAsWord method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Word documents (*.docx)|*.docx|All Files (*.*)|*.*",
+			DefaultExt = "docx",
+			Title = "Save as Word"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsWord(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an Excel file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As Excel" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsExcel_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Excel file to save the list view results; if the user confirms the save operation, call the SaveAsExcel method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Excel Spreadsheet (*.xlsx)|*.xlsx|All Files (*.*)|*.*",
+			DefaultExt = "xlsx",
+			Title = "Save as Excel"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsExcel(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an ODT file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As ODT" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsOdt_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the OpenDocument Text file to save the list view results; if the user confirms the save operation, call the SaveAsOdt method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "OpenDocument Text (*.odt)|*.odt|All Files (*.*)|*.*",
+			DefaultExt = "odt",
+			Title = "Save as ODT"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsOdt(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an ODS file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As ODS" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsOds_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the OpenDocument Spreadsheet file to save the list view results; if the user confirms the save operation, call the SaveAsOds method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "OpenDocument Spreadsheet (*.ods)|*.ods|All Files (*.*)|*.*",
+			DefaultExt = "ods",
+			Title = "Save as ODS"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsOds(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a simplified MOBI file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As MOBI" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsMobi_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the MOBI file to save the list view results; if the user confirms the save operation, call the SaveAsMobi method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "MOBI files (*.mobi)|*.mobi|All Files (*.*)|*.*",
+			DefaultExt = "mobi",
+			Title = "Save as MOBI"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsMobi(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as an RTF file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As RTF" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsRtf_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Rich Text Format file to save the list view results; if the user confirms the save operation, call the SaveAsRtf method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Rich Text Format (*.rtf)|*.rtf|All Files (*.*)|*.*",
+			DefaultExt = "rtf",
+			Title = "Save as RTF"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsRtf(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Saves the current list as a text file.</summary>
+	/// <param name="sender">The event sender.</param>
+	/// <param name="e">The event arguments.</param>
+	/// <remarks>This method is invoked when the user selects the "Save As Text" menu item.</remarks>
+	private void ToolStripMenuItemSaveAsText_Click(object? sender, EventArgs? e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the text file to save the list view results; if the user confirms the save operation, call the SaveAsText method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Text files (*.txt)|*.txt|All Files (*.*)|*.*",
+			DefaultExt = "txt",
+			Title = "Save as Text"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsText(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event for the 'Save As AsciiDoc' menu item and initiates saving the ListView results in AsciiDoc
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables users to export the current ListView results as an AsciiDoc-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the AsciiDoc file to save the list view results; if the user confirms the save operation, call the SaveAsAsciiDoc method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "AsciiDoc files (*.adoc)|*.adoc|All Files (*.*)|*.*",
+			DefaultExt = "adoc",
+			Title = "Save as AsciiDoc"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsAsciiDoc(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event for the 'Save As reStructuredText' menu item and initiates saving the current ListView
+	/// results in reStructuredText format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables users to export the current ListView results as a reStructuredText-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the reStructuredText file to save the list view results; if the user confirms the save operation, call the SaveAsReStructuredText method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "reStructuredText files (*.rst)|*.rst|All Files (*.*)|*.*",
+			DefaultExt = "rst",
+			Title = "Save as reStructuredText"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsReStructuredText(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event of the 'Save As Textile' menu item and initiates saving the ListView results in Textile
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This event handler is typically connected to a ToolStripMenuItem in the user interface. It enables
+	/// users to export the current ListView results as a Textile-formatted file.</remarks>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Textile file to save the list view results; if the user confirms the save operation, call the SaveAsTextile method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Textile files (*.textile)|*.textile|All Files (*.*)|*.*",
+			DefaultExt = "textile",
+			Title = "Save as Textile"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsTextile(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event for the 'Save As Abiword' menu item and initiates saving the current list view results in
+	/// Abiword format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As Abiword" menu item, this event handler is invoked. It calls the SaveListViewResultsAsAbiword method, which generates an AWML (AbiWord XML) file with a .abw extension that can be opened in Abiword. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Abiword file to save the list view results; if the user confirms the save operation, call the SaveAsAbiword method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Abiword files (*.abw)|*.abw|All Files (*.*)|*.*",
+			DefaultExt = "abw",
+			Title = "Save as Abiword"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsAbiword(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the Save As WPS menu item and initiates saving the current ListView results in WPS
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the Save As WPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As WPS" menu item, this event handler is invoked. It calls the SaveAsWps method, which generates an HTML file with a .wps extension that can be opened in WPS Writer. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the WPS Writer file to save the list view results; if the user confirms the save operation, call the SaveAsWps method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "WPS Writer files (*.wps)|*.wps|All Files (*.*)|*.*",
+			DefaultExt = "wps",
+			Title = "Save as WPS Writer"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsWps(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the 'Save As Et' menu item and initiates saving the current ListView results in the Et
+	/// format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As Et" menu item, this event handler is invoked. It calls the SaveAsEt method, which exports the data in a format compatible with WPS Spreadsheets (using CSV internally). If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the WPS Spreadsheets file to save the list view results; if the user confirms the save operation, call the SaveAsEt method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "WPS Spreadsheets (*.et)|*.et|All Files (*.*)|*.*",
+			DefaultExt = "et",
+			Title = "Save as WPS Spreadsheets"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsEt(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event for the 'Save As DocBook' menu item, initiating the process to save the current list view
+	/// results in DocBook format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As DocBook" menu item, this event handler is invoked. It calls the SaveAsDocBook method, which generates an XML document conforming to the DocBook schema, containing the Orbital resonances. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the DocBook file to save the list view results; if the user confirms the save operation, call the SaveAsDocBook method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save as DocBook"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsDocBook(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the click event for the 'Save As TOML' menu item and initiates saving the current results in TOML format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As TOML" menu item, this event handler is invoked. It calls the SaveAsToml method, which generates the necessary TOML structure for the current results and saves it as a .toml file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the TOML file to save the list view results; if the user confirms the save operation, call the SaveAsToml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*",
+			DefaultExt = "toml",
+			Title = "Save as TOML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsToml(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the Save As XPS menu item and initiates saving the current ListView results as an XPS
+	/// document.</summary>
+	/// <param name="sender">The source of the event, typically the Save As XPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As XPS" menu item, this event handler is invoked. It calls the SaveAsXps method, which generates the necessary XML structure for an XPS document and saves it as a .xps file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the XPS file to save the list view results; if the user confirms the save operation, call the SaveAsXps method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*",
+			DefaultExt = "xps",
+			Title = "Save as XPS"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsXps(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the Save As FictionBook2 menu item and initiates saving the current results in
+	/// FictionBook2 format.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As FictionBook2" menu item, this event handler is invoked. It calls the SaveAsFictionBook2 method, which generates an XML document conforming to the FictionBook2 schema, containing the Orbital resonances. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the FictionBook2 file to save the list view results; if the user confirms the save operation, call the SaveAsFictionBook2 method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "FictionBook2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*",
+			DefaultExt = "fb2",
+			Title = "Save as FictionBook2"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsFictionBook2(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the Save As CHM menu item and initiates saving the current ListView results as a CHM
+	/// file.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As CHM" menu item, this event handler is invoked. It calls the SaveAsChm method, which generates the necessary HTML and project files, then uses Microsoft HTML Help Workshop to compile them into a CHM file. If the process is successful, a confirmation message is displayed; otherwise, an error message is shown.</remarks>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the CHM file to save the list view results; if the user confirms the save operation, call the SaveAsChm method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Compiled HTML Help (*.chm)|*.chm|All Files (*.*)|*.*",
+			DefaultExt = "chm",
+			Title = "Save as CHM"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsChm(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
+	/// <summary>Handles the Click event of the Save As SQLite menu item and initiates saving the current ListView results as a SQLite
+	/// file.</summary>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the user clicks the "Save As SQLite" menu item, this event handler is invoked. It calls the SaveAsSqlite method.</remarks>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the SQLite file to save the list view results; if the user confirms the save operation, call the SaveAsSqlite method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQLite Database (*.sqlite)|*.sqlite|All Files (*.*)|*.*",
+			DefaultExt = "sqlite",
+			Title = "Save as SQLite"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		ListViewExporter.SaveAsSqlite(listView: listView, title: "Orbital resonances", fileName: saveFileDialog.FileName);
+	}
+
 	#endregion
 
-	#region static helpers
+	#region DoubleClick event handler
 
-	/// <summary>Processes one raw MPCORB database record and appends matching resonance results to <paramref name="results"/>.</summary>
-	/// <param name="line">The raw MPCORB record string.</param>
-	/// <param name="selectedPlanets">The planet names to include in the resonance comparison.</param>
-	/// <param name="results">The list to which matching <see cref="ResonanceResult"/> items are appended.</param>
-	/// <remarks>Lines that are too short or have an invalid semi-major axis are silently skipped.
-	/// Only resonances whose planet name is in <paramref name="selectedPlanets"/> are added.</remarks>
-	private static void ProcessPlanetoidLine(string line, List<string> selectedPlanets, List<ResonanceResult> results)
+	/// <summary>Handles the ColumnClick event of the ListView.</summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>This method is called when a column header is clicked.</remarks>
+	private void ListView_ColumnClick(object sender, ColumnClickEventArgs e)
 	{
-		if (line.Length < 103)
-		{
-			return;
-		}
-		string semiMajorAxisText = line.Substring(startIndex: 92, length: 11).Trim();
-		if (!double.TryParse(s: semiMajorAxisText, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double semiMajorAxis) || semiMajorAxis <= 0)
-		{
-			return;
-		}
-		string designation = line.Length >= 194
-			? line.Substring(startIndex: 166, length: 28).Trim()
-			: line[..7].Trim();
-		if (string.IsNullOrEmpty(value: designation))
-		{
-			designation = line[..7].Trim();
-		}
-		// Collect all resonances for the selected planets. Any near-resonance
-		// classification (e.g. Yes/No indicators) is handled at a higher level.
-		List<DerivedElements.OrbitalResonance> resonances = DerivedElements.CalculateOrbitalResonances(semiMajorAxis: semiMajorAxis);
-		foreach (DerivedElements.OrbitalResonance resonance in resonances)
-		{
-			if (selectedPlanets.Contains(item: resonance.PlanetName))
-			{
-				results.Add(item: new ResonanceResult(PlanetoidName: designation, Resonance: resonance));
-			}
-		}
+		//TODO: Implement column sorting functionality when a column header is clicked; for now, throw a NotImplementedException to indicate that this feature is not yet available
+		NotImplementedException ex = new(message: "Column sorting is not implemented yet.");
+		throw ex;
+	}
+
+	#endregion
+
+	#region DoubleClick event handler
+
+	private void ListView_DoubleClick(object sender, EventArgs e)
+	{
+		//TODO: Implement double-click functionality for list view items; for now, throw a NotImplementedException to indicate that this feature is not yet available
+		NotImplementedException ex = new(message: "Double-click action is not implemented yet.");
+		throw ex;
 	}
 
 	#endregion

--- a/Forms/OrbitalResonancesOfAllMinorPlanetsForm.resx
+++ b/Forms/OrbitalResonancesOfAllMinorPlanetsForm.resx
@@ -117,22 +117,97 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>234, 17</value>
+  <metadata name="contextMenuSaveToFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>310, 17</value>
   </metadata>
-  <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>234, 17</value>
-  </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>343, 17</value>
+    <value>168, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>64</value>
+  <metadata name="toolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>633, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolStripButtonMercury.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonVenus.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonEarth.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonMars.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonJupiter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonSaturn.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonUranus.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripButtonNeptune.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPY/j27dt/SjDYACcnJ7IwigEf3n8kCZNswPNb
+        J/+f6DYF0yA+yQac6Db5f6hWCmwIiE+mC0wIu2DS2Vf/F1x6DefjwlgNyNr34r/0wkdgTMgQDAOQNRNj
+        CIoBOg0rMTTDMLIhIHbriZeYBmDTiIxBGkEYxge5liQDsGGQqykyAISpZwAlmIEywMAAAAc1/Jwvt6sN
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="toolStripProgress.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>489, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>59</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABACEAMDACAAEAAQAwAwAAFgIAACAgAgABAAEAMAEAAEYFAAAYGAIAAQABAPAAAAB2BgAAEBACAAEA


### PR DESCRIPTION
This PR redesigns the `OrbitalResonancesOfAllMinorPlanetsForm` WinForms UI by moving controls into toolstrips and adding extensive “Save to file” export options for the results list.

**Changes:**
- Replaced the old start/cancel buttons + planet checkboxes UI with a `ToolStripContainer` hosting toolstrips (actions, planet toggles, progress).
- Added a “Save to file” context menu and toolbar dropdown with many export format entries.
- Hooked up new ListView interaction events (column click, double click) in the designer.