### PR TITLE
Added missing functions in `CheckDatabaseForm`

### DIFF
--- a/Forms/CheckDatabaseForm.Designer.cs
+++ b/Forms/CheckDatabaseForm.Designer.cs
@@ -4,7 +4,6 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 using Krypton.Toolkit;
-using Krypton.Toolkit.Suite.Extended.Tool.Strip.Items;
 
 using Planetoid_DB.Resources;
 

--- a/Forms/CheckDatabaseForm.Designer.cs
+++ b/Forms/CheckDatabaseForm.Designer.cs
@@ -4,6 +4,7 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 using Krypton.Toolkit;
+using Krypton.Toolkit.Suite.Extended.Tool.Strip.Items;
 
 using Planetoid_DB.Resources;
 
@@ -54,12 +55,10 @@ partial class CheckDatabaseForm
 		labelModifiedDateValueOnline = new KryptonLabel();
 		tableLayoutPanel = new KryptonTableLayoutPanel();
 		toolStripContainer = new ToolStripContainer();
-		kryptonStatusStrip = new KryptonStatusStrip();
+		kryptonStatusStrip = new Krypton.Toolkit.KryptonStatusStrip();
 		labelInformation = new ToolStripStatusLabel();
-		kryptonManager = new KryptonManager(components);
 		toolStripIcons = new ToolStrip();
 		toolStripDropDownButtonSaveToFile = new ToolStripDropDownButton();
-		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		contextMenuSaveToFile = new ContextMenuStrip(components);
 		toolStripMenuItemTextFiles = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
@@ -100,11 +99,13 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
 		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
+		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		contextMenuFullCopyToClipboard = new ContextMenuStrip(components);
-		menuitemCopyToClipboardLinearEccentricity = new ToolStripMenuItem();
-		menuitemCopyToClipboardSemiMinorAxis = new ToolStripMenuItem();
-		menuitemCopyToClipboardMajorAxis = new ToolStripMenuItem();
-		menuitemCopyToClipboardMinorAxis = new ToolStripMenuItem();
+		menuitemCopyToClipboardDatabaseLocalModifiedDate = new ToolStripMenuItem();
+		menuitemCopyToClipboardDatabaseLocalContentLength = new ToolStripMenuItem();
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate = new ToolStripMenuItem();
+		menuitemCopyToClipboardDatabaseOnlineContentLength = new ToolStripMenuItem();
+		kryptonManager = new KryptonManager(components);
 		contextMenuCopyToClipboard.SuspendLayout();
 		tableLayoutPanel.SuspendLayout();
 		toolStripContainer.BottomToolStripPanel.SuspendLayout();
@@ -423,6 +424,10 @@ partial class CheckDatabaseForm
 		kryptonStatusStrip.TabIndex = 0;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
+		kryptonStatusStrip.Enter += Control_Enter;
+		kryptonStatusStrip.Leave += Control_Leave;
+		kryptonStatusStrip.MouseEnter += Control_Enter;
+		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
 		// labelInformation
 		// 
@@ -435,12 +440,8 @@ partial class CheckDatabaseForm
 		labelInformation.Size = new Size(144, 17);
 		labelInformation.Text = "some information here";
 		labelInformation.ToolTipText = "Shows some information";
-		// 
-		// kryptonManager
-		// 
-		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
-		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
-		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+		labelInformation.MouseEnter += Control_Enter;
+		labelInformation.MouseLeave += Control_Leave;
 		// 
 		// toolStripIcons
 		// 
@@ -460,6 +461,8 @@ partial class CheckDatabaseForm
 		toolStripIcons.TabIndex = 1;
 		toolStripIcons.TabStop = true;
 		toolStripIcons.Text = "Toolbar of copying, printing and exporting";
+		toolStripIcons.MouseEnter += Control_Enter;
+		toolStripIcons.MouseLeave += Control_Leave;
 		// 
 		// toolStripDropDownButtonSaveToFile
 		// 
@@ -472,18 +475,8 @@ partial class CheckDatabaseForm
 		toolStripDropDownButtonSaveToFile.Name = "toolStripDropDownButtonSaveToFile";
 		toolStripDropDownButtonSaveToFile.Size = new Size(93, 22);
 		toolStripDropDownButtonSaveToFile.Text = "&Save to file";
-		// 
-		// toolStripDropDownButtonCopyToClipboard
-		// 
-		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies information to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.ButtonDropDown;
-		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboard;
-		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
-		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
-		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
-		toolStripDropDownButtonCopyToClipboard.Size = new Size(131, 22);
-		toolStripDropDownButtonCopyToClipboard.Text = "&Copy to clipboard";
+		toolStripDropDownButtonSaveToFile.MouseEnter += Control_Enter;
+		toolStripDropDownButtonSaveToFile.MouseLeave += Control_Leave;
 		// 
 		// contextMenuSaveToFile
 		// 
@@ -494,9 +487,12 @@ partial class CheckDatabaseForm
 		contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
 		contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
 		contextMenuSaveToFile.Name = "contextMenuSaveList";
-		contextMenuSaveToFile.Size = new Size(202, 158);
+		contextMenuSaveToFile.OwnerItem = toolStripDropDownButtonSaveToFile;
+		contextMenuSaveToFile.Size = new Size(202, 180);
 		contextMenuSaveToFile.TabStop = true;
 		contextMenuSaveToFile.Text = "&Save list";
+		contextMenuSaveToFile.MouseEnter += Control_Enter;
+		contextMenuSaveToFile.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemTextFiles
 		// 
@@ -509,6 +505,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
 		toolStripMenuItemTextFiles.Size = new Size(201, 22);
 		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsText
 		// 
@@ -520,6 +518,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
 		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsText.Text = "Save as &text";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsLatex
 		// 
@@ -531,6 +532,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
 		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsMarkdown
 		// 
