### PR TITLE
Improveed button disabling/enabling

### DIFF
--- a/Forms/AsteroidFamiliesForm.Designer.cs
+++ b/Forms/AsteroidFamiliesForm.Designer.cs
@@ -105,6 +105,7 @@ partial class AsteroidFamiliesForm
 		toolStripButtonGoToObject.AccessibleDescription = "Navigates to the selected planetoid in the main form and closes this window";
 		toolStripButtonGoToObject.AccessibleName = "Go to object";
 		toolStripButtonGoToObject.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonGoToObject.Enabled = false;
 		toolStripButtonGoToObject.Image = Resources.FatcowIcons16px.fatcow_application_go_16px;
 		toolStripButtonGoToObject.ImageTransparentColor = Color.Magenta;
 		toolStripButtonGoToObject.Name = "toolStripButtonGoToObject";
@@ -201,8 +202,8 @@ partial class AsteroidFamiliesForm
 		listViewMembers.UseCompatibleStateImageBehavior = false;
 		listViewMembers.View = View.Details;
 		listViewMembers.VirtualMode = true;
-		listViewMembers.RetrieveVirtualItem += ListView_RetrieveVirtualItem;
 		listViewMembers.ColumnClick += ListViewMembers_ColumnClick;
+		listViewMembers.RetrieveVirtualItem += ListView_RetrieveVirtualItem;
 		listViewMembers.DoubleClick += ListViewMembers_DoubleClick;
 		listViewMembers.Enter += Control_Enter;
 		listViewMembers.Leave += Control_Leave;
@@ -361,6 +362,7 @@ partial class AsteroidFamiliesForm
 		toolStripButtonCancel.AccessibleDescription = "Cancels the asteroid families detection";
 		toolStripButtonCancel.AccessibleName = "Cancel";
 		toolStripButtonCancel.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonCancel.Enabled = false;
 		toolStripButtonCancel.Image = Resources.FatcowIcons16px.fatcow_cancel_16px;
 		toolStripButtonCancel.ImageTransparentColor = Color.Magenta;
 		toolStripButtonCancel.Name = "toolStripButtonCancel";
@@ -385,6 +387,7 @@ partial class AsteroidFamiliesForm
 		toolStripButtonSaveListSelectedFamily.AccessibleDescription = "Saves the members of a potential asteroid family into a text file";
 		toolStripButtonSaveListSelectedFamily.AccessibleName = "Save the family members into a text file";
 		toolStripButtonSaveListSelectedFamily.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonSaveListSelectedFamily.Enabled = false;
 		toolStripButtonSaveListSelectedFamily.Image = Resources.FatcowIcons16px.fatcow_diskette_16px;
 		toolStripButtonSaveListSelectedFamily.ImageTransparentColor = Color.Magenta;
 		toolStripButtonSaveListSelectedFamily.Name = "toolStripButtonSaveListSelectedFamily";
@@ -399,6 +402,7 @@ partial class AsteroidFamiliesForm
 		toolStripButtonSaveListAllFamilies.AccessibleDescription = "Saves all potential asteroid families into a text file";
 		toolStripButtonSaveListAllFamilies.AccessibleName = "Save all into a text file";
 		toolStripButtonSaveListAllFamilies.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonSaveListAllFamilies.Enabled = false;
 		toolStripButtonSaveListAllFamilies.Image = Resources.FatcowIcons16px.fatcow_disk_multiple_16px;
 		toolStripButtonSaveListAllFamilies.ImageTransparentColor = Color.Magenta;
 		toolStripButtonSaveListAllFamilies.Name = "toolStripButtonSaveListAllFamilies";

--- a/Forms/AsteroidFamiliesForm.Designer.cs
+++ b/Forms/AsteroidFamiliesForm.Designer.cs
@@ -205,6 +205,7 @@ partial class AsteroidFamiliesForm
 		listViewMembers.ColumnClick += ListViewMembers_ColumnClick;
 		listViewMembers.RetrieveVirtualItem += ListView_RetrieveVirtualItem;
 		listViewMembers.DoubleClick += ListViewMembers_DoubleClick;
+		listViewMembers.ItemSelectionChanged += ListViewMembers_ItemSelectionChanged;
 		listViewMembers.Enter += Control_Enter;
 		listViewMembers.Leave += Control_Leave;
 		listViewMembers.MouseEnter += Control_Enter;

--- a/Forms/AsteroidFamiliesForm.cs
+++ b/Forms/AsteroidFamiliesForm.cs
@@ -148,11 +148,12 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 	/// <remarks>This method is called when the Cancel button is clicked to stop the ongoing detection process.</remarks>
 	private void ToolStripButtonCancel_Click(object? sender, EventArgs e)
 	{
-		// If a cancellation token source exists, signal cancellation and disable the Cancel button to prevent multiple clicks.
+		// If a cancellation token source exists, signal cancellation to stop the detection process. Also disable the Cancel button and re-enable the Start button to allow the user to start a new detection if desired.
 		if (_cancellationTokenSource != null)
 		{
 			_cancellationTokenSource.Cancel();
 			toolStripButtonCancel.Enabled = false;
+			toolStripButtonStartSearch.Enabled = true;
 		}
 	}
 
@@ -278,12 +279,12 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 			// After filtering and building the family list, we check for cancellation one last time before updating the UI with the results and report that we have reached 100% progress.
 			cancellationToken.ThrowIfCancellationRequested();
 			progress.Report(value: 100);
