### PR TITLE
Redesigned `OrbitElementsGroupingForm`

### DIFF
--- a/Forms/OrbitElementsGroupingForm.Designer.cs
+++ b/Forms/OrbitElementsGroupingForm.Designer.cs
@@ -35,18 +35,77 @@ partial class OrbitElementsGroupingForm
 	/// It sets up the controls and their properties for the form.</remarks>
 	private void InitializeComponent()
 	{
+		components = new Container();
 		ComponentResourceManager resources = new ComponentResourceManager(typeof(OrbitElementsGroupingForm));
 		kryptonPanelMain = new KryptonPanel();
-		progressBar = new KryptonProgressBar();
-		lblElementsCount = new KryptonLabel();
-		numElementsToCompare = new KryptonNumericUpDown();
-		lblTolerance = new KryptonLabel();
-		numTolerance = new KryptonNumericUpDown();
-		btnCancel = new KryptonButton();
-		btnStart = new KryptonButton();
-		txtOutput = new KryptonRichTextBox();
+		kryptonTextBoxOutput = new KryptonTextBox();
+		kryptonStatusStrip = new KryptonStatusStrip();
+		labelInformation = new ToolStripStatusLabel();
+		toolStripContainer = new ToolStripContainer();
+		kryptonToolStripGenerateList = new KryptonToolStrip();
+		toolStripButtonStart = new ToolStripButton();
+		toolStripButtonCancel = new ToolStripButton();
+		toolStripSeparator1 = new ToolStripSeparator();
+		toolStripLabelTolerance = new ToolStripLabel();
+		toolStripNumericUpDownTolerance = new Planetoid_DB.Helpers.ToolStripNumericUpDown();
+		toolStripLabelElementsCount = new ToolStripLabel();
+		toolStripNumericUpDownElementsCount = new Planetoid_DB.Helpers.ToolStripNumericUpDown();
+		toolStripSeparator2 = new ToolStripSeparator();
+		toolStripDropDownButtonSaveList = new ToolStripDropDownButton();
+		contextMenuSaveToFile = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
+		kryptonToolStripProgress = new KryptonToolStrip();
+		toolStripLabelProgress = new ToolStripLabel();
+		kryptonProgressBar = new KryptonProgressBarToolStripItem();
+		kryptonManager = new KryptonManager(components);
 		((ISupportInitialize)kryptonPanelMain).BeginInit();
 		kryptonPanelMain.SuspendLayout();
+		kryptonStatusStrip.SuspendLayout();
+		toolStripContainer.BottomToolStripPanel.SuspendLayout();
+		toolStripContainer.ContentPanel.SuspendLayout();
+		toolStripContainer.TopToolStripPanel.SuspendLayout();
+		toolStripContainer.SuspendLayout();
+		kryptonToolStripGenerateList.SuspendLayout();
+		contextMenuSaveToFile.SuspendLayout();
+		kryptonToolStripProgress.SuspendLayout();
 		SuspendLayout();
 		// 
 		// kryptonPanelMain
@@ -54,100 +113,868 @@ partial class OrbitElementsGroupingForm
 		kryptonPanelMain.AccessibleDescription = "Groups the data";
 		kryptonPanelMain.AccessibleName = "Panel";
 		kryptonPanelMain.AccessibleRole = AccessibleRole.Pane;
-		kryptonPanelMain.Controls.Add(progressBar);
-		kryptonPanelMain.Controls.Add(lblElementsCount);
-		kryptonPanelMain.Controls.Add(numElementsToCompare);
-		kryptonPanelMain.Controls.Add(lblTolerance);
-		kryptonPanelMain.Controls.Add(numTolerance);
-		kryptonPanelMain.Controls.Add(btnCancel);
-		kryptonPanelMain.Controls.Add(btnStart);
-		kryptonPanelMain.Controls.Add(txtOutput);
+		kryptonPanelMain.Controls.Add(kryptonTextBoxOutput);
 		kryptonPanelMain.Dock = DockStyle.Fill;
 		kryptonPanelMain.Location = new Point(0, 0);
 		kryptonPanelMain.Name = "kryptonPanelMain";
-		kryptonPanelMain.Size = new Size(784, 561);
+		kryptonPanelMain.Size = new Size(617, 338);
 		kryptonPanelMain.TabIndex = 0;
 		kryptonPanelMain.TabStop = true;
+		kryptonPanelMain.Text = "kryptonPanelMain";
+		kryptonPanelMain.Enter += Control_Enter;
+		kryptonPanelMain.Leave += Control_Leave;
+		kryptonPanelMain.MouseEnter += Control_Enter;
+		kryptonPanelMain.MouseLeave += Control_Leave;
 		// 
-		// progressBar
+		// kryptonTextBoxOutput
 		// 
-		progressBar.Location = new Point(12, 50);
-		progressBar.Name = "progressBar";
-		progressBar.Size = new Size(700, 23);
-		progressBar.TabIndex = 6;
-		progressBar.Text = "Label";
-		progressBar.TextBackdropColor = Color.Empty;
-		progressBar.TextShadowColor = Color.Empty;
+		kryptonTextBoxOutput.AccessibleDescription = "Shows the results";
+		kryptonTextBoxOutput.AccessibleName = "Results";
+		kryptonTextBoxOutput.AccessibleRole = AccessibleRole.Text;
+		kryptonTextBoxOutput.Dock = DockStyle.Fill;
+		kryptonTextBoxOutput.Location = new Point(0, 0);
+		kryptonTextBoxOutput.MaxLength = int.MaxValue;
+		kryptonTextBoxOutput.Multiline = true;
+		kryptonTextBoxOutput.Name = "kryptonTextBoxOutput";
+		kryptonTextBoxOutput.ReadOnly = true;
+		kryptonTextBoxOutput.ScrollBars = ScrollBars.Both;
+		kryptonTextBoxOutput.Size = new Size(617, 338);
+		kryptonTextBoxOutput.TabIndex = 0;
+		kryptonTextBoxOutput.ToolTipValues.Description = "Shows the results";
+		kryptonTextBoxOutput.ToolTipValues.Heading = "Results";
+		kryptonTextBoxOutput.Enter += Control_Enter;
+		kryptonTextBoxOutput.Leave += Control_Leave;
+		kryptonTextBoxOutput.MouseEnter += Control_Enter;
+		kryptonTextBoxOutput.MouseLeave += Control_Leave;
 		// 
-		// lblElementsCount
+		// kryptonStatusStrip
 		// 
-		lblElementsCount.Location = new Point(390, 15);
-		lblElementsCount.Name = "lblElementsCount";
-		lblElementsCount.Size = new Size(130, 20);
-		lblElementsCount.TabIndex = 4;
-		lblElementsCount.Values.Text = "Elements vs Elements:";
+		kryptonStatusStrip.AccessibleDescription = "Shows some information";
+		kryptonStatusStrip.AccessibleName = "Status bar with some information";
+		kryptonStatusStrip.AccessibleRole = AccessibleRole.StatusBar;
+		kryptonStatusStrip.AllowClickThrough = true;
+		kryptonStatusStrip.AllowItemReorder = true;
+		kryptonStatusStrip.Dock = DockStyle.None;
+		kryptonStatusStrip.Font = new Font("Segoe UI", 9F);
+		kryptonStatusStrip.Items.AddRange(new ToolStripItem[] { labelInformation });
+		kryptonStatusStrip.Location = new Point(0, 0);
+		kryptonStatusStrip.Name = "kryptonStatusStrip";
+		kryptonStatusStrip.ProgressBars = null;
+		kryptonStatusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
+		kryptonStatusStrip.ShowItemToolTips = true;
+		kryptonStatusStrip.Size = new Size(617, 22);
+		kryptonStatusStrip.TabIndex = 0;
+		kryptonStatusStrip.TabStop = true;
+		kryptonStatusStrip.Text = "Status bar";
+		kryptonStatusStrip.Enter += Control_Enter;
+		kryptonStatusStrip.Leave += Control_Leave;
+		kryptonStatusStrip.MouseEnter += Control_Enter;
+		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
-		// numElementsToCompare
+		// labelInformation
 		// 
-		numElementsToCompare.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-		numElementsToCompare.Location = new Point(520, 14);
-		numElementsToCompare.Maximum = new decimal(new int[] { 7, 0, 0, 0 });
-		numElementsToCompare.Minimum = new decimal(new int[] { 2, 0, 0, 0 });
-		numElementsToCompare.Name = "numElementsToCompare";
-		numElementsToCompare.Size = new Size(60, 22);
-		numElementsToCompare.TabIndex = 5;
-		numElementsToCompare.Value = new decimal(new int[] { 3, 0, 0, 0 });
+		labelInformation.AccessibleDescription = "Shows some information";
+		labelInformation.AccessibleName = "Some information";
+		labelInformation.AccessibleRole = AccessibleRole.StaticText;
+		labelInformation.AutoToolTip = true;
+		labelInformation.Image = Resources.FatcowIcons16px.fatcow_lightbulb_16px;
+		labelInformation.Name = "labelInformation";
+		labelInformation.Size = new Size(144, 17);
+		labelInformation.Text = "some information here";
+		labelInformation.ToolTipText = "Shows some information";
+		labelInformation.MouseEnter += Control_Enter;
+		labelInformation.MouseLeave += Control_Leave;
 		// 
-		// lblTolerance
+		// toolStripContainer
 		// 
-		lblTolerance.Location = new Point(210, 15);
-		lblTolerance.Name = "lblTolerance";
-		lblTolerance.Size = new Size(94, 20);
-		lblTolerance.TabIndex = 2;
-		lblTolerance.Values.Text = "Tolerance (%):";
+		toolStripContainer.AccessibleDescription = "Container to arrange the toolbars";
+		toolStripContainer.AccessibleName = "Container to arrange the toolbars";
+		toolStripContainer.AccessibleRole = AccessibleRole.Grouping;
 		// 
-		// numTolerance
+		// toolStripContainer.BottomToolStripPanel
 		// 
-		numTolerance.Increment = new decimal(new int[] { 1, 0, 0, 0 });
-		numTolerance.Location = new Point(310, 14);
-		numTolerance.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
-		numTolerance.Minimum = new decimal(new int[] { 1, 0, 0, 65536 });
-		numTolerance.Name = "numTolerance";
-		numTolerance.Size = new Size(60, 22);
-		numTolerance.TabIndex = 3;
-		numTolerance.Value = new decimal(new int[] { 5, 0, 0, 0 });
+		toolStripContainer.BottomToolStripPanel.Controls.Add(kryptonStatusStrip);
 		// 
-		// btnCancel
+		// toolStripContainer.ContentPanel
 		// 
-		btnCancel.Enabled = false;
-		btnCancel.Location = new Point(108, 12);
-		btnCancel.Name = "btnCancel";
-		btnCancel.Size = new Size(90, 25);
-		btnCancel.TabIndex = 1;
-		btnCancel.Values.DropDownArrowColor = Color.Empty;
-		btnCancel.Values.Text = "&Cancel";
-		btnCancel.Click += BtnCancel_Click;
+		toolStripContainer.ContentPanel.Controls.Add(kryptonPanelMain);
+		toolStripContainer.ContentPanel.Size = new Size(617, 338);
+		toolStripContainer.Dock = DockStyle.Fill;
+		toolStripContainer.Location = new Point(0, 0);
+		toolStripContainer.Name = "toolStripContainer";
+		toolStripContainer.Size = new Size(617, 412);
+		toolStripContainer.TabIndex = 10;
+		toolStripContainer.Text = "toolStripContainer";
 		// 
-		// btnStart
+		// toolStripContainer.TopToolStripPanel
 		// 
-		btnStart.Location = new Point(12, 12);
-		btnStart.Name = "btnStart";
-		btnStart.Size = new Size(90, 25);
-		btnStart.TabIndex = 0;
-		btnStart.Values.DropDownArrowColor = Color.Empty;
-		btnStart.Values.Text = "&Start Search";
-		btnStart.Click += BtnStart_Click;
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripGenerateList);
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripProgress);
+		toolStripContainer.Enter += Control_Enter;
+		toolStripContainer.Leave += Control_Leave;
+		toolStripContainer.MouseEnter += Control_Enter;
+		toolStripContainer.MouseLeave += Control_Leave;
 		// 