@@ -542,6 +546,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
 		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsAsciiDoc
 		// 
@@ -553,6 +560,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
 		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsReStructuredText
 		// 
@@ -564,6 +574,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
 		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsTextile
 		// 
@@ -575,6 +588,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
 		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
 		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTextile.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemWriterDocuments
 		// 
@@ -587,6 +603,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
 		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
 		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsWord
 		// 
@@ -598,6 +616,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
 		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
 		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsOdt
 		// 
@@ -609,6 +630,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
 		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
 		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsRtf
 		// 
@@ -620,6 +644,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
 		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
 		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsAbiword
 		// 
@@ -631,6 +658,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
 		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
 		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsWps
 		// 
@@ -642,6 +672,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
 		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
 		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSpreadsheetDocuments
 		// 
@@ -654,6 +687,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
 		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
 		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsExcel
 		// 
@@ -665,6 +700,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
 		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsOds
 		// 
@@ -676,6 +714,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
 		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsCsv
 		// 
@@ -687,6 +728,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
 		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsTsv
 		// 
@@ -698,6 +742,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
 		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsPsv
 		// 
@@ -709,6 +756,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
 		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsEt
 		// 
@@ -720,6 +770,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
 		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
 		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemXmlDocuments
 		// 
@@ -732,6 +785,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
 		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
 		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsHtml
 		// 
@@ -741,8 +796,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
 		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
-		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsXml
 		// 
@@ -752,8 +810,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsXml.AutoToolTip = true;
 		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
-		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsDocBook
 		// 
@@ -763,8 +824,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
 		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
 		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
-		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemConfigurationFiles
 		// 
@@ -777,6 +841,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
 		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
 		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsJson
 		// 
@@ -786,8 +852,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsJson.AutoToolTip = true;
 		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
-		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsYaml
 		// 
@@ -797,8 +866,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
 		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
-		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsToml
 		// 
@@ -808,8 +880,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsToml.AutoToolTip = true;
 		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
 		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
-		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemDatabaseScripts
 		// 
@@ -822,6 +897,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
 		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
 		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsSql
 		// 
@@ -831,8 +908,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsSql.AutoToolTip = true;
 		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
 		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
-		toolStripMenuItemSaveAsSql.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSql.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsSqlite
 		// 
@@ -842,8 +922,11 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
 		toolStripMenuItemSaveAsSqlite.Image = FatcowIcons16px.fatcow_page_white_database_16px;
 		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
-		toolStripMenuItemSaveAsSqlite.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSqlite.Size = new Size(180, 22);
 		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemPortableDocuments
 		// 
@@ -856,6 +939,8 @@ partial class CheckDatabaseForm
 		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
 		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
 		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsPdf
 		// 
@@ -867,6 +952,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
 		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsPostScript
 		// 
@@ -878,6 +966,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
 		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsEpub
 		// 
@@ -889,6 +980,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
 		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsMobi
 		// 
@@ -900,6 +994,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
 		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsXps
 		// 
@@ -911,6 +1008,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
 		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXps.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsFictionBook2
 		// 
@@ -922,6 +1022,9 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
 		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemSaveAsChm
 		// 
@@ -933,6 +1036,23 @@ partial class CheckDatabaseForm
 		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
 		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
 		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonCopyToClipboard
+		// 
+		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies information to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.ButtonDropDown;
+		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboard;
+		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_copy_16px;
+		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
+		toolStripDropDownButtonCopyToClipboard.Size = new Size(131, 22);
+		toolStripDropDownButtonCopyToClipboard.Text = "&Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
+		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
 		// 
 		// contextMenuFullCopyToClipboard
 		// 
@@ -940,54 +1060,74 @@ partial class CheckDatabaseForm
 		contextMenuFullCopyToClipboard.AccessibleName = "Context menu for copying database information to the clipboard";
 		contextMenuFullCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
 		contextMenuFullCopyToClipboard.Font = new Font("Segoe UI", 9F);
-		contextMenuFullCopyToClipboard.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardLinearEccentricity, menuitemCopyToClipboardSemiMinorAxis, menuitemCopyToClipboardMajorAxis, menuitemCopyToClipboardMinorAxis });
+		contextMenuFullCopyToClipboard.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardDatabaseLocalModifiedDate, menuitemCopyToClipboardDatabaseLocalContentLength, menuitemCopyToClipboardDatabaseOnlineModifiedDate, menuitemCopyToClipboardDatabaseOnlineContentLength });
 		contextMenuFullCopyToClipboard.Name = "Context menu for copying database information to the clipboard";
-		contextMenuFullCopyToClipboard.Size = new Size(171, 92);
+		contextMenuFullCopyToClipboard.Size = new Size(240, 92);
 		contextMenuFullCopyToClipboard.Text = "Copy to clipboard";
+		contextMenuFullCopyToClipboard.MouseEnter += Control_Enter;
+		contextMenuFullCopyToClipboard.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopyToClipboardLinearEccentricity
+		// menuitemCopyToClipboardDatabaseLocalModifiedDate
 		// 
-		menuitemCopyToClipboardLinearEccentricity.AccessibleDescription = "Copies to clipboard: Linear eccentricity";
-		menuitemCopyToClipboardLinearEccentricity.AccessibleName = "Copy to clipboard: Linear eccentricity";
-		menuitemCopyToClipboardLinearEccentricity.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopyToClipboardLinearEccentricity.AutoToolTip = true;
-		menuitemCopyToClipboardLinearEccentricity.Image = (Image)resources.GetObject("menuitemCopyToClipboardLinearEccentricity.Image");
-		menuitemCopyToClipboardLinearEccentricity.Name = "menuitemCopyToClipboardLinearEccentricity";
-		menuitemCopyToClipboardLinearEccentricity.Size = new Size(170, 22);
-		menuitemCopyToClipboardLinearEccentricity.Text = "Linear eccentricity";
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.AccessibleDescription = "Copies to clipboard: Database local modified date";
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.AccessibleName = "Copy to clipboard: Database local modified date";
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.AutoToolTip = true;
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.Image = (Image)resources.GetObject("menuitemCopyToClipboardDatabaseLocalModifiedDate.Image");
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.Name = "menuitemCopyToClipboardDatabaseLocalModifiedDate";
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.Size = new Size(239, 22);
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.Text = "Database local modified date";
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.Click += MenuitemCopyToClipboardDatabaseLocalModifiedDate_Click;
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.MouseEnter += Control_Enter;
+		menuitemCopyToClipboardDatabaseLocalModifiedDate.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopyToClipboardSemiMinorAxis
+		// menuitemCopyToClipboardDatabaseLocalContentLength
 		// 
