### PR TITLE
Redesigned `GoToObject` button in `ListReadableDesignationsForm`

### DIFF
--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -104,7 +104,7 @@ partial class ListReadableDesignationsForm
 		toolStripLabelMaximum = new ToolStripLabel();
 		toolStripNumericUpDownMaximum = new Planetoid_DB.Helpers.ToolStripNumericUpDown();
 		kryptonToolStripSaveList = new KryptonToolStrip();
-		toolStripButtonLoad = new ToolStripButton();
+		toolStripButtonGoToObject = new ToolStripButton();
 		toolStripSeparator2 = new ToolStripSeparator();
 		kryptonStatusStrip.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
@@ -971,7 +971,7 @@ partial class ListReadableDesignationsForm
 		kryptonToolStripSaveList.AllowItemReorder = true;
 		kryptonToolStripSaveList.Dock = DockStyle.None;
 		kryptonToolStripSaveList.Font = new Font("Segoe UI", 9F);
-		kryptonToolStripSaveList.Items.AddRange(new ToolStripItem[] { toolStripButtonLoad, toolStripSeparator2, toolStripDropDownButtonSaveList });
+		kryptonToolStripSaveList.Items.AddRange(new ToolStripItem[] { toolStripButtonGoToObject, toolStripSeparator2, toolStripDropDownButtonSaveList });
 		kryptonToolStripSaveList.Location = new Point(0, 26);
 		kryptonToolStripSaveList.Name = "kryptonToolStripSaveList";
 		kryptonToolStripSaveList.Size = new Size(341, 25);
@@ -983,19 +983,19 @@ partial class ListReadableDesignationsForm
 		kryptonToolStripSaveList.MouseEnter += Control_Enter;
 		kryptonToolStripSaveList.MouseLeave += Control_Leave;
 		// 
-		// toolStripButtonLoad
+		// toolStripButtonGoToObject
 		// 
-		toolStripButtonLoad.AccessibleDescription = "Loads the selected planetoid";
-		toolStripButtonLoad.AccessibleName = "Load";
-		toolStripButtonLoad.AccessibleRole = AccessibleRole.PushButton;
-		toolStripButtonLoad.Image = FatcowIcons16px.fatcow_bullet_go_16px;
-		toolStripButtonLoad.ImageTransparentColor = Color.Magenta;
-		toolStripButtonLoad.Name = "toolStripButtonLoad";
-		toolStripButtonLoad.Size = new Size(53, 22);
-		toolStripButtonLoad.Text = "L&oad";
-		toolStripButtonLoad.Click += ToolStripButtonLoad_Click;
-		toolStripButtonLoad.MouseEnter += Control_Enter;
-		toolStripButtonLoad.MouseLeave += Control_Leave;
+		toolStripButtonGoToObject.AccessibleDescription = "Goes to the selected planetoid";
+		toolStripButtonGoToObject.AccessibleName = "Go to object";
+		toolStripButtonGoToObject.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonGoToObject.Image = FatcowIcons16px.fatcow_application_go_16px;
+		toolStripButtonGoToObject.ImageTransparentColor = Color.Magenta;
+		toolStripButtonGoToObject.Name = "toolStripButtonGoToObject";
+		toolStripButtonGoToObject.Size = new Size(92, 22);
+		toolStripButtonGoToObject.Text = "G&o to object";
+		toolStripButtonGoToObject.Click += ToolStripButtonGoToObject_Click;
+		toolStripButtonGoToObject.MouseEnter += Control_Enter;
+		toolStripButtonGoToObject.MouseLeave += Control_Leave;
 		// 
 		// toolStripSeparator2
 		// 
@@ -1074,7 +1074,7 @@ partial class ListReadableDesignationsForm
 	private KryptonToolStrip kryptonToolStripGenerateList;
 	private ToolStripButton toolStripButtonCreateList;
 	private KryptonToolStrip kryptonToolStripSaveList;
-	private ToolStripButton toolStripButtonLoad;
+	private ToolStripButton toolStripButtonGoToObject;
 	private ToolStripSeparator toolStripSeparator1;
 	private Helpers.ToolStripNumericUpDown toolStripNumericUpDownMinimum;
 	private ToolStripLabel toolStripLabelMinimum;