-		// txtOutput
+		// kryptonToolStripGenerateList
 		// 
-		txtOutput.Location = new Point(12, 85);
-		txtOutput.Name = "txtOutput";
-		txtOutput.ReadOnly = true;
-		txtOutput.ShowSelectionMargin = true;
-		txtOutput.Size = new Size(760, 464);
-		txtOutput.TabIndex = 8;
-		txtOutput.Text = "";
-		txtOutput.WordWrap = false;
+		kryptonToolStripGenerateList.AccessibleDescription = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleName = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripGenerateList.AllowClickThrough = true;
+		kryptonToolStripGenerateList.AllowItemReorder = true;
+		kryptonToolStripGenerateList.Dock = DockStyle.None;
+		kryptonToolStripGenerateList.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripGenerateList.Items.AddRange(new ToolStripItem[] { toolStripButtonStart, toolStripButtonCancel, toolStripSeparator1, toolStripLabelTolerance, toolStripNumericUpDownTolerance, toolStripLabelElementsCount, toolStripNumericUpDownElementsCount, toolStripSeparator2, toolStripDropDownButtonSaveList });
+		kryptonToolStripGenerateList.Location = new Point(0, 0);
+		kryptonToolStripGenerateList.Name = "kryptonToolStripGenerateList";
+		kryptonToolStripGenerateList.Size = new Size(617, 26);
+		kryptonToolStripGenerateList.Stretch = true;
+		kryptonToolStripGenerateList.TabIndex = 0;
+		kryptonToolStripGenerateList.TabStop = true;
+		kryptonToolStripGenerateList.Text = "Toolbar of generating list";
+		kryptonToolStripGenerateList.Enter += Control_Enter;
+		kryptonToolStripGenerateList.Leave += Control_Leave;
+		kryptonToolStripGenerateList.MouseEnter += Control_Enter;
+		kryptonToolStripGenerateList.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonStart
+		// 
+		toolStripButtonStart.AccessibleDescription = "Starts the progress and create the list";
+		toolStripButtonStart.AccessibleName = "Create the List";
+		toolStripButtonStart.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonStart.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripButtonStart.ImageTransparentColor = Color.Magenta;
+		toolStripButtonStart.Name = "toolStripButtonStart";
+		toolStripButtonStart.Size = new Size(45, 23);
+		toolStripButtonStart.Text = "&List";
+		toolStripButtonStart.Click += ButtonStart_Click;
+		toolStripButtonStart.MouseEnter += Control_Enter;
+		toolStripButtonStart.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonCancel
+		// 
+		toolStripButtonCancel.AccessibleDescription = "Cancels the search";
+		toolStripButtonCancel.AccessibleName = "Cancel";
+		toolStripButtonCancel.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonCancel.Enabled = false;
+		toolStripButtonCancel.Image = Resources.FatcowIcons16px.fatcow_cancel_16px;
+		toolStripButtonCancel.ImageTransparentColor = Color.Magenta;
+		toolStripButtonCancel.Name = "toolStripButtonCancel";
+		toolStripButtonCancel.Size = new Size(63, 23);
+		toolStripButtonCancel.Text = "&Cancel";
+		toolStripButtonCancel.Click += ButtonCancel_Click;
+		toolStripButtonCancel.MouseEnter += Control_Enter;
+		toolStripButtonCancel.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator1
+		// 
+		toolStripSeparator1.AccessibleDescription = "Just a separator";
+		toolStripSeparator1.AccessibleName = "Just a separator";
+		toolStripSeparator1.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator1.Name = "toolStripSeparator1";
+		toolStripSeparator1.Size = new Size(6, 26);
+		toolStripSeparator1.MouseEnter += Control_Enter;
+		toolStripSeparator1.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelTolerance
+		// 
+		toolStripLabelTolerance.AccessibleDescription = "Shows the tolerance";
+		toolStripLabelTolerance.AccessibleName = "Tolerance";
+		toolStripLabelTolerance.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelTolerance.AutoToolTip = true;
+		toolStripLabelTolerance.Name = "toolStripLabelTolerance";
+		toolStripLabelTolerance.Size = new Size(78, 23);
+		toolStripLabelTolerance.Text = "Tolerance (%)";
+		toolStripLabelTolerance.MouseEnter += Control_Enter;
+		toolStripLabelTolerance.MouseLeave += Control_Leave;
+		// 
+		// toolStripNumericUpDownTolerance
+		// 
+		toolStripNumericUpDownTolerance.AccessibleDescription = "Shows the tolerance value for the list";
+		toolStripNumericUpDownTolerance.AccessibleName = "Value of the tolerance";
+		toolStripNumericUpDownTolerance.AccessibleRole = AccessibleRole.SpinButton;
+		toolStripNumericUpDownTolerance.AutoSize = true;
+		toolStripNumericUpDownTolerance.AutoToolTip = true;
+		toolStripNumericUpDownTolerance.Minimum = new decimal(new int[] { 1, 0, 0, 65536 });
+		toolStripNumericUpDownTolerance.Name = "toolStripNumericUpDownTolerance";
+		toolStripNumericUpDownTolerance.Size = new Size(41, 23);
+		toolStripNumericUpDownTolerance.Text = "5";
+		toolStripNumericUpDownTolerance.TextAlign = HorizontalAlignment.Center;
+		toolStripNumericUpDownTolerance.Value = new decimal(new int[] { 5, 0, 0, 0 });
+		toolStripNumericUpDownTolerance.MouseEnter += Control_Enter;
+		toolStripNumericUpDownTolerance.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelElementsCount
+		// 
+		toolStripLabelElementsCount.AccessibleDescription = "Shows the element versus element";
+		toolStripLabelElementsCount.AccessibleName = "Element versus element";
+		toolStripLabelElementsCount.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelElementsCount.AutoToolTip = true;
+		toolStripLabelElementsCount.Name = "toolStripLabelElementsCount";
+		toolStripLabelElementsCount.Size = new Size(110, 23);
+		toolStripLabelElementsCount.Text = "Element &vs element";
+		toolStripLabelElementsCount.MouseEnter += Control_Enter;
+		toolStripLabelElementsCount.MouseLeave += Control_Leave;
+		// 
+		// toolStripNumericUpDownElementsCount
+		// 
+		toolStripNumericUpDownElementsCount.AccessibleDescription = "Shows the maximum value for the list";
+		toolStripNumericUpDownElementsCount.AccessibleName = "Maximum value for the list";
+		toolStripNumericUpDownElementsCount.AccessibleRole = AccessibleRole.SpinButton;
+		toolStripNumericUpDownElementsCount.AutoSize = true;
+		toolStripNumericUpDownElementsCount.AutoToolTip = true;
+		toolStripNumericUpDownElementsCount.Maximum = new decimal(new int[] { 7, 0, 0, 0 });
+		toolStripNumericUpDownElementsCount.Minimum = new decimal(new int[] { 2, 0, 0, 0 });
+		toolStripNumericUpDownElementsCount.Name = "toolStripNumericUpDownElementsCount";
+		toolStripNumericUpDownElementsCount.Size = new Size(29, 23);
+		toolStripNumericUpDownElementsCount.Text = "2";
+		toolStripNumericUpDownElementsCount.TextAlign = HorizontalAlignment.Center;
+		toolStripNumericUpDownElementsCount.Value = new decimal(new int[] { 2, 0, 0, 0 });
+		toolStripNumericUpDownElementsCount.MouseEnter += Control_Enter;
+		toolStripNumericUpDownElementsCount.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator2
+		// 
+		toolStripSeparator2.AccessibleDescription = "Just a separator";
+		toolStripSeparator2.AccessibleName = "Just a separator";
+		toolStripSeparator2.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator2.Name = "toolStripSeparator2";
+		toolStripSeparator2.Size = new Size(6, 26);
+		toolStripSeparator2.MouseEnter += Control_Enter;
+		toolStripSeparator2.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonSaveList
+		// 
+		toolStripDropDownButtonSaveList.AccessibleDescription = "Saves the list as file";
+		toolStripDropDownButtonSaveList.AccessibleName = "Save list";
+		toolStripDropDownButtonSaveList.AccessibleRole = AccessibleRole.ButtonDropDown;
+		toolStripDropDownButtonSaveList.DropDown = contextMenuSaveToFile;
+		toolStripDropDownButtonSaveList.Image = Resources.FatcowIcons16px.fatcow_diskette_16px;
+		toolStripDropDownButtonSaveList.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonSaveList.Name = "toolStripDropDownButtonSaveList";
+		toolStripDropDownButtonSaveList.Size = new Size(78, 23);
+		toolStripDropDownButtonSaveList.Text = "&Save list";
+		toolStripDropDownButtonSaveList.MouseEnter += Control_Enter;
+		toolStripDropDownButtonSaveList.MouseLeave += Control_Leave;
+		// 
+		// contextMenuSaveToFile
+		// 
+		contextMenuSaveToFile.AccessibleDescription = "Save the list as file";
+		contextMenuSaveToFile.AccessibleName = "Save list";
+		contextMenuSaveToFile.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuSaveToFile.AllowClickThrough = true;
+		contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
+		contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveToFile.Name = "contextMenuSaveList";
+		contextMenuSaveToFile.OwnerItem = toolStripDropDownButtonSaveList;
+		contextMenuSaveToFile.Size = new Size(202, 158);
+		contextMenuSaveToFile.TabStop = true;
+		contextMenuSaveToFile.Text = "&Save list";
+		contextMenuSaveToFile.MouseEnter += Control_Enter;
+		contextMenuSaveToFile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemTextFiles
+		// 
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.Image = Resources.FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsText
+		// 
+		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsText.AutoToolTip = true;
+		toolStripMenuItemSaveAsText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as &text";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsLatex
+		// 
+		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
+		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+		toolStripMenuItemSaveAsLatex.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMarkdown
+		// 
+		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
+		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+		toolStripMenuItemSaveAsMarkdown.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAsciiDoc
+		// 
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Saves the list as AsciiDoc file";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
+		toolStripMenuItemSaveAsAsciiDoc.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsReStructuredText
+		// 
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Saves the list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTextile
+		// 
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Saves the list as Textile file";
+		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
+		toolStripMenuItemSaveAsTextile.Image = Resources.FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTextile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWord
+		// 
+		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
+		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWord.AutoToolTip = true;
+		toolStripMenuItemSaveAsWord.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOdt
+		// 
+		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
+		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+		toolStripMenuItemSaveAsOdt.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsRtf
+		// 
+		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
+		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+		toolStripMenuItemSaveAsRtf.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = Resources.FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsExcel
+		// 
+		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
+		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+		toolStripMenuItemSaveAsExcel.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOds
+		// 
+		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
+		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOds.AutoToolTip = true;
+		toolStripMenuItemSaveAsOds.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsCsv
+		// 
+		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
+		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsCsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTsv
+		// 
+		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
+		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsTsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPsv
+		// 
+		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
+		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsPsv.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = Resources.FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsHtml
+		// 
+		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
+		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+		toolStripMenuItemSaveAsHtml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXml
+		// 
+		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
+		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXml.AutoToolTip = true;
+		toolStripMenuItemSaveAsXml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook file";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = Resources.FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsToml });
+		toolStripMenuItemConfigurationFiles.Image = Resources.FatcowIcons16px.fatcow_file_extension_bat_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsJson
+		// 
+		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
+		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsJson.AutoToolTip = true;
+		toolStripMenuItemSaveAsJson.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsYaml
+		// 
+		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
+		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+		toolStripMenuItemSaveAsYaml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = Resources.FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
+		toolStripMenuItemDatabaseScripts.Image = Resources.FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSql
+		// 
+		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
+		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSql.AutoToolTip = true;
+		toolStripMenuItemSaveAsSql.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+		toolStripMenuItemSaveAsSql.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = Resources.FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, toolStripMenuItemSaveAsXps, toolStripMenuItemSaveAsFictionBook2, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = Resources.FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPdf
+		// 
+		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
+		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+		toolStripMenuItemSaveAsPdf.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPostScript
+		// 
+		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
+		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+		toolStripMenuItemSaveAsPostScript.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEpub
+		// 
+		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
+		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+		toolStripMenuItemSaveAsEpub.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMobi
+		// 
+		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
+		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+		toolStripMenuItemSaveAsMobi.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXps
+		// 
+		toolStripMenuItemSaveAsXps.AccessibleDescription = "Saves the list as XPS file";
+		toolStripMenuItemSaveAsXps.AccessibleName = "Save as XPS";
+		toolStripMenuItemSaveAsXps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXps.AutoToolTip = true;
+		toolStripMenuItemSaveAsXps.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsFictionBook2
+		// 
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
+		toolStripMenuItemSaveAsFictionBook2.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = Resources.FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
+		// 
+		// kryptonToolStripProgress
+		// 
+		kryptonToolStripProgress.AccessibleDescription = "Toolbar of progress";
+		kryptonToolStripProgress.AccessibleName = "Toolbar of progress";
+		kryptonToolStripProgress.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripProgress.AllowClickThrough = true;
+		kryptonToolStripProgress.AllowItemReorder = true;
+		kryptonToolStripProgress.Dock = DockStyle.None;
+		kryptonToolStripProgress.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripProgress.Items.AddRange(new ToolStripItem[] { toolStripLabelProgress, kryptonProgressBar });
+		kryptonToolStripProgress.Location = new Point(0, 26);
+		kryptonToolStripProgress.Name = "kryptonToolStripProgress";
+		kryptonToolStripProgress.Size = new Size(617, 26);
+		kryptonToolStripProgress.Stretch = true;
+		kryptonToolStripProgress.TabIndex = 1;
+		kryptonToolStripProgress.TabStop = true;
+		kryptonToolStripProgress.Text = "Toolbar of progress";
+		kryptonToolStripProgress.Enter += Control_Enter;
+		kryptonToolStripProgress.Leave += Control_Leave;
+		kryptonToolStripProgress.MouseEnter += Control_Enter;
+		kryptonToolStripProgress.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelProgress
+		// 
+		toolStripLabelProgress.AccessibleDescription = "Shows the progress of comparing";
+		toolStripLabelProgress.AccessibleName = "Progress";
+		toolStripLabelProgress.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelProgress.AutoToolTip = true;
+		toolStripLabelProgress.Name = "toolStripLabelProgress";
+		toolStripLabelProgress.Size = new Size(52, 23);
+		toolStripLabelProgress.Text = "Pro&gress";
+		toolStripLabelProgress.MouseEnter += Control_Enter;
+		toolStripLabelProgress.MouseLeave += Control_Leave;
+		// 
+		// kryptonProgressBar
+		// 
+		kryptonProgressBar.AccessibleDescription = "Shows the progress";
+		kryptonProgressBar.AccessibleName = "Progress";
+		kryptonProgressBar.AccessibleRole = AccessibleRole.ProgressBar;
+		kryptonProgressBar.AutoToolTip = true;
+		kryptonProgressBar.Name = "kryptonProgressBar";
+		kryptonProgressBar.Size = new Size(500, 23);
+		kryptonProgressBar.StateCommon.Back.Color1 = Color.Green;
+		kryptonProgressBar.StateDisabled.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.StateNormal.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.Values.Text = "";
+		kryptonProgressBar.Enter += Control_Enter;
+		kryptonProgressBar.Leave += Control_Leave;
+		kryptonProgressBar.MouseEnter += Control_Enter;
+		kryptonProgressBar.MouseLeave += Control_Leave;
+		// 
+		// kryptonManager
+		// 
+		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
+		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 		// 
 		// OrbitElementsGroupingForm
 		// 