-		menuitemCopyToClipboardSemiMinorAxis.AccessibleDescription = "Copies to clipboard: Semi minor axis";
-		menuitemCopyToClipboardSemiMinorAxis.AccessibleName = "Copy to clipboard: Semi minor axis";
-		menuitemCopyToClipboardSemiMinorAxis.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopyToClipboardSemiMinorAxis.AutoToolTip = true;
-		menuitemCopyToClipboardSemiMinorAxis.Image = (Image)resources.GetObject("menuitemCopyToClipboardSemiMinorAxis.Image");
-		menuitemCopyToClipboardSemiMinorAxis.Name = "menuitemCopyToClipboardSemiMinorAxis";
-		menuitemCopyToClipboardSemiMinorAxis.Size = new Size(256, 22);
-		menuitemCopyToClipboardSemiMinorAxis.Text = "Semi minor axis";
+		menuitemCopyToClipboardDatabaseLocalContentLength.AccessibleDescription = "Copies to clipboard: Database local content length";
+		menuitemCopyToClipboardDatabaseLocalContentLength.AccessibleName = "Copy to clipboard: Database local content length";
+		menuitemCopyToClipboardDatabaseLocalContentLength.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopyToClipboardDatabaseLocalContentLength.AutoToolTip = true;
+		menuitemCopyToClipboardDatabaseLocalContentLength.Image = (Image)resources.GetObject("menuitemCopyToClipboardDatabaseLocalContentLength.Image");
+		menuitemCopyToClipboardDatabaseLocalContentLength.Name = "menuitemCopyToClipboardDatabaseLocalContentLength";
+		menuitemCopyToClipboardDatabaseLocalContentLength.Size = new Size(239, 22);
+		menuitemCopyToClipboardDatabaseLocalContentLength.Text = "Database local content length";
+		menuitemCopyToClipboardDatabaseLocalContentLength.Click += MenuitemCopyToClipboardDatabaseLocalContentLength_Click;
+		menuitemCopyToClipboardDatabaseLocalContentLength.MouseEnter += Control_Enter;
+		menuitemCopyToClipboardDatabaseLocalContentLength.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopyToClipboardMajorAxis
+		// menuitemCopyToClipboardDatabaseOnlineModifiedDate
 		// 
-		menuitemCopyToClipboardMajorAxis.AccessibleDescription = "Copies to clipboard: Major axis";
-		menuitemCopyToClipboardMajorAxis.AccessibleName = "Copy to clipboard: Major axis";
-		menuitemCopyToClipboardMajorAxis.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopyToClipboardMajorAxis.AutoToolTip = true;
-		menuitemCopyToClipboardMajorAxis.Image = (Image)resources.GetObject("menuitemCopyToClipboardMajorAxis.Image");
-		menuitemCopyToClipboardMajorAxis.Name = "menuitemCopyToClipboardMajorAxis";
-		menuitemCopyToClipboardMajorAxis.Size = new Size(256, 22);
-		menuitemCopyToClipboardMajorAxis.Text = "Major axis";
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.AccessibleDescription = "Copies to clipboard: Database online modified date";
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.AccessibleName = "Copy to clipboard: Database online modified date";
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.AutoToolTip = true;
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.Image = (Image)resources.GetObject("menuitemCopyToClipboardDatabaseOnlineModifiedDate.Image");
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.Name = "menuitemCopyToClipboardDatabaseOnlineModifiedDate";
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.Size = new Size(239, 22);
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.Text = "Database online modified date";
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.Click += MenuitemCopyToClipboardDatabaseOnlineModifiedDate_Click;
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.MouseEnter += Control_Enter;
+		menuitemCopyToClipboardDatabaseOnlineModifiedDate.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopyToClipboardMinorAxis
+		// menuitemCopyToClipboardDatabaseOnlineContentLength
 		// 
-		menuitemCopyToClipboardMinorAxis.AccessibleDescription = "Copies to clipboard: Minor axis";
-		menuitemCopyToClipboardMinorAxis.AccessibleName = "Copy to clipboard: Minor axis";
-		menuitemCopyToClipboardMinorAxis.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopyToClipboardMinorAxis.AutoToolTip = true;
-		menuitemCopyToClipboardMinorAxis.Image = (Image)resources.GetObject("menuitemCopyToClipboardMinorAxis.Image");
-		menuitemCopyToClipboardMinorAxis.Name = "menuitemCopyToClipboardMinorAxis";
-		menuitemCopyToClipboardMinorAxis.Size = new Size(256, 22);
-		menuitemCopyToClipboardMinorAxis.Text = "Minor axis";
+		menuitemCopyToClipboardDatabaseOnlineContentLength.AccessibleDescription = "Copies to clipboard: Database online content length";
+		menuitemCopyToClipboardDatabaseOnlineContentLength.AccessibleName = "Copy to clipboard: Database online content length";
+		menuitemCopyToClipboardDatabaseOnlineContentLength.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopyToClipboardDatabaseOnlineContentLength.AutoToolTip = true;
+		menuitemCopyToClipboardDatabaseOnlineContentLength.Image = (Image)resources.GetObject("menuitemCopyToClipboardDatabaseOnlineContentLength.Image");
+		menuitemCopyToClipboardDatabaseOnlineContentLength.Name = "menuitemCopyToClipboardDatabaseOnlineContentLength";
+		menuitemCopyToClipboardDatabaseOnlineContentLength.Size = new Size(239, 22);
+		menuitemCopyToClipboardDatabaseOnlineContentLength.Text = "Database online content length";
+		menuitemCopyToClipboardDatabaseOnlineContentLength.Click += MenuitemCopyToClipboardDatabaseOnlineContentLength_Click;
+		menuitemCopyToClipboardDatabaseOnlineContentLength.MouseEnter += Control_Enter;
+		menuitemCopyToClipboardDatabaseOnlineContentLength.MouseLeave += Control_Leave;
+		// 
+		// kryptonManager
+		// 
+		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 		// 
 		// CheckDatabaseForm
 		// 