-			// We use InvokeAsync to marshal the update back to the UI thread, where we set the _families field to the detected families, populate the tree view with the new data, and enable the Save All button if any families were found.
+			// We use InvokeAsync to marshal the update back to the UI thread, where we set the _families field to the detected families, populate the tree view with the new data, and enable the save buttons if any families were detected.
 			await InvokeAsync(callback: () =>
 			{
 				_families = families;
 				PopulateTreeView();
-				toolStripButtonSaveListAllFamilies.Enabled = _families.Count > 0;
+				toolStripButtonSaveListAllFamilies.Enabled = toolStripButtonSaveListSelectedFamily.Enabled = toolStripButtonGoToObject.Enabled = _families.Count > 0;
 			}, cancellationToken: cancellationToken);
 		}
 		// We catch OperationCanceledException to handle the case where the detection was cancelled by the user. In this case, we simply ignore the exception since cancellation is an expected outcome.

--- a/Forms/AsteroidFamiliesForm.cs
+++ b/Forms/AsteroidFamiliesForm.cs
@@ -110,11 +110,12 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 				icon: KryptonMessageBoxIcon.Information);
 			return;
 		}
-		// Disable the Start button and enable the Cancel button while detection is in progress. Also disable save buttons until results are available.
+		// Disable the Start button and enable the Cancel button while detection is in progress. Also disable save and navigation buttons until results are available.
 		toolStripButtonStartSearch.Enabled = false;
 		toolStripButtonCancel.Enabled = true;
 		toolStripButtonSaveListSelectedFamily.Enabled = false;
 		toolStripButtonSaveListAllFamilies.Enabled = false;
+		toolStripButtonGoToObject.Enabled = false;
 		// Clear previous results and reset progress indicators.
 		treeViewFamilies.Nodes.Clear();
 		listViewMembers.VirtualListSize = 0;
@@ -148,12 +149,11 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 	/// <remarks>This method is called when the Cancel button is clicked to stop the ongoing detection process.</remarks>
 	private void ToolStripButtonCancel_Click(object? sender, EventArgs e)
 	{
-		// If a cancellation token source exists, signal cancellation to stop the detection process. Also disable the Cancel button and re-enable the Start button to allow the user to start a new detection if desired.
+		// If a cancellation token source exists, signal cancellation to stop the detection process and disable the Cancel button. The Start button will be re-enabled by the finally block in PerformDetectionAsync once the background task has fully completed, preventing a new run from starting while the previous one is still unwinding.
 		if (_cancellationTokenSource != null)
 		{
 			_cancellationTokenSource.Cancel();
 			toolStripButtonCancel.Enabled = false;
-			toolStripButtonStartSearch.Enabled = true;
 		}
 	}
 
@@ -279,12 +279,12 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 			// After filtering and building the family list, we check for cancellation one last time before updating the UI with the results and report that we have reached 100% progress.
 			cancellationToken.ThrowIfCancellationRequested();
 			progress.Report(value: 100);
-			// We use InvokeAsync to marshal the update back to the UI thread, where we set the _families field to the detected families, populate the tree view with the new data, and enable the save buttons if any families were detected.
+			// We use InvokeAsync to marshal the update back to the UI thread, where we set the _families field to the detected families, populate the tree view with the new data, and enable the Save All button if any families were detected. Save Selected and Go to object remain disabled until the user selects a family or a member.
 			await InvokeAsync(callback: () =>
 			{
 				_families = families;
 				PopulateTreeView();
-				toolStripButtonSaveListAllFamilies.Enabled = toolStripButtonSaveListSelectedFamily.Enabled = toolStripButtonGoToObject.Enabled = _families.Count > 0;
+				toolStripButtonSaveListAllFamilies.Enabled = _families.Count > 0;
 			}, cancellationToken: cancellationToken);
 		}
 		// We catch OperationCanceledException to handle the case where the detection was cancelled by the user. In this case, we simply ignore the exception since cancellation is an expected outcome.
@@ -361,6 +361,8 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 			listViewMembers.VirtualListSize = _selectedFamily.Members.Count;
 			listViewMembers.Invalidate();
 			toolStripButtonSaveListSelectedFamily.Enabled = true;
+			// No member is selected yet in the new family — disable Go to object until a member is chosen.
+			toolStripButtonGoToObject.Enabled = false;
 		}
 	}
 
@@ -597,6 +599,17 @@ public partial class AsteroidFamiliesForm : BaseKryptonForm
 	/// in the <see cref="PlanetoidDbForm"/> without closing this form.</remarks>
 	private void ListViewMembers_DoubleClick(object? sender, EventArgs e) =>
 		NavigateToSelectedMember(closeAfterNavigation: false);
+
+	#endregion
+
+	#region ItemSelectionChanged event handler
+
+	/// <summary>Handles the ItemSelectionChanged event of the member ListView.</summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The event data.</param>
+	/// <remarks>Enables the 'Go to object' toolbar button when at least one member is selected, and disables it when the selection is cleared.</remarks>
+	private void ListViewMembers_ItemSelectionChanged(object? sender, ListViewItemSelectionChangedEventArgs e) =>
+		toolStripButtonGoToObject.Enabled = listViewMembers.SelectedIndices.Count > 0;
 
 	#endregion
 


### PR DESCRIPTION
This PR adjusts the initial enabled/disabled state of several toolbar buttons in `AsteroidFamiliesForm` and updates the runtime logic that toggles these buttons during/after asteroid family detection.

**Changes:**
- Initialize several ToolStrip buttons as disabled in the designer (Go to object / Cancel / Save selected / Save all).
- Update Cancel-click handling to toggle Start/Cancel enabled state.
- Update post-detection UI update to enable multiple buttons based on whether any families were detected.