@@ -156,10 +983,10 @@ partial class OrbitElementsGroupingForm
 		AccessibleRole = AccessibleRole.Dialog;
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
-		ClientSize = new Size(784, 561);
+		ClientSize = new Size(617, 412);
 		ControlBox = false;
-		Controls.Add(kryptonPanelMain);
-		FormBorderStyle = FormBorderStyle.FixedToolWindow;
+		Controls.Add(toolStripContainer);
+		FormBorderStyle = FormBorderStyle.SizableToolWindow;
 		Icon = (Icon)resources.GetObject("$this.Icon");
 		MaximizeBox = false;
 		MinimizeBox = false;
@@ -170,16 +997,82 @@ partial class OrbitElementsGroupingForm
 		((ISupportInitialize)kryptonPanelMain).EndInit();
 		kryptonPanelMain.ResumeLayout(false);
 		kryptonPanelMain.PerformLayout();
+		kryptonStatusStrip.ResumeLayout(false);
+		kryptonStatusStrip.PerformLayout();
+		toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
+		toolStripContainer.BottomToolStripPanel.PerformLayout();
+		toolStripContainer.ContentPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.PerformLayout();
+		toolStripContainer.ResumeLayout(false);
+		toolStripContainer.PerformLayout();
+		kryptonToolStripGenerateList.ResumeLayout(false);
+		kryptonToolStripGenerateList.PerformLayout();
+		contextMenuSaveToFile.ResumeLayout(false);
+		kryptonToolStripProgress.ResumeLayout(false);
+		kryptonToolStripProgress.PerformLayout();
 		ResumeLayout(false);
 	}
 
 	private KryptonPanel kryptonPanelMain;
-    private KryptonButton btnStart;
-    private KryptonButton btnCancel;
-    private KryptonProgressBar progressBar;
-    private KryptonRichTextBox txtOutput;
-    private KryptonNumericUpDown numTolerance;
-    private KryptonLabel lblTolerance;
     private KryptonNumericUpDown numElementsToCompare;
     private KryptonLabel lblElementsCount;
+	private KryptonStatusStrip kryptonStatusStrip;
+	private ToolStripStatusLabel labelInformation;
+	private ToolStripContainer toolStripContainer;
+	private KryptonToolStrip kryptonToolStripGenerateList;
+	private ToolStripButton toolStripButtonStart;
+	private ToolStripSeparator toolStripSeparator1;
+	private ToolStripLabel toolStripLabelTolerance;
+	private Helpers.ToolStripNumericUpDown toolStripNumericUpDownTolerance;
+	private ToolStripLabel toolStripLabelElementsCount;
+	private Helpers.ToolStripNumericUpDown toolStripNumericUpDownElementsCount;
+	private ToolStripSeparator toolStripSeparator2;
+	private ToolStripDropDownButton toolStripDropDownButtonSaveList;
+	private KryptonManager kryptonManager;
+	private ContextMenuStrip contextMenuSaveToFile;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWord;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOds;
+	private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
+	private KryptonTextBox kryptonTextBoxOutput;
+	private KryptonToolStrip kryptonToolStripProgress;
+	private ToolStripLabel toolStripLabelProgress;
+	private KryptonProgressBarToolStripItem kryptonProgressBar;
+	private ToolStripButton toolStripButtonCancel;
 }