@@ -1039,7 +1179,7 @@ partial class CheckDatabaseForm
 	private KryptonLabel labelModifiedDateValueLocal;
 	private KryptonLabel labelContentLengthValueOnline;
 	private KryptonLabel labelModifiedDateValueOnline;
-	private KryptonStatusStrip kryptonStatusStrip;
+	private Krypton.Toolkit.KryptonStatusStrip kryptonStatusStrip;
 	private ToolStripStatusLabel labelInformation;
 	private ToolStripContainer toolStripContainer;
 	private KryptonManager kryptonManager;
@@ -1089,8 +1229,8 @@ partial class CheckDatabaseForm
 	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
 	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
 	private ContextMenuStrip contextMenuFullCopyToClipboard;
-	private ToolStripMenuItem menuitemCopyToClipboardLinearEccentricity;
-	private ToolStripMenuItem menuitemCopyToClipboardSemiMinorAxis;
-	private ToolStripMenuItem menuitemCopyToClipboardMajorAxis;
-	private ToolStripMenuItem menuitemCopyToClipboardMinorAxis;
+	private ToolStripMenuItem menuitemCopyToClipboardDatabaseLocalModifiedDate;
+	private ToolStripMenuItem menuitemCopyToClipboardDatabaseLocalContentLength;
+	private ToolStripMenuItem menuitemCopyToClipboardDatabaseOnlineModifiedDate;
+	private ToolStripMenuItem menuitemCopyToClipboardDatabaseOnlineContentLength;
 }

--- a/Forms/CheckDatabaseForm.cs
+++ b/Forms/CheckDatabaseForm.cs
@@ -6,6 +6,7 @@
 using NLog;
 
 using Planetoid_DB.Forms;
+using Planetoid_DB.Helpers;
 
 using System.Diagnostics;
 using System.Globalization;
@@ -78,6 +79,22 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 	/// <returns>A string representation of the current instance for use in the debugger.</returns>
 	/// <remarks>This method is used to provide a visual representation of the object in the debugger.</remarks>
 	private string GetDebuggerDisplay() => ToString();
+
+	/// <summary>Prepares the save dialog for exporting data.</summary>
+	/// <param name="dialog">The file dialog to prepare.</param>
+	/// <param name="ext">The file extension.</param>
+	/// <returns>True if the dialog was shown successfully; otherwise, false.</returns>
+	/// <remarks>This method is used to prepare the save dialog for exporting data.</remarks>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"Database-Information-local-online.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
 
 	#endregion
 
@@ -219,4 +236,1053 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 	}
 
 	#endregion