--- a/Forms/ListReadableDesignationsForm.Designer.cs
+++ b/Forms/ListReadableDesignationsForm.Designer.cs
@@ -988,11 +988,12 @@ partial class ListReadableDesignationsForm
 		toolStripButtonGoToObject.AccessibleDescription = "Goes to the selected planetoid";
 		toolStripButtonGoToObject.AccessibleName = "Go to object";
 		toolStripButtonGoToObject.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonGoToObject.Enabled = false;
 		toolStripButtonGoToObject.Image = FatcowIcons16px.fatcow_application_go_16px;
 		toolStripButtonGoToObject.ImageTransparentColor = Color.Magenta;
 		toolStripButtonGoToObject.Name = "toolStripButtonGoToObject";
 		toolStripButtonGoToObject.Size = new Size(92, 22);
-		toolStripButtonGoToObject.Text = "G&o to object";
+		toolStripButtonGoToObject.Text = "&Go to object";
 		toolStripButtonGoToObject.Click += ToolStripButtonGoToObject_Click;
 		toolStripButtonGoToObject.MouseEnter += Control_Enter;
 		toolStripButtonGoToObject.MouseLeave += Control_Leave;

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -248,7 +248,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Update the status bar with the selected item's details
 		SetStatusBar(label: labelInformation, text: $"{I18nStrings.Index}: {item.Text} - {item.SubItems[index: 1].Text}");
 		// Enable the load button
-		toolStripButtonLoad.Enabled = true;
+		toolStripButtonGoToObject.Enabled = true;
 		selectedIndex = index;
 	}
 
@@ -267,7 +267,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Clear the status bar on load
 		ClearStatusBar(label: labelInformation);
 		// Disable controls until data is available