--- a/Forms/OrbitElementsGroupingForm.Designer.cs
+++ b/Forms/OrbitElementsGroupingForm.Designer.cs
@@ -138,6 +138,7 @@ partial class OrbitElementsGroupingForm
 		kryptonTextBoxOutput.Name = "kryptonTextBoxOutput";
 		kryptonTextBoxOutput.ReadOnly = true;
 		kryptonTextBoxOutput.ScrollBars = ScrollBars.Both;
+		kryptonTextBoxOutput.WordWrap = false;
 		kryptonTextBoxOutput.Size = new Size(617, 338);
 		kryptonTextBoxOutput.TabIndex = 0;
 		kryptonTextBoxOutput.ToolTipValues.Description = "Shows the results";
@@ -327,9 +328,9 @@ partial class OrbitElementsGroupingForm
 		toolStripNumericUpDownElementsCount.Minimum = new decimal(new int[] { 2, 0, 0, 0 });
 		toolStripNumericUpDownElementsCount.Name = "toolStripNumericUpDownElementsCount";
 		toolStripNumericUpDownElementsCount.Size = new Size(29, 23);
-		toolStripNumericUpDownElementsCount.Text = "2";
+		toolStripNumericUpDownElementsCount.Text = "3";
 		toolStripNumericUpDownElementsCount.TextAlign = HorizontalAlignment.Center;
-		toolStripNumericUpDownElementsCount.Value = new decimal(new int[] { 2, 0, 0, 0 });
+		toolStripNumericUpDownElementsCount.Value = new decimal(new int[] { 3, 0, 0, 0 });
 		toolStripNumericUpDownElementsCount.MouseEnter += Control_Enter;
 		toolStripNumericUpDownElementsCount.MouseLeave += Control_Leave;
 		// 
@@ -1015,8 +1016,6 @@ partial class OrbitElementsGroupingForm
 	}
 
 	private KryptonPanel kryptonPanelMain;
-    private KryptonNumericUpDown numElementsToCompare;
-    private KryptonLabel lblElementsCount;
 	private KryptonStatusStrip kryptonStatusStrip;
 	private ToolStripStatusLabel labelInformation;
 	private ToolStripContainer toolStripContainer;

--- a/Forms/OrbitElementsGroupingForm.cs
+++ b/Forms/OrbitElementsGroupingForm.cs
@@ -1,5 +1,7 @@
-using Krypton.Toolkit;
-
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
 using NLog;
 
 using Planetoid_DB.Helpers;
@@ -10,129 +12,211 @@ using System.Text;
 
 namespace Planetoid_DB.Forms;
 