+
+	#region Click event handlers
+
+	/// <summary>Handles the click event for copying the local database modified date to the clipboard.</summary>
+	/// <remarks>If the local modified date is not available, a warning message is displayed and nothing is copied
+	/// to the clipboard.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void MenuitemCopyToClipboardDatabaseLocalModifiedDate_Click(object sender, EventArgs e)
+	{
+		if (string.IsNullOrEmpty(value: labelModifiedDateValueLocal.Text))
+		{
+			string messageNoLocalModifiedDateToCopyText = "No local modified date available to copy to clipboard.";
+			logger.Warn(message: messageNoLocalModifiedDateToCopyText);
+			MessageBox.Show(text: messageNoLocalModifiedDateToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			return;
+		}
+		Clipboard.SetText(text: labelModifiedDateValueLocal.Text);
+	}
+
+	/// <summary>Handles the click event for copying the local content length value to the clipboard.</summary>
+	/// <remarks>If the local content length value is not available, a warning message is displayed and nothing is
+	/// copied to the clipboard.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void MenuitemCopyToClipboardDatabaseLocalContentLength_Click(object sender, EventArgs e)
+	{
+		if (string.IsNullOrEmpty(value: labelContentLengthValueLocal.Text))
+		{
+			string messageNoLocalContentLengthToCopyText = "No local content length available to copy to clipboard.";
+			logger.Warn(message: messageNoLocalContentLengthToCopyText);
+			MessageBox.Show(text: messageNoLocalContentLengthToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			return;
+		}
+		Clipboard.SetText(text: labelContentLengthValueLocal.Text);
+	}
+
+	/// <summary>Handles the click event for copying the online modified date value to the clipboard.</summary>
+	/// <remarks>If the online modified date value is not available, a warning message is displayed and nothing is
+	/// copied to the clipboard.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void MenuitemCopyToClipboardDatabaseOnlineModifiedDate_Click(object sender, EventArgs e)
+	{
+		if (string.IsNullOrEmpty(value: labelModifiedDateValueOnline.Text))
+		{
+			string messageNoOnlineModifiedDateToCopyText = "No online modified date available to copy to clipboard.";
+			logger.Warn(message: messageNoOnlineModifiedDateToCopyText);
+			MessageBox.Show(text: messageNoOnlineModifiedDateToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			return;
+		}
+		Clipboard.SetText(text: labelModifiedDateValueOnline.Text);
+	}
+
+	/// <summary>Handles the click event for copying the online content length value to the clipboard.</summary>
+	/// <remarks>If the online content length value is not available, a warning message is displayed and nothing is
+	/// copied to the clipboard.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void MenuitemCopyToClipboardDatabaseOnlineContentLength_Click(object sender, EventArgs e)
+	{
+		if (string.IsNullOrEmpty(value: labelContentLengthValueOnline.Text))
+		{
+			string messageNoOnlineContentLengthToCopyText = "No online content length available to copy to clipboard.";
+			logger.Warn(message: messageNoOnlineContentLengthToCopyText);
+			MessageBox.Show(text: messageNoOnlineContentLengthToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
+			return;
+		}
+		Clipboard.SetText(text: labelContentLengthValueOnline.Text);
+	}
+
+	#endregion
+
+	/// <summary>Handles the Click event of the Save As Text menu item, allowing the user to export the contents of the table layout
+	/// panel to a text file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the file location and name. If the user
+	/// confirms, the method exports the current list view results to the specified text file.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As Text menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsText_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the text file to save the list view results; if the user confirms the save operation, call the SaveAsText method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*",
+			DefaultExt = "txt",
+			Title = "Save as Text"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsText(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as LaTeX' menu item, allowing the user to export the contents of the table
+	/// layout panel to a LaTeX file.</summary>
+	/// <remarks>Opens a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// method exports the current table layout panel data to a LaTeX file at the specified location.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsLatex_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the LaTeX file to save the list view results; if the user confirms the save operation, call the SaveAsLatex method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "LaTeX Files (*.tex)|*.tex|All Files (*.*)|*.*",
+			DefaultExt = "tex",
+			Title = "Save as LaTeX"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsLatex(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as Markdown' menu item, allowing the user to export the current table layout
+	/// panel content to a Markdown file.</summary>
+	/// <remarks>This method displays a Save File dialog for the user to specify the destination file. If the user
+	/// confirms, the current table layout panel data is exported as a Markdown file. The export operation will not proceed
+	/// if the dialog is canceled or invalid input is provided.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Markdown file to save the list view results; if the user confirms the save operation, call the SaveAsMarkdown method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Markdown Files (*.md)|*.md|All Files (*.*)|*.*",
+			DefaultExt = "md",
+			Title = "Save as Markdown"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsMarkdown(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as AsciiDoc' menu item, allowing the user to export the current list view
+	/// results to an AsciiDoc file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// current table layout is exported as an AsciiDoc document. The export operation is only performed if the dialog is
+	/// successfully prepared and the user completes the save action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the AsciiDoc file to save the list view results; if the user confirms the save operation, call the SaveAsAsciiDoc method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "AsciiDoc Files (*.adoc)|*.adoc|All Files (*.*)|*.*",
+			DefaultExt = "adoc",
+			Title = "Save as AsciiDoc"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsAsciiDoc(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as ReStructuredText' menu item, allowing the user to export the list view
+	/// results to a ReStructuredText (.rst) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the file location and name. If the user
+	/// confirms, the current table layout is exported as a ReStructuredText file. The export includes the list of readable
+	/// designations.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the ReStructuredText file to save the list view results; if the user confirms the save operation, call the SaveAsReStructuredText method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "ReStructuredText Files (*.rst)|*.rst|All Files (*.*)|*.*",
+			DefaultExt = "rst",
+			Title = "Save as ReStructuredText"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsReStructuredText(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save As Textile' menu item to export the contents of the table layout panel to a
+	/// Textile file.</summary>
+	/// <remarks>Displays a Save File dialog to allow the user to specify the file name and location for the Textile
+	/// export. If the user confirms the operation, the contents of the table layout panel are saved in Textile
+	/// format.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the textile file to save the list view results; if the user confirms the save operation, call the SaveAsTextile method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Textile Files (*.textile)|*.textile|All Files (*.*)|*.*",
+			DefaultExt = "textile",
+			Title = "Save as Textile"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsTextile(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as Word' menu item to export the contents of the table layout panel to a Word
+	/// document.</summary>
+	/// <remarks>This method displays a Save File dialog to allow the user to specify the destination for the
+	/// exported Word document. If the user confirms the operation, the contents of the table layout panel are saved to the
+	/// specified file in .docx format.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsWord_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Word file to save the list view results; if the user confirms the save operation, call the SaveAsWord method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Word Files (*.docx)|*.docx|All Files (*.*)|*.*",
+			DefaultExt = "docx",
+			Title = "Save as Word"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsWord(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as ODT' menu item to export the contents of the table layout panel to an
+	/// OpenDocument Text (.odt) file.</summary>
+	/// <remarks>Displays a Save File dialog allowing the user to specify the destination file. If the user
+	/// confirms, the method exports the current list view results to the specified ODT file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsOdt_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the OpenDocument Text file to save the list view results; if the user confirms the save operation, call the SaveAsOdt method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "OpenDocument Text Files (*.odt)|*.odt|All Files (*.*)|*.*",
+			DefaultExt = "odt",
+			Title = "Save as OpenDocument Text"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsOdt(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As RTF menu item, allowing the user to export the contents of the table layout
+	/// panel to a Rich Text Format (RTF) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the file location and name. If the user
+	/// confirms, the method exports the current list view results to an RTF file. The exported file includes the readable
+	/// designations displayed in the table layout panel.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As RTF menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsRtf_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the RTF file to save the list view results; if the user confirms the save operation, call the SaveAsRtf method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Rich Text Format Files (*.rtf)|*.rtf|All Files (*.*)|*.*",
+			DefaultExt = "rtf",
+			Title = "Save as RTF"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsRtf(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save As Abiword' menu item, allowing the user to export the list view results to an
+	/// Abiword (.abw) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the Abiword file location and name. If the user
+	/// confirms, the current table layout is exported to the specified file in Abiword format.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Abiword file to save the list view results; if the user confirms the save operation, call the SaveAsAbiword method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Abiword Files (*.abw)|*.abw|All Files (*.*)|*.*",
+			DefaultExt = "abw",
+			Title = "Save as Abiword"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsAbiword(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As WPS menu item, allowing the user to export the current list view results to
+	/// a WPS Writer file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// method exports the data to the selected WPS file.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As WPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the WPS Writer file to save the list view results; if the user confirms the save operation, call the SaveAsWps method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "WPS Files (*.wps)|*.wps|All Files (*.*)|*.*",
+			DefaultExt = "wps",
+			Title = "Save as WPS"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsWps(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event of the 'Save as Excel' menu item to export the contents of the table layout panel to an
+	/// Excel file.</summary>
+	/// <remarks>This method displays a Save File dialog to the user for specifying the Excel file location and
+	/// name. If the user confirms the operation, the contents of the table layout panel are exported to the specified
+	/// Excel file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsExcel_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the Excel file to save the list view results; if the user confirms the save operation, call the SaveAsExcel method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*",
+			DefaultExt = "xlsx",
+			Title = "Save as Excel"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsExcel(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as ODS' menu item, allowing the user to export the contents of the table
+	/// layout panel to an OpenDocument Spreadsheet (ODS) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination ODS file. If the user confirms,
+	/// the method exports the current table layout panel data to the selected file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsOds_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the OpenDocument Spreadsheet file to save the list view results; if the user confirms the save operation, call the SaveAsOds method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "OpenDocument Spreadsheet Files (*.ods)|*.ods|All Files (*.*)|*.*",
+			DefaultExt = "ods",
+			Title = "Save as ODS"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsOds(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as CSV' menu item, allowing the user to export the contents of the table
+	/// layout panel to a CSV file.</summary>
+	/// <remarks>This method displays a Save File dialog for the user to specify the destination file. If the user
+	/// confirms, the contents of the table layout panel are exported to the selected CSV file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsCsv_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the CSV file to save the list view results; if the user confirms the save operation, call the SaveAsCsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Comma-Separated Values (*.csv)|*.csv|All Files (*.*)|*.*",
+			DefaultExt = "csv",
+			Title = "Save as CSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsCsv(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As TSV menu item, allowing the user to export the contents of the table layout
+	/// panel to a tab-separated values (TSV) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the file location and name. If the user
+	/// confirms the operation, the method exports the current data to a TSV file. The exported file can be used for data
+	/// exchange or further processing in spreadsheet applications.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsTsv_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the TSV file to save the list view results; if the user confirms the save operation, call the SaveAsTsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Tab-Separated Values (*.tsv)|*.tsv|All Files (*.*)|*.*",
+			DefaultExt = "tsv",
+			Title = "Save as TSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsTsv(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as PSV' menu item to export the contents of the table layout panel to a
+	/// pipe-separated values (PSV) file.</summary>
+	/// <remarks>This method displays a Save File dialog allowing the user to specify the destination file for the
+	/// PSV export. If the user confirms the operation, the current data is saved in PSV format. The export includes the
+	/// Information of local and online database from the table layout panel.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsPsv_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PSV file to save the list view results; if the user confirms the save operation, call the SaveAsPsv method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Pipe-Separated Values (*.psv)|*.psv|All Files (*.*)|*.*",
+			DefaultExt = "psv",
+			Title = "Save as PSV"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsPsv(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event for the 'Save As ET' menu item, allowing the user to export the current list view results
+	/// to an ET file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the file location and name. If the user
+	/// confirms, the current table layout is exported to the specified ET file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the ET file to save the list view results; if the user confirms the save operation, call the SaveAsEt method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "ET Files (*.et)|*.et|All Files (*.*)|*.*",
+			DefaultExt = "et",
+			Title = "Save as ET"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsEt(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as HTML' menu item to export the contents of the table layout panel to an HTML
+	/// file.</summary>
+	/// <remarks>Displays a Save File dialog to allow the user to specify the destination file. If the user
+	/// confirms, the method exports the current table layout panel data to the selected HTML file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsHtml_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the HTML file to save the list view results; if the user confirms the save operation, call the SaveAsHtml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "HTML Files (*.html)|*.html|All Files (*.*)|*.*",
+			DefaultExt = "html",
+			Title = "Save as HTML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsHtml(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as XML' menu item to export the current list view results to an XML file.</summary>
+	/// <remarks>This method displays a Save File dialog to the user for specifying the XML file location and name.
+	/// If the user confirms the operation, the current table layout panel data is exported as an XML file. The export
+	/// includes the Information of local and online database.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsXml_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the XML file to save the list view results; if the user confirms the save operation, call the SaveAsXml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save as XML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsXml(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as DocBook' menu item, allowing the user to export the list view results to a
+	/// DocBook XML file.</summary>
+	/// <remarks>Opens a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// current table layout is exported as a DocBook XML file. The export operation may overwrite an existing file if the
+	/// user selects one.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the DocBook file to save the list view results; if the user confirms the save operation, call the SaveAsDocBook method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*",
+			DefaultExt = "xml",
+			Title = "Save as DocBook"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsDocBook(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as JSON' menu item, allowing the user to export the current list view results
+	/// to a JSON file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// current data is exported to the selected JSON file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsJson_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the JSON file to save the list view results; if the user confirms the save operation, call the SaveAsJson method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*",
+			DefaultExt = "json",
+			Title = "Save as JSON"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsJson(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+
+	}
+
+	/// <summary>Handles the click event for the 'Save as YAML' menu item, allowing the user to export the current table layout
+	/// panel data to a YAML file.</summary>
+	/// <remarks>This method displays a Save File dialog for the user to specify the destination file. If the user
+	/// confirms the operation, the current data from the table layout panel is exported to the selected YAML
+	/// file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsYaml_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the YAML file to save the list view results; if the user confirms the save operation, call the SaveAsYaml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "YAML Files (*.yaml)|*.yaml|All Files (*.*)|*.*",
+			DefaultExt = "yaml",
+			Title = "Save as YAML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsYaml(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as TOML' menu item, allowing the user to export the current list view results
+	/// to a TOML file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// current table layout panel data is exported to the specified TOML file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the TOML file to save the list view results; if the user confirms the save operation, call the SaveAsToml method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*",
+			DefaultExt = "toml",
+			Title = "Save as TOML"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsToml(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As SQL menu item to export the current list view results to a SQL file.</summary>
+	/// <remarks>This method displays a Save File dialog to allow the user to specify the destination for the SQL
+	/// export. If the user confirms the operation, the current contents of the table layout panel are exported as a SQL
+	/// file.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As SQL menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsSql_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the SQL file to save the list view results; if the user confirms the save operation, call the SaveAsSql method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQL Files (*.sql)|*.sql|All Files (*.*)|*.*",
+			DefaultExt = "sql",
+			Title = "Save as SQL"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsSql(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as SQLite' menu item, allowing the user to export the current list view
+	/// results to a SQLite database file.</summary>
+	/// <remarks>Opens a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// method exports the data to the selected SQLite file. The export includes the current contents of the associated
+	/// table layout panel.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the SQLite file to save the list view results; if the user confirms the save operation, call the SaveAsSqlite method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "SQLite Files (*.sqlite)|*.sqlite|All Files (*.*)|*.*",
+			DefaultExt = "sqlite",
+			Title = "Save as SQLite"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsSqlite(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event of the 'Save as PDF' menu item to export the contents of the table layout panel to a PDF
+	/// file.</summary>
+	/// <remarks>Displays a Save File dialog to allow the user to specify the destination for the PDF file. If the
+	/// user confirms the operation, the contents of the table layout panel are exported to the specified PDF
+	/// file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsPdf_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PDF file to save the list view results; if the user confirms the save operation, call the SaveAsPdf method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "PDF Files (*.pdf)|*.pdf|All Files (*.*)|*.*",
+			DefaultExt = "pdf",
+			Title = "Save as PDF"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsPdf(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As PostScript menu item to allow the user to export the list view results as a
+	/// PostScript file.</summary>
+	/// <remarks>This handler displays a Save File dialog for the user to specify the destination file. If the user
+	/// confirms, the current table layout is exported to a PostScript file. The export operation is only performed if the
+	/// dialog is successfully prepared and the user completes the save action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As PostScript menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the PostScript file to save the list view results; if the user confirms the save operation, call the SaveAsPostScript method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "PostScript Files (*.ps)|*.ps|All Files (*.*)|*.*",
+			DefaultExt = "ps",
+			Title = "Save as PostScript"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsPostScript(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as EPUB' menu item, allowing the user to export the current list view results
+	/// to an EPUB file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the EPUB file location and name. If the user
+	/// confirms the operation, the current table layout is exported as an EPUB file. The export is only performed if the
+	/// dialog is successfully prepared and the user completes the save action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsEpub_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the EPUB file to save the list view results; if the user confirms the save operation, call the SaveAsEpub method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "EPUB Files (*.epub)|*.epub|All Files (*.*)|*.*",
+			DefaultExt = "epub",
+			Title = "Save as EPUB"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsEpub(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As MOBI menu item, allowing the user to export the current list view results to
+	/// a MOBI file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms, the
+	/// method exports the data to the specified MOBI file.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsMobi_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the MOBI file to save the list view results; if the user confirms the save operation, call the SaveAsMobi method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "MOBI Files (*.mobi)|*.mobi|All Files (*.*)|*.*",
+			DefaultExt = "mobi",
+			Title = "Save as MOBI"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsMobi(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Save As XPS menu item, allowing the user to export the current list view results to
+	/// an XPS file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination XPS file. If the user confirms,
+	/// the current table layout panel content is exported to the specified XPS file.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As XPS menu item.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the XPS file to save the list view results; if the user confirms the save operation, call the SaveAsXps method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*",
+			DefaultExt = "xps",
+			Title = "Save as XPS"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsXps(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the Click event of the 'Save as FictionBook2' menu item, allowing the user to export the current list view
+	/// results to a FictionBook2 (.fb2) file.</summary>
+	/// <remarks>Displays a Save File dialog for the user to specify the destination file. If the user confirms the
+	/// operation, the method exports the data to the specified FictionBook2 file format.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the FictionBook2 file to save the list view results; if the user confirms the save operation, call the SaveAsFictionBook2 method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "FictionBook2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*",
+			DefaultExt = "fb2",
+			Title = "Save as FictionBook2"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsFictionBook2(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Handles the click event for the 'Save as CHM' menu item, allowing the user to export the current list view results
+	/// to a Compiled HTML Help (CHM) file.</summary>
+	/// <remarks>This method displays a Save File dialog for the user to specify the destination and filename for
+	/// the CHM export. If the user confirms the operation, the current table layout is exported to a CHM file at the
+	/// specified location.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e)
+	{
+		// Open a SaveFileDialog to allow the user to specify the location and name of the CHM file to save the list view results; if the user confirms the save operation, call the SaveAsChm method to perform the export
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = "Compiled HTML Help Files (*.chm)|*.chm|All Files (*.*)|*.*",
+			DefaultExt = "chm",
+			Title = "Save as CHM"
+		};
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: saveFileDialog.DefaultExt))
+		{
+			return;
+		}
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			TableLayoutPanelExporter.SaveAsChm(tableLayoutPanel: tableLayoutPanel, title: "Information of local and online database", fileName: saveFileDialog.FileName);
+		}
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
 }

--- a/Forms/CheckDatabaseForm.cs
+++ b/Forms/CheckDatabaseForm.cs
@@ -253,7 +253,7 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 			MessageBox.Show(text: messageNoLocalModifiedDateToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 			return;
 		}
-		Clipboard.SetText(text: labelModifiedDateValueLocal.Text);
+		CopyToClipboard(text: labelModifiedDateValueLocal.Text);
 	}
 
 	/// <summary>Handles the click event for copying the local content length value to the clipboard.</summary>
@@ -270,7 +270,7 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 			MessageBox.Show(text: messageNoLocalContentLengthToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 			return;
 		}
-		Clipboard.SetText(text: labelContentLengthValueLocal.Text);
+		CopyToClipboard(text: labelContentLengthValueLocal.Text);
 	}
 
 	/// <summary>Handles the click event for copying the online modified date value to the clipboard.</summary>
@@ -287,7 +287,7 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 			MessageBox.Show(text: messageNoOnlineModifiedDateToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 			return;
 		}
-		Clipboard.SetText(text: labelModifiedDateValueOnline.Text);
+		CopyToClipboard(text: labelModifiedDateValueOnline.Text);
 	}
 
 	/// <summary>Handles the click event for copying the online content length value to the clipboard.</summary>
@@ -304,7 +304,7 @@ public partial class CheckDatabaseForm : BaseKryptonForm
 			MessageBox.Show(text: messageNoOnlineContentLengthToCopyText, caption: "Warning", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Warning);
 			return;
 		}
-		Clipboard.SetText(text: labelContentLengthValueOnline.Text);
+		CopyToClipboard(text: labelContentLengthValueOnline.Text);
 	}
 
 	#endregion

--- a/Forms/CheckDatabaseForm.resx
+++ b/Forms/CheckDatabaseForm.resx
@@ -132,78 +132,78 @@
   <metadata name="contextMenuFullCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>527, 17</value>
   </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="menuitemCopyToClipboardDatabaseLocalModifiedDate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardDatabaseLocalContentLength.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardDatabaseOnlineModifiedDate.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="menuitemCopyToClipboardDatabaseOnlineContentLength.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
+        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
+        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
+        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
+        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
+        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
+        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
+        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
+        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
+        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
+        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
+        93PYBwAAAABJRU5ErkJggg==
+</value>
+  </data>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>168, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="menuitemCopyToClipboardLinearEccentricity.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
-        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
-        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
-        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
-        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
-        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
-        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
-        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
-        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
-        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
-        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
-        93PYBwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="menuitemCopyToClipboardSemiMinorAxis.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
-        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
-        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
-        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
-        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
-        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
-        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
-        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
-        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
-        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
-        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
-        93PYBwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="menuitemCopyToClipboardMajorAxis.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
-        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
-        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
-        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
-        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
-        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
-        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
-        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
-        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
-        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
-        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
-        93PYBwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="menuitemCopyToClipboardMinorAxis.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAoJJREFUOE99ks1PE1EUxVmq8b9x4w5DKH4lJIAtboyJCxfEmBBLQiNqpY2wxSob
-        NXErGxNloyUQoO30mxZQUto+ST9oZ1poZ6YtdGY6xztDXRU8yclbzH2/ufe82zfk4Jas7mh8fC7KbPOh
-        tOHxuVB62BVO3Jj2P+1/uHap73+65w4nNE1L87LKBHJZUlm+qrCCpLA5r8DG3Fsfrz3+dqVb3ivbm8h+
-        hS76M+SsyjYybba8IzO5rTJfTmGe1Qq7+WLT2S3v1agrlK4TIJoj5w2QwlZSDZbhZVaRFSafquzR+1im
-        W94rAyA2VLZNl5NkA+SjLj5tClhcO8Rbb8H0k8/J5sSHROvBu8j+gMP38vrkl8smYIQAUkNjuwXVtAEJ
-        ZxW2uFqEDoCXOxDIZUlDvqagJCmY9wqwuuPf+yeWrpqAugnoQggQI3vor0dNHX6mgTtQQdlgeacJua2D
-        soFnvYpbzzc8JkAkQIrXWFo4Ow2Y0Xa9pSOW0xDLawj+UbCSOkGWb4KyAWWDMSenmwDjFc4DiCc6tosa
-        kgUNlA182Ta8ey18Tcoo0Dj33SECvIqygljtASwQQDoBfpV008liB+EDBT7WNjspSR2MG4DhGW7H6KAs
-        0vLUFcaLtFC0TAs/aQQTAPwudbB72EGCOonkjTwUlGUdNhcB7jgCP+46gnGLPZAdfBbY/edRd5hGAFI8
-        kBbOzj2CbReBSA7mN+tsUDef8jyNuqLqcVO9EFBrqbA6qYOLNDa7hZJYuxBQlmqwvY6jW96r29PcUVXW
-        QNmgVFdA2YCyMV0hHzc6GHFy7W55rwYmN9cHpgKHlim/brFzssUeJBsnJw9N+RuD9o3yyExY/AtgyKNq
-        93PYBwAAAABJRU5ErkJggg==
-</value>
-  </data>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>53</value>
   </metadata>


### PR DESCRIPTION
This PR fills in missing UI wiring and event handler implementations for `CheckDatabaseForm`, enabling copy-to-clipboard actions for database fields and adding export/save functionality for many formats using the existing `TableLayoutPanelExporter` helpers.

**Changes:**
- Added click handlers in `CheckDatabaseForm` for copy-to-clipboard actions and for exporting the table layout panel to multiple file formats.
- Updated the Designer to wire menu item Click events, update the “Copy to clipboard” menu items to match database fields, and extend Enter/Leave/MouseEnter/MouseLeave status-bar behaviors.
- Updated the `.resx` resource keys/images to match the renamed copy-to-clipboard menu items and adjusted tray metadata placement.