-		labelInformation.Enabled = listView.Visible = toolStripButtonLoad.Enabled = toolStripDropDownButtonSaveList.Enabled = false;
+		labelInformation.Enabled = listView.Visible = toolStripButtonGoToObject.Enabled = toolStripDropDownButtonSaveList.Enabled = false;
 		// Check if the planetoids database is empty
 		if (planetoidsDatabase.Count <= 0)
 		{
@@ -517,12 +517,12 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>Handles the Click event of the Load button on the tool strip, initiating the selection of a planetoid and,
+	/// <summary>Handles the Click event of the Go To Object button on the tool strip, initiating the selection of a planetoid and,
 	/// when successful, closing the current form.</summary>
-	/// <param name="sender">The source of the event, typically the Load button on the tool strip.</param>
+	/// <param name="sender">The source of the event, typically the Go To Object button on the tool strip.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	/// <remarks>When the Load button is clicked, this method calls the SelectPlanetoidInMainForm method to navigate to the selected planetoid record in the main form. After initiating the selection, it closes the current form to return control to the main form, and sets the dialog result to <see cref="DialogResult.OK"/> to signal a successful selection.</remarks>
-	private void ToolStripButtonLoad_Click(object sender, EventArgs e)
+	/// <remarks>When the Go To Object button is clicked, this method calls the SelectPlanetoidInMainForm method to navigate to the selected planetoid record in the main form. After initiating the selection, it closes the current form to return control to the main form, and sets the dialog result to <see cref="DialogResult.OK"/> to signal a successful selection.</remarks>
+	private void ToolStripButtonGoToObject_Click(object sender, EventArgs e)
 	{
 		// Select the planetoid in the main form
 		SelectPlanetoidInMainForm();

--- a/Forms/ListReadableDesignationsForm.cs
+++ b/Forms/ListReadableDesignationsForm.cs
@@ -178,14 +178,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 
 	/// <summary>Selects the currently highlighted planetoid in the list view and navigates to its corresponding record in the main
 	/// form.</summary>
-	/// <remarks>If no item is selected or the selected record is invalid, the method does nothing. When a valid
+	/// <remarks>If no item is selected or the selected record is invalid, the method returns <c>false</c> without performing any action. When a valid
 	/// planetoid is selected, the main form is brought to the foreground and displays the details of the selected
 	/// planetoid.</remarks>
-	private void SelectPlanetoidInMainForm()
+	/// <returns><c>true</c> if navigation to the selected planetoid succeeded; otherwise, <c>false</c>.</returns>
+	private bool SelectPlanetoidInMainForm()
 	{
 		if (listView.SelectedIndices.Count == 0)
 		{
-			return;
+			return false;
 		}
 		int selectedIndex = listView.SelectedIndices[index: 0];
 		// Calculate the real database index (considering virtual mode offset and sorting)
@@ -195,7 +196,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Check if the index is valid
 		if (dbIndex < 0 || dbIndex >= planetoidsDatabase.Count)
 		{
-			return;
+			return false;
 		}
 		// Get the record string
 		string currentData = planetoidsDatabase[index: dbIndex];
@@ -204,7 +205,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		{
 			// If parsing fails, show an error message and return
 			_ = MessageBox.Show(text: "Invalid record format.", caption: I18nStrings.ErrorCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
-			return;
+			return false;
 		}
 		// Jump to the record in the main form
 		if (Application.OpenForms.OfType<PlanetoidDbForm>().FirstOrDefault() is PlanetoidDbForm mainForm)
@@ -212,6 +213,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 			mainForm.JumpToRecord(index: strIndex, designation: strDesignation);
 			mainForm.BringToFront();
 		}
+		return true;
 	}
 
 	/// <summary>Prepares the save dialog for exporting data.</summary>
@@ -231,7 +233,7 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 
 	/// <summary>Handles the ListView <c>SelectedIndexChanged</c> event.
 	/// Updates the status bar with the selected planetoid's index and readable designation,
-	/// enables the load button if necessary and stores the currently selected index.</summary>
+	/// enables the Go to object button if necessary and stores the currently selected index.</summary>
 	/// <param name="sender">Event source (expected to be the list view).</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to handle the SelectedIndexChanged event of the ListView.</remarks>
@@ -240,14 +242,23 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 		// Check if there are any selected indices
 		if (listView.SelectedIndices.Count <= 0)
 		{
+			SetStatusBar(label: labelInformation, text: string.Empty);
+			toolStripButtonGoToObject.Enabled = false;
 			return;
 		}
-		// Get the selected index and item
+		// Get the selected virtual index
 		int index = listView.SelectedIndices[index: 0];
-		ListViewItem item = listView.Items[index: index];
-		// Update the status bar with the selected item's details
-		SetStatusBar(label: labelInformation, text: $"{I18nStrings.Index}: {item.Text} - {item.SubItems[index: 1].Text}");
-		// Enable the load button
+		// Calculate the real database index (considering virtual mode offset and sorting)
+		int dbIndex = listView.VirtualMode
+			? (sortedIndices != null && index < sortedIndices.Count ? sortedIndices[index: index] : virtualListOffset + index)
+			: index;
+		// Derive display text from the backing data to avoid accessing Items in virtual mode
+		if (dbIndex >= 0 && dbIndex < planetoidsDatabase.Count &&
+			TryParsePlanetoidRecord(record: planetoidsDatabase[index: dbIndex], recordIndex: dbIndex, parsedIndex: out string strIndex, parsedDesignation: out string strDesignation))
+		{
+			SetStatusBar(label: labelInformation, text: $"{I18nStrings.Index}: {strIndex} - {strDesignation}");
+		}
+		// Enable the Go to object button
 		toolStripButtonGoToObject.Enabled = true;
 		selectedIndex = index;
 	}
@@ -521,14 +532,15 @@ public partial class ListReadableDesignationsForm : BaseKryptonForm
 	/// when successful, closing the current form.</summary>
 	/// <param name="sender">The source of the event, typically the Go To Object button on the tool strip.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	/// <remarks>When the Go To Object button is clicked, this method calls the SelectPlanetoidInMainForm method to navigate to the selected planetoid record in the main form. After initiating the selection, it closes the current form to return control to the main form, and sets the dialog result to <see cref="DialogResult.OK"/> to signal a successful selection.</remarks>
+	/// <remarks>When the Go To Object button is clicked, this method calls the SelectPlanetoidInMainForm method to navigate to the selected planetoid record in the main form. Only if navigation succeeds, it closes the current form and sets the dialog result to <see cref="DialogResult.OK"/> to signal a successful selection.</remarks>
 	private void ToolStripButtonGoToObject_Click(object sender, EventArgs e)
 	{
-		// Select the planetoid in the main form
-		SelectPlanetoidInMainForm();
-		// Set the dialog result to OK and close the form
-		DialogResult = DialogResult.OK;
-		Close();
+		// Select the planetoid in the main form; only close if navigation succeeded
+		if (SelectPlanetoidInMainForm())
+		{
+			DialogResult = DialogResult.OK;
+			Close();
+		}
 	}
 
 	/// <summary>Saves the current list as a CSV file.</summary>


### PR DESCRIPTION
# Pull request overview

Updates `ListReadableDesignationsForm` to rename and restyle the toolbar action previously labeled “Load” into a clearer “Go to object” action, aligning the UI intent with navigation behavior in the app.

**Changes:**
- Replaced `toolStripButtonLoad` with `toolStripButtonGoToObject` (text, icon, accessible metadata, click handler).
- Updated selection-changed logic and form-load initial enable/disable state to use the renamed button.
- Renamed the click handler to `ToolStripButtonGoToObject_Click` and updated related remarks.