-/// <summary>
-/// Form to analyze and group planetoids based on common orbital element ranges.
-/// </summary>
+/// <summary>Form to analyze and group planetoids based on common orbital element ranges.</summary>
+/// <remarks>This form provides functionality to group planetoids based on their orbital elements, allowing for analysis of patterns and similarities.</remarks>
 // You can customize the debugger display for this class by providing a method that returns a string representation of the instance, which will be shown in the debugger when you inspect an object of this class. In this case, the GetDebuggerDisplay method is used to return a string representation of the instance, and the DebuggerDisplay attribute is applied to the class to specify that this method should be used for the debugger display.
 [DebuggerDisplay(value: "{" + nameof(GetDebuggerDisplay) + "(),nq}")]
 public partial class OrbitElementsGroupingForm : BaseKryptonForm
 {
-	/// <summary>
-	/// NLog logger instance.
-	/// </summary>
-	/// <remarks>
-	/// This logger is used throughout the form to log important events and errors.
-	/// </remarks>
+	/// <summary>NLog logger instance.</summary>
+	/// <remarks>This logger is used throughout the form to log important events and errors.</remarks>
 	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-	/// <summary>
-	/// Gets the status label used for displaying information in the status bar.
-	/// </summary>
-	/// <remarks>
-	/// Overrides the base class property to return the form-specific status label.
-	/// </remarks>
-	//protected override ToolStripStatusLabel? StatusLabel => labelInformation;
+	/// <summary>Gets the status label used for displaying information in the status bar.</summary>
+	/// <remarks>Overrides the base class property to return the form-specific status label.</remarks>
+	protected override ToolStripStatusLabel? StatusLabel => labelInformation;
 
+	/// <summary>The list of planetoid string records to process.</summary>
+	/// <remarks>This list is provided during the form's initialization and is used for grouping operations.</remarks>
 	private readonly IReadOnlyList<string> _planetoids;
+
+	/// <summary>Stores the source used to issue cancellation requests for asynchronous operations.</summary>
+	/// <remarks>This field holds a reference to a CancellationTokenSource, which can be used to signal cancellation to one or more tasks. If null, no cancellation source is currently assigned.</remarks>
 	private CancellationTokenSource? _cancellationTokenSource;
 
-	/// <summary>
-	/// Initializes a new instance of the <see cref="OrbitElementsGroupingForm"/> class.
-	/// </summary>
+	/// <summary>Represents immutable data for a planetoid, including its identifier, name, and associated orbital elements.</summary>
+	/// <param name="Index">The unique identifier or catalog index for the planetoid.</param>
+	/// <param name="Name">The name of the planetoid.</param>
+	/// <param name="Elements">An array of double values representing the orbital elements of the planetoid. The array must not be null.</param>
+	/// <remarks>This record is used to store and manage the relevant data for each planetoid during the grouping process. The Elements array typically includes values such as mean anomaly, argument of perihelion, longitude of ascending node, inclination, orbital eccentricity, motion, and semi-major axis.</remarks>
+	private record PlanetoidData(string Index, string Name, double[] Elements);
+
+	#region Constructor
+
+	/// <summary>Initializes a new instance of the <see cref="OrbitElementsGroupingForm"/> class.</summary>
 	/// <param name="planetoids">The planetoid string records to process from the database.</param>
+	/// <remarks>Initializes the form and sets up necessary data for grouping operations.</remarks>
 	public OrbitElementsGroupingForm(IReadOnlyList<string> planetoids)
 	{
+		// Log the initialization of the form with the count of planetoids provided
 		InitializeComponent();
 		_planetoids = planetoids;
+		logger.Info(message: "OrbitElementsGroupingForm initialized with {0} planetoids.", argument: _planetoids.Count);
 	}
 
-	/// <summary>
-	/// Returns a short debugger display string for this instance.
-	/// </summary>
+	#endregion
+
+	#region helper methods
+
+	/// <summary>Returns a short debugger display string for this instance.</summary>
 	/// <returns>A string representation of the current instance for use in the debugger.</returns>
-	/// <remarks>
-	/// This method is used to provide a visual representation of the object in the debugger.
-	/// </remarks>
+	/// <remarks>This method is used to provide a visual representation of the object in the debugger.</remarks>
 	private string GetDebuggerDisplay() => ToString();
 
-	private void BtnStart_Click(object? sender, EventArgs e)
+	/// <summary>Retrieves the name of the orbital element corresponding to the specified index.</summary>
+	/// <remarks>The method maps specific indices to standard orbital element names. If an index outside the range 0–6 is provided, the method returns "Unknown".</remarks>
+	/// <param name="index">The zero-based index of the orbital element. Valid values are 0 through 6.</param>
+	/// <returns>A string representing the name of the orbital element for the given index, or "Unknown" if the index is not recognized.</returns>
+	private static string GetElementName(int index) => index switch
 	{
-		if (_planetoids.Count == 0)
+		// Map the indices to their corresponding orbital element names. This mapping is based on the order of elements as they are parsed from the planetoid data.
+		0 => "MeanAnomaly",
+		1 => "ArgPeri",
+		2 => "LongAscNode",
+		3 => "Incl",
+		4 => "OrbEcc",
+		5 => "Motion",
+		6 => "SemiMajorAxis",
+		_ => "Unknown"
+	};
+
+	/// <summary>Prepares the save dialog for exporting data.</summary>
+	/// <param name="dialog">The file dialog to prepare.</param>
+	/// <param name="ext">The file extension.</param>
+	/// <returns>True if the dialog was shown successfully; otherwise, false.</returns>
+	/// <remarks>This method is used to prepare the save dialog for exporting data.</remarks>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"Orbit-Elements-Grouping_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
+	/// <summary>Performs the save export operation by displaying a save dialog and invoking the specified export action.</summary>
+	/// <param name="filter">The file type filter for the save dialog.</param>
+	/// <param name="defaultExt">The default file extension.</param>
+	/// <param name="dialogTitle">The title of the save dialog.</param>
+	/// <param name="exportAction">The export action to invoke with the text box, title, and file name.</param>
+	/// <remarks>This method encapsulates the logic for displaying a save dialog and performing the export action based on the user's selection. It handles the preparation of the dialog, execution of the export action, and manages the cursor state during the operation.</remarks>
+	private void PerformSaveExport(string filter, string defaultExt, string dialogTitle, Action<TextBox, string, string> exportAction)
+	{
+		// Create and configure the save file dialog with the specified filter, default extension, and title. The dialog allows the user to choose where to save the exported file and what name to give it.
+		using SaveFileDialog saveFileDialog = new()
 		{
-			KryptonMessageBox.Show("No planetoid data available.", "Information", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+			Filter = filter,
+			DefaultExt = defaultExt,
+			Title = dialogTitle
+		};
+		// Prepare and show the save dialog. If the user cancels the dialog, the method returns without performing any export action.
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: defaultExt))
+		{
 			return;
 		}
-
-		btnStart.Enabled = false;
-		btnCancel.Enabled = true;
-		txtOutput.Clear();
-		progressBar.Value = 0;
-		progressBar.Text = "0%";
-
-		int elementsCount = (int)numElementsToCompare.Value;
-		double tolerancePercent = (double)numTolerance.Value / 100.0;
-
-		_cancellationTokenSource = new CancellationTokenSource();
-
-		var progress = new Progress<int>(handler: percent =>
-		{
-			progressBar.Value = percent;
-			progressBar.Text = $"{percent}%";
-		});
-
-		var messageProgress = new Progress<string>(handler: message =>
-		{
-			txtOutput.AppendText(message + Environment.NewLine);
-		});
-
-		using Task _ = Task.Run(function: () => PerformGroupingAsync(elementsCount: elementsCount, tolerancePercent: tolerancePercent, progress: progress, messageProgress: messageProgress, cancellationToken: _cancellationTokenSource.Token), cancellationToken: _cancellationTokenSource.Token);
-	}
-
-	private void BtnCancel_Click(object? sender, EventArgs e)
-	{
-		if (_cancellationTokenSource != null)
-		{
-			_cancellationTokenSource.Cancel();
-			btnCancel.Enabled = false;
-		}
-	}
-
-	private void OrbitElementsGroupingForm_FormClosing(object? sender, FormClosingEventArgs e)
-	{
-		if (_cancellationTokenSource != null)
-		{
-			_cancellationTokenSource.Cancel();
-			_cancellationTokenSource.Dispose();
-		}
-	}
-
-	private async Task PerformGroupingAsync(int elementsCount, double tolerancePercent, IProgress<int> progress, IProgress<string> messageProgress, CancellationToken cancellationToken)
-	{
+		// If the user selects a file and confirms the dialog, set the cursor to a wait cursor to indicate that an operation is in progress, and then invoke the specified export action with the text box containing the output, the title for the export, and the selected file name. After the export action is completed, reset the cursor to the default state.
 		try
 		{
-			messageProgress.Report(value: "Parsing data...");
+			Cursor.Current = Cursors.WaitCursor;
+			exportAction(kryptonTextBoxOutput.TextBox, "Orbit Elements Grouping", saveFileDialog.FileName);
+		}
+		// Handle any exceptions that may occur during the export action
+		catch (Exception ex)
+		{
+			logger.Error(message: $"An error occurred during export: {ex}");
+			MessageBox.Show(text: $"An error has occurred during export: {ex.Message}", caption: "Export Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+		}
+		// In the finally block, ensure that the cursor is reset to the default state regardless of whether the export action succeeds or fails. This ensures that the user interface remains responsive and provides appropriate feedback to the user.
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
 
+	/// <summary>Generates all possible combinations of a specified length from the provided array of elements.</summary>
+	/// <remarks>The order of elements within each combination matches their order in the input array. The method does not return duplicate combinations. If k is 0, a single empty combination is returned.</remarks>
+	/// <param name="elements">The array of elements from which combinations are generated. Cannot be null.</param>
+	/// <param name="k">The number of elements in each combination. Must be between 0 and the length of the elements array, inclusive.</param>
+	/// <returns>A list of integer arrays, where each array represents a unique combination of k elements from the input array. Returns an empty list if no combinations are possible.</returns>
+	private static List<int[]> GetKCombinations(int[] elements, int k)
+	{
+		// Validate input parameters to ensure they are within acceptable ranges. If k is less than 0 or greater than the length of the elements array, an ArgumentException is thrown.
+		if (k == 0)
+		{
+			return [.. new[] { Array.Empty<int>() }];
+		}
+		// If the elements array is empty, return an empty list of combinations, as no combinations can be generated from an empty set.
+		if (elements.Length == 0)
+		{
+			return [.. Array.Empty<int[]>()];
+		}
+		// If the number of elements in the input array matches k, return a single combination that includes all elements. This is a base case for the recursive generation of combinations.
+		if (elements.Length == k)
+		{
+			return [.. new[] { elements }];
+		}
+		// Initialize a list to hold the resulting combinations. The method uses a recursive approach to generate combinations that include the first element of the input array, as well as combinations that do not include the first element.
+		List<int[]> result = [];
+		// Generate combinations that include the first element of the input array. For each combination generated from the remaining elements (with k reduced by 1), a new combination is created by adding the first element to the front of the combination. This is done using a foreach loop that iterates through the combinations generated from the recursive call.
+		foreach ((int[]? c, int[]? res) in
+			from c in GetKCombinations(elements: [.. elements.Skip(count: 1)], k: k - 1)
+			let res = new int[k]
+			select (c, res))
+		{
+			// For each combination generated from the recursive call, create a new combination that includes the first element of the input array. The first element is assigned to the first position of the new combination array, and the rest of the elements are copied from the combination generated by the recursive call. This new combination is then added to the result list.
+			res[0] = elements[0];
+			Array.Copy(sourceArray: c, sourceIndex: 0, destinationArray: res, destinationIndex: 1, length: k - 1);
+			result.Add(item: res);
+		}
+		// Generate combinations that do not include the first element of the input array by making a recursive call to GetKCombinations with the remaining elements and the same value of k. The resulting combinations are added to the result list.
+		result.AddRange(collection: GetKCombinations(elements: [.. elements.Skip(count: 1)], k: k));
+		// Return the list of generated combinations. Each combination is represented as an array of integers, where the integers correspond to the indices of the orbital elements being analyzed for grouping.
+		return result;
+	}
+
+	#endregion
+
+	#region Task handlers
+
+	/// <summary>Performs asynchronous grouping of planetoid data based on specified orbital element combinations and a tolerance threshold, reporting progress and status messages throughout the operation.</summary>
+	/// <remarks>This method parses planetoid data, generates all possible combinations of the specified number of orbital elements, and groups planetoids whose elements are within the given tolerance. Progress and status messages are reported throughout the process. If the operation is canceled, a cancellation message is reported. Any errors encountered during processing are also reported via the message progress interface.</remarks>
+	/// <param name="elementsCount">The number of orbital elements to use when generating combinations for grouping. Must be between 1 and the total number of available elements.</param>
+	/// <param name="tolerancePercent">The tolerance, as a percentage, used to determine whether planetoid elements are considered similar for grouping purposes. Must be a non-negative value.</param>
+	/// <param name="progress">An object that receives progress updates as integer percentage values representing the overall completion of the operation.</param>
+	/// <param name="messageProgress">An object that receives status or informational messages about the current stage of processing.</param>
+	/// <param name="cancellationToken">A token that can be used to request cancellation of the operation. If cancellation is requested, the method will terminate early.</param>
+	/// <returns>A task that represents the asynchronous grouping operation.</returns>
+	private async Task PerformGroupingAsync(int elementsCount, double tolerancePercent, IProgress<int> progress, IProgress<string> messageProgress, CancellationToken cancellationToken)
+	{
+		// Validate input parameters to ensure they are within acceptable ranges. If the elementsCount is less than 1 or greater than the total number of available elements, or if the tolerancePercent is negative, an ArgumentException is thrown.
+		try
+		{
+			// Validate input parameters
+			messageProgress.Report(value: "Parsing data...");
 			// Parse valid orbital parameters
-			var parsedData = new List<PlanetoidData>();
+			List<PlanetoidData> parsedData = [];
 			object parseLock = new();
 			int parsedCount = 0;
 			int totalRecords = _planetoids.Count;
-
-			_planetoids.AsParallel().WithCancellation(cancellationToken).ForAll(line =>
+			// Use parallel processing to parse the planetoid data efficiently. Each line is processed to extract the relevant orbital elements, and valid entries are added to the parsedData list. Progress is reported every 1000 records processed.
+			_planetoids.AsParallel().WithCancellation(cancellationToken: cancellationToken).ForAll(action: line =>
 			{
 				if (line.Length >= 103)
 				{
+					// Extract the index and designation from the line. The index is taken from the first 7 characters, while the designation is taken from characters 166 to 193 if the line is long enough.
 					string index = line[..7].Trim();
-					string designation = line.Length >= 194 ? line.Substring(166, 28).Trim() : "";
-
-					if (double.TryParse(line.Substring(26, 9).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double meanAnomaly) &&
-						double.TryParse(line.Substring(37, 9).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double argPeri) &&
-						double.TryParse(line.Substring(48, 9).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double longAscNode) &&
-						double.TryParse(line.Substring(59, 9).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double incl) &&
-						double.TryParse(line.Substring(70, 9).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double orbEcc) &&
-						double.TryParse(line.Substring(80, 11).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double motion) &&
-						double.TryParse(line.Substring(92, 11).Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double semiMajorAxis))
+					string designation = line.Length >= 194 ? line.Substring(startIndex: 166, length: 28).Trim() : "";
+					// Attempt to parse the orbital elements from the line. If all elements are successfully parsed, a new PlanetoidData object is created and added to the parsedData list in a thread-safe manner using a lock.
+					if (double.TryParse(s: line.Substring(startIndex: 26, length: 9).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double meanAnomaly) &&
+						double.TryParse(s: line.Substring(startIndex: 37, length: 9).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double argPeri) &&
+						double.TryParse(s: line.Substring(startIndex: 48, length: 9).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double longAscNode) &&
+						double.TryParse(s: line.Substring(startIndex: 59, length: 9).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double incl) &&
+						double.TryParse(s: line.Substring(startIndex: 70, length: 9).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double orbEcc) &&
+						double.TryParse(s: line.Substring(startIndex: 80, length: 11).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double motion) &&
+						double.TryParse(s: line.Substring(startIndex: 92, length: 11).Trim(), style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double semiMajorAxis))
 					{
+						// If all elements are successfully parsed, create a new PlanetoidData object with the index, designation, and elements, and add it to the parsedData list in a thread-safe manner using a lock.
 						double[] elements = [meanAnomaly, argPeri, longAscNode, incl, orbEcc, motion, semiMajorAxis];
 						lock (parseLock)
 						{
@@ -140,54 +224,65 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 						}
 					}
 				}
-
+				// Increment the parsed count and report progress every 1000 records processed. The progress is calculated as a percentage of the total records.
 				int currentCount = Interlocked.Increment(location: ref parsedCount);
 				if (currentCount % 1000 == 0)
 				{
+					// Report progress every 1000 records processed. The progress is calculated as a percentage of the total records, with a step of 10% for parsing.
 					progress.Report(value: currentCount * 10 / totalRecords); // 10% step for parsing
 					TaskbarProgress.SetValue(windowHandle: Handle, progressValue: (ulong)(currentCount * 10 / totalRecords), progressMax: 100);
 				}
 			});
-
+			// After parsing is complete, check for cancellation before proceeding to the next steps. If cancellation has been requested, an OperationCanceledException will be thrown, which is caught in the outer try-catch block.
 			cancellationToken.ThrowIfCancellationRequested();
-
+			// Report that the extraction of element combinations and grouping is starting. This message is displayed in the output text box to inform the user about the current stage of processing.
 			messageProgress.Report(value: "Extracting element combinations and grouping...");
-
+			// Define the number of orbital elements to analyze for grouping. This value is taken from the user input and determines how many elements will be considered when generating combinations for grouping the planetoids.
 			int combinationThreshold = elementsCount;
-
 			// Define combinations
 			int[] indices = [0, 1, 2, 3, 4, 5, 6];
+			// Generate all possible combinations of the specified number of orbital elements to analyze and group the planetoids. The GetKCombinations method is used to generate these combinations based on the indices of the orbital elements.
 			List<int[]> combinations = [.. GetKCombinations(elements: indices, k: combinationThreshold)];
-
+			// Process each combination
 			int comboIndex = 0;
+			// Store the total number of combinations to analyze, which is used for progress reporting. This value is calculated based on the number of combinations generated and is used to provide feedback to the user about the progress of the grouping operation.
 			int totalCombos = combinations.Count;
-
+			// Iterate through each combination of orbital elements to analyze and group the planetoids. For each combination, the planetoids are sorted based on the first element in the combination, and then clustered using a binning mechanism with a specified tolerance. Progress is reported throughout the process, and if cancellation is requested, an OperationCanceledException will be thrown to terminate the operation.
 			foreach (int[] combo in combinations)
 			{
+				// Check for cancellation at the start of each combination processing. If cancellation has been requested, an OperationCanceledException will be thrown, which is caught in the outer try-catch block to handle cancellation gracefully.
 				cancellationToken.ThrowIfCancellationRequested();
-
-				messageProgress.Report($"Analyzing combination {comboIndex + 1}/{totalCombos}...");
-				// A simplified algorithm to cluster them using a generic grouping mechanism (binning with tolerance)
-				var sortedData = parsedData.OrderBy(d => d.Elements[combo[0]]).ToList();
-				var clusters = new List<List<PlanetoidData>>();
-				var currentCluster = new List<PlanetoidData>();
-
+				// Report the current combination being analyzed, including the index of the combination and the total number of combinations. This message is displayed in the output text box to inform the user about the current stage of processing.
+				messageProgress.Report(value: $"Analyzing combination {comboIndex + 1}/{totalCombos}...");
+				// A simplified algorithm to cluster them using a generic grouping mechanism (binning with tolerance)n processed to group planetoids that have similar values for the specified elements within the given tolerance.
+				List<PlanetoidData> sortedData = [.. parsedData.OrderBy(keySelector: d => d.Elements[combo[0]])];
+				// Initialize a list to hold the clusters of planetoids that are found to be similar based on the current combination of elements. Each cluster is a list of PlanetoidData objects that share similar values for the specified elements within the given tolerance.
+				List<List<PlanetoidData>> clusters = [];
+				// Initialize a temporary list to hold the current cluster of planetoids being analyzed. As the sorted data is processed, planetoids that are found to be similar based on the current combination of elements will be added to this list. When a new cluster is started, this list will be cleared and reused for the next set of similar planetoids.
+				List<PlanetoidData> currentCluster = [];
+				// Iterate through the sorted planetoid data to identify clusters of planetoids that are similar based on the current combination of elements. For each planetoid, the algorithm checks if it is similar to the representative planetoid of the current cluster (the first planetoid in the cluster) by comparing their values for the specified elements within the given tolerance. If they are similar, the current planetoid is added to the current cluster; otherwise, a new cluster is started.
 				for (int i = 0; i < sortedData.Count; i++)
 				{
+					// Check for cancellation at the start of each iteration. If cancellation has been requested, an OperationCanceledException will be thrown, which is caught in the outer try-catch block to handle cancellation gracefully.
 					cancellationToken.ThrowIfCancellationRequested();
-
-					var current = sortedData[i];
+					// Get the current planetoid data being analyzed. This planetoid will be compared to the representative planetoid of the current cluster to determine if it should be added to the cluster or if a new cluster should be started.
+					PlanetoidData current = sortedData[index: i];
+					// If the current cluster is empty, add the current planetoid as the first member of the cluster. This planetoid will serve as the representative for the cluster, and subsequent planetoids will be compared to it to determine if they belong to the same cluster.
 					if (currentCluster.Count == 0)
 					{
-						currentCluster.Add(current);
+						currentCluster.Add(item: current);
 					}
+					// If the current cluster is not empty, compare the current planetoid to the representative planetoid of the cluster (the first planetoid in the cluster) by checking if their values for the specified elements are within the given tolerance. If they are similar, add the current planetoid to the current cluster; otherwise, if the current cluster has more than one member, add it to the list of clusters and start a new cluster with the current planetoid as its first member.
 					else
 					{
-						var rep = currentCluster[0];
+						// Get the representative planetoid of the current cluster (the first planetoid in the cluster) to compare against the current planetoid. The algorithm will check if the values of the specified elements for the current planetoid are similar to those of the representative planetoid within the given tolerance.
+						PlanetoidData rep = currentCluster[index: 0];
+						// Check if the current planetoid is similar to the representative planetoid of the current cluster by comparing their values for the specified elements within the given tolerance. If all specified elements are similar, the current planetoid is added to the current cluster; otherwise, if the current cluster has more than one member, it is added to the list of clusters, and a new cluster is started with the current planetoid as its first member.
 						bool similar = true;
 						foreach (int idx in combo)
 						{
-							double diff = Math.Abs(current.Elements[idx] - rep.Elements[idx]);
+							// Calculate the absolute difference between the current planetoid's element value and the representative planetoid's element value for the current index. Then, calculate the threshold for similarity based on the representative planetoid's element value and the specified tolerance percentage. If the difference exceeds the threshold, the planetoids are not considered similar, and the loop breaks to start a new cluster.
+							double diff = Math.Abs(value: current.Elements[idx] - rep.Elements[idx]);
 							double threshold = Math.Max(0.001, rep.Elements[idx] * tolerancePercent);
 							if (diff > threshold)
 							{
@@ -195,7 +290,7 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 								break;
 							}
 						}
-
+						// If the current planetoid is similar to the representative planetoid of the current cluster, add it to the current cluster. Otherwise, if the current cluster has more than one member, add it to the list of clusters, and start a new cluster with the current planetoid as its first member.
 						if (similar)
 						{
 							currentCluster.Add(item: current);
@@ -210,110 +305,390 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 							currentCluster.Add(item: current);
 						}
 					}
-
+					// Report progress every 5000 records processed. The progress is calculated as a percentage of the total combinations and the current position within the sorted data for the current combination.
 					if (i % 5000 == 0)
 					{
 						int currentProgress = 10 + (int)(90.0 * (((double)comboIndex / totalCombos) + ((double)i / sortedData.Count / totalCombos)));
 						progress.Report(value: currentProgress);
 					}
 				}
-
+				// After processing all planetoids for the current combination, if the current cluster has more than one member, add it to the list of clusters. This ensures that any remaining cluster that was being built at the end of the loop is included in the results if it contains multiple planetoids.
 				if (currentCluster.Count > 1)
 				{
-					clusters.Add(currentCluster);
+					clusters.Add(item: currentCluster);
 				}
-
-				// Output clusters
+				// If any clusters were found for the current combination, build a message to report the details of the clusters, including the number of planetoids in each cluster and their representative planetoid. The message is built using a StringBuilder for efficiency, and it is reported through the message progress interface to be displayed in the output text box.
 				if (clusters.Count != 0)
 				{
 					StringBuilder sb = new();
-					sb.AppendLine($"--- Clusters for elements {string.Join(", ", combo.Select(GetElementName))} ---");
-
-					var orderedClusters = clusters.OrderByDescending(c => c.Count).Take(999); // Show top 999 groups
-					foreach (var group in orderedClusters)
+					sb.AppendLine(handler: $"--- Clusters for elements {string.Join(separator: ", ", values: combo.Select(GetElementName))} ---");
+					// Order clusters by size and take the top 999 groups to display. This ensures that the most significant clusters are shown to the user, while very small clusters are omitted for clarity.
+					IEnumerable<List<PlanetoidData>> orderedClusters = clusters.OrderByDescending(keySelector: c => c.Count).Take(count: 999); // Show top 999 groups
+					foreach (List<PlanetoidData> group in orderedClusters)
 					{
-						sb.AppendLine($"Found group with {group.Count} planetoids (Representative: {group[0].Index} - {group[0].Name}):");
-						foreach (var p in group.Take(999))
+						// For each cluster, append a message that includes the number of planetoids in the cluster and the representative planetoid (the first planetoid in the cluster). Then, for each planetoid in the cluster, append a line with its index, name, and the values of the specified elements. This provides detailed information about each cluster and its members.
+						sb.AppendLine(handler: $"Found group with {group.Count} planetoids (Representative: {group[index: 0].Index} - {group[index: 0].Name}):");
+						foreach (PlanetoidData? p in group.Take(count: 999))
 						{
-							sb.AppendLine($"  {p.Index} '{p.Name}' " + string.Join(", ", combo.Select(c => $"{GetElementName(c)}={p.Elements[c]:F4}")));
+							// Append a line for each planetoid in the cluster, showing its index, name, and the values of the specified elements. The element values are formatted to four decimal places for readability. This provides detailed information about each member of the cluster.
+							sb.AppendLine(value: $"  {p.Index} '{p.Name}' {string.Join(separator: ", ", values: combo.Select(c => $"{GetElementName(index: c)}={p.Elements[c]:F4}"))}");
 						}
-						//if (group.Count > 5) sb.AppendLine("  ...");
+						// Append a new line after each cluster for better readability in the output text box.
 						sb.AppendLine();
 					}
-					messageProgress.Report(sb.ToString());
+					// Report the details of the clusters found for the current combination through the message progress interface, which will display the information in the output text box. This allows the user to see the results of the grouping operation for each combination of elements.
+					messageProgress.Report(value: sb.ToString());
 				}
-
+				// Increment the combination index to move on to the next combination of elements for analysis. This index is used for progress reporting and to keep track of which combination is currently being processed.
 				comboIndex++;
 			}
-
-			progress.Report(100);
-			messageProgress.Report("Search completed successfully.");
+			// After all combinations have been processed, report that the search has been completed successfully. This message is displayed in the output text box to inform the user that the grouping operation has finished.
+			progress.Report(value: 100);
+			messageProgress.Report(value: "Search completed successfully.");
 		}
+		// Handle cancellation of the operation gracefully by catching the OperationCanceledException. When cancellation is requested, a message is reported to inform the user that the search has been canceled.
 		catch (OperationCanceledException)
 		{
-			messageProgress.Report("Search canceled by user.");
+			messageProgress.Report(value: "Search canceled by user.");
+			logger.Info(message: "Search operation was canceled by the user.");
 		}
+		// Catch any other exceptions that may occur during processing and report the error message through the message progress interface. Additionally, log the error using the NLog logger to provide details about the exception for troubleshooting purposes.
 		catch (Exception ex)
 		{
-			messageProgress.Report($"Error during processing: {ex.Message}");
+			messageProgress.Report(value: $"Error during processing: {ex.Message}");
+			logger.Error(message: $"Error during processing: {ex.Message}", exception: ex);
 		}
+		// In the finally block, ensure that the cancellation token source is disposed of to free resources, and reset the UI elements (Start and Cancel buttons) to their default states. This ensures that the form is ready for another operation if needed, and that resources are properly cleaned up regardless of how the operation completed.
 		finally
 		{
 			_cancellationTokenSource?.Dispose();
 			_cancellationTokenSource = null;
 			await InvokeAsync(callback: () =>
 			{
-				btnStart.Enabled = true;
-				btnCancel.Enabled = false;
+				toolStripButtonStart.Enabled = true;
+				toolStripButtonCancel.Enabled = false;
 			}, cancellationToken: cancellationToken);
 		}
 	}
 
-	private static string GetElementName(int index) => index switch
+	#endregion
+
+	#region Form event handlers
+
+	/// <summary>Handles the FormClosing event to ensure that any ongoing operations are properly canceled and resources are released.</summary>
+	/// <remarks>Checks if a cancellation token source is available, and if so, issues a cancellation request and disposes of the token source to free resources.</remarks>
+	private void OrbitElementsGroupingForm_FormClosing(object? sender, FormClosingEventArgs e)
 	{
-		0 => "MeanAnomaly",
-		1 => "ArgPeri",
-		2 => "LongAscNode",
-		3 => "Incl",
-		4 => "OrbEcc",
-		5 => "Motion",
-		6 => "SemiMajorAxis",
-		_ => "Unknown"
-	};
-
-	private static List<int[]> GetKCombinations(int[] elements, int k)
-	{
-		if (k == 0)
+		// Check if a cancellation token source is currently assigned. If it is, call the Cancel method to signal cancellation to any ongoing operations, and dispose of the token source to free resources.
+		if (_cancellationTokenSource != null)
 		{
-			return [.. new[] { Array.Empty<int>() }];
+			_cancellationTokenSource.Cancel();
+			_cancellationTokenSource.Dispose();
 		}
-
-		if (elements.Length == 0)
-		{
-			return [.. Array.Empty<int[]>()];
-		}
-
-		if (elements.Length == k)
-		{
-			return [.. new[] { elements }];
-		}
-
-		List<int[]> result = [];
-		foreach ((int[]? c, int[]? res) in
-		// combinations with first element
-		from c in GetKCombinations([.. elements.Skip(count: 1)], k: k - 1)
-		let res = new int[k]
-		select (c, res))
-		{
-			res[0] = elements[0];
-			Array.Copy(sourceArray: c, sourceIndex: 0, destinationArray: res, destinationIndex: 1, length: k - 1);
-			result.Add(item: res);
-		}
-		// combinations without first element
-		result.AddRange(collection: GetKCombinations(elements: [.. elements.Skip(count: 1)], k: k));
-
-		return result;
 	}
 
-	private record PlanetoidData(string Index, string Name, double[] Elements);
+	#endregion
+
+	#region Click event handlers
+
+	/// <summary>Handles the Click event of the Start button to initiate the planetoid grouping process.</summary>
+	/// <remarks>Disables the Start button, enables the Cancel button, resets progress indicators, and starts the grouping operation asynchronously. Displays an informational message if no planetoid data is available.</remarks>
+	/// <param name="sender">The source of the event, typically the Start button.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private async void ButtonStart_Click(object? sender, EventArgs e)
+	{
+		// Check if there are any planetoid records to process. If not, show an informational message and return.
+		if (_planetoids.Count == 0)
+		{
+			logger.Error(message: "No planetoid data available to process.");
+			MessageBox.Show(text: "No planetoid data available.", caption: "Information", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
+			return;
+		}
+		// Disable the Start button to prevent multiple concurrent operations and enable the Cancel button to allow cancellation of the ongoing operation.
+		toolStripButtonStart.Enabled = false;
+		toolStripButtonCancel.Enabled = true;
+		toolStripNumericUpDownTolerance.Enabled = false;
+		toolStripNumericUpDownElementsCount.Enabled = false;
+		toolStripDropDownButtonSaveList.Enabled = false;
+		kryptonTextBoxOutput.Clear();
+		kryptonProgressBar.Value = 0;
+		kryptonProgressBar.Text = "0%";
+		// Retrieve the number of elements to group by and the tolerance percentage from the respective numeric up-down controls.
+		int elementsCount = (int)toolStripNumericUpDownElementsCount.Value;
+		double tolerancePercent = (double)toolStripNumericUpDownTolerance.Value / 100.0;
+		// Initialize a new CancellationTokenSource to manage cancellation of the asynchronous grouping operation.
+		_cancellationTokenSource = new();
+		// Set up progress reporting for both percentage completion and message updates. The percentage progress updates the progress bar and its text, while the message progress appends messages to the output text box.
+		Progress<int> progress = new(handler: percent =>
+		{
+			kryptonProgressBar.Value = percent;
+			kryptonProgressBar.Text = $"{percent}%";
+		});
+		// The message progress handler appends messages to the output text box, ensuring that each message is followed by a new line for readability.
+		Progress<string> messageProgress = new(handler: message => kryptonTextBoxOutput.AppendText(text: message + Environment.NewLine));
+		// Start the grouping operation asynchronously using Task.Run, passing the necessary parameters and the cancellation token. The operation will run on a background thread, allowing the UI to remain responsive.
+		try
+		{
+			await Task.Run(function: () => PerformGroupingAsync(elementsCount: elementsCount, tolerancePercent: tolerancePercent, progress: progress, messageProgress: messageProgress, cancellationToken: _cancellationTokenSource.Token), cancellationToken: _cancellationTokenSource.Token);
+		}
+		// Handle cancellation of the operation gracefully by catching the OperationCanceledException. When cancellation is requested, an informational message is logged to indicate that the grouping task was canceled.
+		catch (OperationCanceledException)
+		{
+			logger.Info(message: "Grouping task was canceled.");
+		}
+		// Catch any exceptions that may occur during the execution of the grouping operation and log the error message using the NLog logger. This provides details about any issues that arise during processing for troubleshooting purposes.
+		catch (Exception ex)
+		{
+			logger.Error(message: $"An error occurred during grouping: {ex}");
+			MessageBox.Show(text: $"An error has occurred during grouping: {ex.Message}", caption: "Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+		}
+		// In the finally block, ensure that the cancellation token source is disposed of to free resources, and reset the UI elements (Start and Cancel buttons) to their default states. This ensures that the form is ready for another operation if needed, and that resources are properly cleaned up regardless of how the operation completed.
+		finally
+		{
+			// Re-enable the Start button and disable the Cancel button regardless of the outcome.
+			toolStripButtonStart.Enabled = true;
+			toolStripButtonCancel.Enabled = false;
+			toolStripNumericUpDownTolerance.Enabled = true;
+			toolStripNumericUpDownElementsCount.Enabled = true;
+			toolStripDropDownButtonSaveList.Enabled = true;
+		}
+	}
+
+	/// <summary>Handles the Click event of the Cancel button to request cancellation of the ongoing grouping operation.</summary>
+	/// <remarks>Checks if a cancellation token source is available, and if so, issues a cancellation request and disables the Cancel button to prevent multiple cancellation attempts.</remarks>
+	private void ButtonCancel_Click(object? sender, EventArgs e)
+	{
+		// Check if a cancellation token source is currently assigned. If it is, call the Cancel method to signal cancellation to the ongoing operation, and disable the Cancel button to prevent further cancellation attempts.
+		if (_cancellationTokenSource != null)
+		{
+			_cancellationTokenSource.Cancel();
+			toolStripButtonCancel.Enabled = false;
+		}
+	}
+
+	/// <summary>Handles the Click event to export the output as a text file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsText_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Text Files (*.txt)|*.txt|All Files (*.*)|*.*", defaultExt: "txt", dialogTitle: "Save as Text", exportAction: TextBoxExporter.SaveAsText);
+
+	/// <summary>Handles the Click event to export the output as a LaTeX file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsLatex_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "LaTeX Files (*.tex)|*.tex|All Files (*.*)|*.*", defaultExt: "tex", dialogTitle: "Save as LaTeX", exportAction: TextBoxExporter.SaveAsLatex);
+
+	/// <summary>Handles the Click event to export the output as a Markdown file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Markdown Files (*.md)|*.md|All Files (*.*)|*.*", defaultExt: "md", dialogTitle: "Save as Markdown", exportAction: TextBoxExporter.SaveAsMarkdown);
+
+	/// <summary>Handles the Click event to export the output as an AsciiDoc file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "AsciiDoc Files (*.adoc)|*.adoc|All Files (*.*)|*.*", defaultExt: "adoc", dialogTitle: "Save as AsciiDoc", exportAction: TextBoxExporter.SaveAsAsciiDoc);
+
+	/// <summary>Handles the Click event to export the output as a ReStructuredText file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "ReStructuredText Files (*.rst)|*.rst|All Files (*.*)|*.*", defaultExt: "rst", dialogTitle: "Save as ReStructuredText", exportAction: TextBoxExporter.SaveAsReStructuredText);
+
+	/// <summary>Handles the Click event to export the output as a Textile file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Textile Files (*.textile)|*.textile|All Files (*.*)|*.*", defaultExt: "textile", dialogTitle: "Save as Textile", exportAction: TextBoxExporter.SaveAsTextile);
+
+	/// <summary>Handles the Click event to export the output as a Word file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWord_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Word Files (*.docx)|*.docx|All Files (*.*)|*.*", defaultExt: "docx", dialogTitle: "Save as Word", exportAction: TextBoxExporter.SaveAsWord);
+
+	/// <summary>Handles the Click event to export the output as an OpenDocument Text file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOdt_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "OpenDocument Text Files (*.odt)|*.odt|All Files (*.*)|*.*", defaultExt: "odt", dialogTitle: "Save as OpenDocument Text", exportAction: TextBoxExporter.SaveAsOdt);
+
+	/// <summary>Handles the Click event to export the output as an RTF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsRtf_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Rich Text Format Files (*.rtf)|*.rtf|All Files (*.*)|*.*", defaultExt: "rtf", dialogTitle: "Save as RTF", exportAction: TextBoxExporter.SaveAsRtf);
+
+	/// <summary>Handles the Click event to export the output as an Abiword file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Abiword Files (*.abw)|*.abw|All Files (*.*)|*.*", defaultExt: "abw", dialogTitle: "Save as Abiword", exportAction: TextBoxExporter.SaveAsAbiword);
+
+	/// <summary>Handles the Click event to export the output as a WPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "WPS Files (*.wps)|*.wps|All Files (*.*)|*.*", defaultExt: "wps", dialogTitle: "Save as WPS", exportAction: TextBoxExporter.SaveAsWps);
+
+	/// <summary>Handles the Click event to export the output as an Excel file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsExcel_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*", defaultExt: "xlsx", dialogTitle: "Save as Excel", exportAction: TextBoxExporter.SaveAsExcel);
+
+	/// <summary>Handles the Click event to export the output as an ODS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOds_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "OpenDocument Spreadsheet Files (*.ods)|*.ods|All Files (*.*)|*.*", defaultExt: "ods", dialogTitle: "Save as ODS", exportAction: TextBoxExporter.SaveAsOds);
+
+	/// <summary>Handles the Click event to export the output as a CSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsCsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Comma-Separated Values (*.csv)|*.csv|All Files (*.*)|*.*", defaultExt: "csv", dialogTitle: "Save as CSV", exportAction: TextBoxExporter.SaveAsCsv);
+
+	/// <summary>Handles the Click event to export the output as a TSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Tab-Separated Values (*.tsv)|*.tsv|All Files (*.*)|*.*", defaultExt: "tsv", dialogTitle: "Save as TSV", exportAction: TextBoxExporter.SaveAsTsv);
+
+	/// <summary>Handles the Click event to export the output as a PSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Pipe-Separated Values (*.psv)|*.psv|All Files (*.*)|*.*", defaultExt: "psv", dialogTitle: "Save as PSV", exportAction: TextBoxExporter.SaveAsPsv);
+
+	/// <summary>Handles the Click event to export the output as an ET file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "ET Files (*.et)|*.et|All Files (*.*)|*.*", defaultExt: "et", dialogTitle: "Save as ET", exportAction: TextBoxExporter.SaveAsEt);
+
+	/// <summary>Handles the Click event to export the output as an HTML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsHtml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "HTML Files (*.html)|*.html|All Files (*.*)|*.*", defaultExt: "html", dialogTitle: "Save as HTML", exportAction: TextBoxExporter.SaveAsHtml);
+
+	/// <summary>Handles the Click event to export the output as an XML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "XML Files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as XML", exportAction: TextBoxExporter.SaveAsXml);
+
+	/// <summary>Handles the Click event to export the output as a DocBook file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as DocBook", exportAction: TextBoxExporter.SaveAsDocBook);
+
+	/// <summary>Handles the Click event to export the output as a JSON file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsJson_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "JSON Files (*.json)|*.json|All Files (*.*)|*.*", defaultExt: "json", dialogTitle: "Save as JSON", exportAction: TextBoxExporter.SaveAsJson);
+
+	/// <summary>Handles the Click event to export the output as a YAML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsYaml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "YAML Files (*.yaml)|*.yaml|All Files (*.*)|*.*", defaultExt: "yaml", dialogTitle: "Save as YAML", exportAction: TextBoxExporter.SaveAsYaml);
+
+	/// <summary>Handles the Click event to export the output as a TOML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*", defaultExt: "toml", dialogTitle: "Save as TOML", exportAction: TextBoxExporter.SaveAsToml);
+
+	/// <summary>Handles the Click event to export the output as a SQL file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSql_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "SQL Files (*.sql)|*.sql|All Files (*.*)|*.*", defaultExt: "sql", dialogTitle: "Save as SQL", exportAction: TextBoxExporter.SaveAsSql);
+
+	/// <summary>Handles the Click event to export the output as a SQLite file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "SQLite Files (*.sqlite)|*.sqlite|All Files (*.*)|*.*", defaultExt: "sqlite", dialogTitle: "Save as SQLite", exportAction: TextBoxExporter.SaveAsSqlite);
+
+	/// <summary>Handles the Click event to export the output as a PDF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPdf_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "PDF Files (*.pdf)|*.pdf|All Files (*.*)|*.*", defaultExt: "pdf", dialogTitle: "Save as PDF", exportAction: TextBoxExporter.SaveAsPdf);
+
+	/// <summary>Handles the Click event to export the output as a PostScript file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "PostScript Files (*.ps)|*.ps|All Files (*.*)|*.*", defaultExt: "ps", dialogTitle: "Save as PostScript", exportAction: TextBoxExporter.SaveAsPostScript);
+
+	/// <summary>Handles the Click event to export the output as an EPUB file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEpub_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "EPUB Files (*.epub)|*.epub|All Files (*.*)|*.*", defaultExt: "epub", dialogTitle: "Save as EPUB", exportAction: TextBoxExporter.SaveAsEpub);
+
+	/// <summary>Handles the Click event to export the output as a MOBI file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMobi_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "MOBI Files (*.mobi)|*.mobi|All Files (*.*)|*.*", defaultExt: "mobi", dialogTitle: "Save as MOBI", exportAction: TextBoxExporter.SaveAsMobi);
+
+	/// <summary>Handles the Click event to export the output as an XPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*", defaultExt: "xps", dialogTitle: "Save as XPS", exportAction: TextBoxExporter.SaveAsXps);
+
+	/// <summary>Handles the Click event to export the output as a FictionBook2 file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "FictionBook2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*", defaultExt: "fb2", dialogTitle: "Save as FictionBook2", exportAction: TextBoxExporter.SaveAsFictionBook2);
+
+	/// <summary>Handles the Click event to export the output as a CHM file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Compiled HTML Help Files (*.chm)|*.chm|All Files (*.*)|*.*", defaultExt: "chm", dialogTitle: "Save as CHM", exportAction: TextBoxExporter.SaveAsChm);
+
+	#endregion
 }

--- a/Forms/OrbitElementsGroupingForm.cs
+++ b/Forms/OrbitElementsGroupingForm.cs
@@ -187,18 +187,34 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 	/// <param name="messageProgress">An object that receives status or informational messages about the current stage of processing.</param>
 	/// <param name="cancellationToken">A token that can be used to request cancellation of the operation. If cancellation is requested, the method will terminate early.</param>
 	/// <returns>A task that represents the asynchronous grouping operation.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="elementsCount"/> is less than 1, greater than the number of available orbital elements, or when <paramref name="tolerancePercent"/> is negative.</exception>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="progress"/> or <paramref name="messageProgress"/> is <see langword="null"/>.</exception>
 	private async Task PerformGroupingAsync(int elementsCount, double tolerancePercent, IProgress<int> progress, IProgress<string> messageProgress, CancellationToken cancellationToken)
 	{
-		// Validate input parameters to ensure they are within acceptable ranges. If the elementsCount is less than 1 or greater than the total number of available elements, or if the tolerancePercent is negative, an ArgumentException is thrown.
+		const int availableElementsCount = 7;
+
+		ArgumentNullException.ThrowIfNull(argument: progress);
+		ArgumentNullException.ThrowIfNull(argument: messageProgress);
+		ArgumentOutOfRangeException.ThrowIfNegative(value: tolerancePercent);
+
+		if (elementsCount < 1 || elementsCount > availableElementsCount)
+		{
+			throw new ArgumentOutOfRangeException(
+				paramName: nameof(elementsCount),
+				actualValue: elementsCount,
+				message: $"The value must be between 1 and {availableElementsCount}.");
+		}
+
 		try
 		{
-			// Validate input parameters
 			messageProgress.Report(value: "Parsing data...");
 			// Parse valid orbital parameters
 			List<PlanetoidData> parsedData = [];
 			object parseLock = new();
 			int parsedCount = 0;
 			int totalRecords = _planetoids.Count;
+			// Capture the window handle on the UI thread before entering parallel processing.
+			IntPtr windowHandle = Handle;
 			// Use parallel processing to parse the planetoid data efficiently. Each line is processed to extract the relevant orbital elements, and valid entries are added to the parsedData list. Progress is reported every 1000 records processed.
 			_planetoids.AsParallel().WithCancellation(cancellationToken: cancellationToken).ForAll(action: line =>
 			{
@@ -230,7 +246,7 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 				{
 					// Report progress every 1000 records processed. The progress is calculated as a percentage of the total records, with a step of 10% for parsing.
 					progress.Report(value: currentCount * 10 / totalRecords); // 10% step for parsing
-					TaskbarProgress.SetValue(windowHandle: Handle, progressValue: (ulong)(currentCount * 10 / totalRecords), progressMax: 100);
+					TaskbarProgress.SetValue(windowHandle: windowHandle, progressValue: (ulong)(currentCount * 10 / totalRecords), progressMax: 100);
 				}
 			});
 			// After parsing is complete, check for cancellation before proceeding to the next steps. If cancellation has been requested, an OperationCanceledException will be thrown, which is caught in the outer try-catch block.
@@ -254,7 +270,7 @@ public partial class OrbitElementsGroupingForm : BaseKryptonForm
 				cancellationToken.ThrowIfCancellationRequested();
 				// Report the current combination being analyzed, including the index of the combination and the total number of combinations. This message is displayed in the output text box to inform the user about the current stage of processing.
 				messageProgress.Report(value: $"Analyzing combination {comboIndex + 1}/{totalCombos}...");
-				// A simplified algorithm to cluster them using a generic grouping mechanism (binning with tolerance)n processed to group planetoids that have similar values for the specified elements within the given tolerance.
+				// A simplified algorithm clusters planetoids using a generic grouping mechanism (binning with tolerance) to group planetoids that have similar values for the specified elements within the given tolerance.
 				List<PlanetoidData> sortedData = [.. parsedData.OrderBy(keySelector: d => d.Elements[combo[0]])];
 				// Initialize a list to hold the clusters of planetoids that are found to be similar based on the current combination of elements. Each cluster is a list of PlanetoidData objects that share similar values for the specified elements within the given tolerance.
 				List<List<PlanetoidData>> clusters = [];

--- a/Forms/OrbitElementsGroupingForm.resx
+++ b/Forms/OrbitElementsGroupingForm.resx
@@ -117,6 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>22, 12</value>
+  </metadata>
+  <metadata name="kryptonToolStripGenerateList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>177, 14</value>
+  </metadata>
+  <metadata name="contextMenuSaveToFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>525, 14</value>
+  </metadata>
+  <metadata name="kryptonToolStripProgress.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>704, 14</value>
+  </metadata>
+  <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>383, 14</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>42</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
Redesigns `OrbitElementsGroupingForm` to use ToolStrip-based controls (start/cancel, parameters, progress, and export options) and a status strip, updating the layout/resources accordingly.

**Changes:**
- Replaced the previous button/label/numeric layout with ToolStrips, StatusStrip, and a ToolStripContainer layout.
- Switched the results output control to a read-only multiline `KryptonTextBox` and added extensive export menu items.
- Updated the grouping/export implementation to wire up new UI elements and status reporting.