### PR TITLE
Redesigned `ObservationsForm`

### DIFF
--- a/Forms/ObservationsForm.Designer.cs
+++ b/Forms/ObservationsForm.Designer.cs
@@ -53,16 +53,65 @@ partial class ObservationsForm
 		columnHeaderObservedDeclination = new ColumnHeader();
 		columnHeaderObservedMagnitudeAndBand = new ColumnHeader();
 		columnHeaderObservatoryCode = new ColumnHeader();
+		contextMenuSaveToFile = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
+		toolStripDropDownButtonSaveList = new ToolStripDropDownButton();
 		kryptonStatusStrip = new KryptonStatusStrip();
 		labelInformation = new ToolStripStatusLabel();
 		kryptonManager = new KryptonManager(components);
 		toolStripContainer = new ToolStripContainer();
+		kryptonToolStripGenerateList = new KryptonToolStrip();
+		toolStripButtonReload = new ToolStripButton();
+		toolStripSeparator1 = new ToolStripSeparator();
+		toolStripLabelProgress = new ToolStripLabel();
+		kryptonProgressBar = new KryptonProgressBarToolStripItem();
 		((ISupportInitialize)kryptonPanelMain).BeginInit();
 		kryptonPanelMain.SuspendLayout();
+		contextMenuSaveToFile.SuspendLayout();
 		kryptonStatusStrip.SuspendLayout();
 		toolStripContainer.BottomToolStripPanel.SuspendLayout();
 		toolStripContainer.ContentPanel.SuspendLayout();
+		toolStripContainer.TopToolStripPanel.SuspendLayout();
 		toolStripContainer.SuspendLayout();
+		kryptonToolStripGenerateList.SuspendLayout();
 		SuspendLayout();
 		// 
 		// kryptonPanelMain
@@ -75,7 +124,7 @@ partial class ObservationsForm
 		kryptonPanelMain.Location = new Point(0, 0);
 		kryptonPanelMain.Name = "kryptonPanelMain";
 		kryptonPanelMain.PanelBackStyle = PaletteBackStyle.FormMain;
-		kryptonPanelMain.Size = new Size(1024, 500);
+		kryptonPanelMain.Size = new Size(744, 450);
 		kryptonPanelMain.TabIndex = 0;
 		kryptonPanelMain.TabStop = true;
 		kryptonPanelMain.Text = "Mainpanel";
@@ -90,24 +139,16 @@ partial class ObservationsForm
 		listView.AccessibleName = "Observations list";
 		listView.AccessibleRole = AccessibleRole.List;
 		listView.AllowColumnReorder = true;
-		listView.Columns.AddRange(new ColumnHeader[] {
-			columnHeaderPackedMinorPlanetNumber,
-			columnHeaderPackedProvisionalDesignation,
-			columnHeaderDiscoveryAsterisk,
-			columnHeaderDateOfObservation,
-			columnHeaderObservedRectascension,
-			columnHeaderObservedDeclination,
-			columnHeaderObservedMagnitudeAndBand,
-			columnHeaderObservatoryCode });
+		listView.Columns.AddRange(new ColumnHeader[] { columnHeaderPackedMinorPlanetNumber, columnHeaderPackedProvisionalDesignation, columnHeaderDiscoveryAsterisk, columnHeaderDateOfObservation, columnHeaderObservedRectascension, columnHeaderObservedDeclination, columnHeaderObservedMagnitudeAndBand, columnHeaderObservatoryCode });
+		listView.ContextMenuStrip = contextMenuSaveToFile;
 		listView.Dock = DockStyle.Fill;
 		listView.Font = new Font("Segoe UI", 9F);
 		listView.FullRowSelect = true;
 		listView.GridLines = true;
-		listView.HideSelection = false;
 		listView.Location = new Point(0, 0);
 		listView.Name = "listView";
 		listView.ShowItemToolTips = true;
-		listView.Size = new Size(1024, 500);
+		listView.Size = new Size(744, 450);
 		listView.TabIndex = 0;
 		listView.UseCompatibleStateImageBehavior = false;
 		listView.View = View.Details;
@@ -139,13 +180,13 @@ partial class ObservationsForm
 		// 
 		// columnHeaderObservedRectascension
 		// 
-		columnHeaderObservedRectascension.Text = "R.A.";
-		columnHeaderObservedRectascension.Width = 100;
+		columnHeaderObservedRectascension.Text = "Rectascension";
+		columnHeaderObservedRectascension.Width = 90;
 		// 
 		// columnHeaderObservedDeclination
 		// 
 		columnHeaderObservedDeclination.Text = "Declination";
-		columnHeaderObservedDeclination.Width = 100;
+		columnHeaderObservedDeclination.Width = 90;
 		// 
 		// columnHeaderObservedMagnitudeAndBand
 		// 
@@ -156,6 +197,500 @@ partial class ObservationsForm
 		// 
 		columnHeaderObservatoryCode.Text = "Obs. Code";
 		columnHeaderObservatoryCode.Width = 70;
+		// 
+		// contextMenuSaveToFile
+		// 
+		contextMenuSaveToFile.AccessibleDescription = "Save the list as file";
+		contextMenuSaveToFile.AccessibleName = "Save list";
+		contextMenuSaveToFile.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuSaveToFile.AllowClickThrough = true;
+		contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
+		contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveToFile.Name = "contextMenuSaveList";
+		contextMenuSaveToFile.OwnerItem = toolStripDropDownButtonSaveList;
+		contextMenuSaveToFile.Size = new Size(202, 158);
+		contextMenuSaveToFile.TabStop = true;
+		contextMenuSaveToFile.Text = "&Save list";
+		// 
+		// toolStripMenuItemTextFiles
+		// 
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.Image = FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		// 
+		// toolStripMenuItemSaveAsText
+		// 
+		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsText.AutoToolTip = true;
+		toolStripMenuItemSaveAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as &text";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		// 
+		// toolStripMenuItemSaveAsLatex
+		// 
+		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
+		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+		toolStripMenuItemSaveAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		// 
+		// toolStripMenuItemSaveAsMarkdown
+		// 
+		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
+		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+		toolStripMenuItemSaveAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		// 
+		// toolStripMenuItemSaveAsAsciiDoc
+		// 
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Saves the list as AsciiDoc file";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
+		toolStripMenuItemSaveAsAsciiDoc.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		// 
+		// toolStripMenuItemSaveAsReStructuredText
+		// 
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Saves the list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		// 
+		// toolStripMenuItemSaveAsTextile
+		// 
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Saves the list as Textile file";
+		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
+		toolStripMenuItemSaveAsTextile.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		// 
+		// toolStripMenuItemSaveAsWord
+		// 
+		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
+		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWord.AutoToolTip = true;
+		toolStripMenuItemSaveAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		// 
+		// toolStripMenuItemSaveAsOdt
+		// 
+		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
+		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+		toolStripMenuItemSaveAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		// 
+		// toolStripMenuItemSaveAsRtf
+		// 
+		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
+		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+		toolStripMenuItemSaveAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		// 
+		// toolStripMenuItemSaveAsExcel
+		// 
+		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
+		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+		toolStripMenuItemSaveAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		// 
+		// toolStripMenuItemSaveAsOds
+		// 
+		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
+		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOds.AutoToolTip = true;
+		toolStripMenuItemSaveAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		// 
+		// toolStripMenuItemSaveAsCsv
+		// 
+		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
+		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		// 
+		// toolStripMenuItemSaveAsTsv
+		// 
+		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
+		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		// 
+		// toolStripMenuItemSaveAsPsv
+		// 
+		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
+		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		// 
+		// toolStripMenuItemSaveAsHtml
+		// 
+		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
+		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		// 
+		// toolStripMenuItemSaveAsXml
+		// 
+		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
+		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXml.AutoToolTip = true;
+		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook file";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsYaml, toolStripMenuItemSaveAsToml });
+		toolStripMenuItemConfigurationFiles.Image = FatcowIcons16px.fatcow_file_extension_bat_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		// 
+		// toolStripMenuItemSaveAsJson
+		// 
+		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
+		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsJson.AutoToolTip = true;
+		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		// 
+		// toolStripMenuItemSaveAsYaml
+		// 
+		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
+		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
+		toolStripMenuItemDatabaseScripts.Image = FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		// 
+		// toolStripMenuItemSaveAsSql
+		// 
+		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
+		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSql.AutoToolTip = true;
+		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+		toolStripMenuItemSaveAsSql.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, toolStripMenuItemSaveAsXps, toolStripMenuItemSaveAsFictionBook2, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		// 
+		// toolStripMenuItemSaveAsPdf
+		// 
+		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
+		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+		toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		// 
+		// toolStripMenuItemSaveAsPostScript
+		// 
+		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
+		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+		toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		// 
+		// toolStripMenuItemSaveAsEpub
+		// 
+		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
+		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+		toolStripMenuItemSaveAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		// 
+		// toolStripMenuItemSaveAsMobi
+		// 
+		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
+		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+		toolStripMenuItemSaveAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		// 
+		// toolStripMenuItemSaveAsXps
+		// 
+		toolStripMenuItemSaveAsXps.AccessibleDescription = "Saves the list as XPS file";
+		toolStripMenuItemSaveAsXps.AccessibleName = "Save as XPS";
+		toolStripMenuItemSaveAsXps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXps.AutoToolTip = true;
+		toolStripMenuItemSaveAsXps.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		// 
+		// toolStripMenuItemSaveAsFictionBook2
+		// 
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
+		toolStripMenuItemSaveAsFictionBook2.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		// 
+		// toolStripDropDownButtonSaveList
+		// 
+		toolStripDropDownButtonSaveList.AccessibleDescription = "Saves the list as file";
+		toolStripDropDownButtonSaveList.AccessibleName = "Save list";
+		toolStripDropDownButtonSaveList.AccessibleRole = AccessibleRole.ButtonDropDown;
+		toolStripDropDownButtonSaveList.DropDown = contextMenuSaveToFile;
+		toolStripDropDownButtonSaveList.Image = FatcowIcons16px.fatcow_diskette_16px;
+		toolStripDropDownButtonSaveList.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonSaveList.Name = "toolStripDropDownButtonSaveList";
+		toolStripDropDownButtonSaveList.Size = new Size(78, 22);
+		toolStripDropDownButtonSaveList.Text = "&Save list";
 		// 
 		// kryptonStatusStrip
 		// 
@@ -172,8 +707,7 @@ partial class ObservationsForm
 		kryptonStatusStrip.ProgressBars = null;
 		kryptonStatusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
 		kryptonStatusStrip.ShowItemToolTips = true;
-		kryptonStatusStrip.Size = new Size(1024, 22);
-		kryptonStatusStrip.SizingGrip = false;
+		kryptonStatusStrip.Size = new Size(744, 22);
 		kryptonStatusStrip.TabIndex = 0;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
@@ -210,14 +744,78 @@ partial class ObservationsForm
 		// 
 		toolStripContainer.ContentPanel.Controls.Add(kryptonPanelMain);
 		toolStripContainer.ContentPanel.Margin = new Padding(4, 3, 4, 3);
-		toolStripContainer.ContentPanel.Size = new Size(1024, 500);
+		toolStripContainer.ContentPanel.Size = new Size(744, 450);
 		toolStripContainer.Dock = DockStyle.Fill;
 		toolStripContainer.Location = new Point(0, 0);
 		toolStripContainer.Name = "toolStripContainer";
-		toolStripContainer.Size = new Size(1024, 522);
+		toolStripContainer.Size = new Size(744, 497);
 		toolStripContainer.TabIndex = 0;
 		toolStripContainer.Text = "toolStripContainer";
-		toolStripContainer.TopToolStripPanelVisible = false;
+		// 
+		// toolStripContainer.TopToolStripPanel
+		// 
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripGenerateList);
+		// 
+		// kryptonToolStripGenerateList
+		// 
+		kryptonToolStripGenerateList.AccessibleDescription = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleName = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripGenerateList.AllowClickThrough = true;
+		kryptonToolStripGenerateList.AllowItemReorder = true;
+		kryptonToolStripGenerateList.Dock = DockStyle.None;
+		kryptonToolStripGenerateList.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripGenerateList.Items.AddRange(new ToolStripItem[] { toolStripButtonReload, toolStripDropDownButtonSaveList, toolStripSeparator1, toolStripLabelProgress, kryptonProgressBar });
+		kryptonToolStripGenerateList.Location = new Point(0, 0);
+		kryptonToolStripGenerateList.Name = "kryptonToolStripGenerateList";
+		kryptonToolStripGenerateList.Size = new Size(744, 25);
+		kryptonToolStripGenerateList.Stretch = true;
+		kryptonToolStripGenerateList.TabIndex = 0;
+		kryptonToolStripGenerateList.TabStop = true;
+		kryptonToolStripGenerateList.Text = "Toolbar of generating list";
+		// 
+		// toolStripButtonReload
+		// 
+		toolStripButtonReload.AccessibleDescription = "Reloads the observation list";
+		toolStripButtonReload.AccessibleName = "Reload";
+		toolStripButtonReload.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonReload.Image = FatcowIcons16px.fatcow_update_16px;
+		toolStripButtonReload.ImageTransparentColor = Color.Magenta;
+		toolStripButtonReload.Name = "toolStripButtonReload";
+		toolStripButtonReload.Size = new Size(63, 22);
+		toolStripButtonReload.Text = "&Reload";
+		toolStripButtonReload.Click += ToolStripButtonReload_Click;
+		// 
+		// toolStripSeparator1
+		// 
+		toolStripSeparator1.AccessibleDescription = "Just a separator";
+		toolStripSeparator1.AccessibleName = "Just a separator";
+		toolStripSeparator1.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator1.Name = "toolStripSeparator1";
+		toolStripSeparator1.Size = new Size(6, 25);
+		// 
+		// toolStripLabelProgress
+		// 
+		toolStripLabelProgress.AccessibleDescription = "Shows the progress of comparing";
+		toolStripLabelProgress.AccessibleName = "Progress";
+		toolStripLabelProgress.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelProgress.AutoToolTip = true;
+		toolStripLabelProgress.Name = "toolStripLabelProgress";
+		toolStripLabelProgress.Size = new Size(52, 22);
+		toolStripLabelProgress.Text = "Pro&gress";
+		// 
+		// kryptonProgressBar
+		// 
+		kryptonProgressBar.AccessibleDescription = "Shows the progress of the file comparison";
+		kryptonProgressBar.AccessibleName = "Comparison progress";
+		kryptonProgressBar.AccessibleRole = AccessibleRole.ProgressBar;
+		kryptonProgressBar.AutoToolTip = true;
+		kryptonProgressBar.Name = "kryptonProgressBar";
+		kryptonProgressBar.Size = new Size(470, 22);
+		kryptonProgressBar.StateCommon.Back.Color1 = Color.Green;
+		kryptonProgressBar.StateDisabled.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.StateNormal.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.Values.Text = "";
 		// 
 		// ObservationsForm
 		// 
@@ -226,11 +824,13 @@ partial class ObservationsForm
 		AccessibleRole = AccessibleRole.Dialog;
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
-		ClientSize = new Size(1024, 522);
+		ClientSize = new Size(744, 497);
+		ControlBox = false;
 		Controls.Add(toolStripContainer);
-		FormBorderStyle = FormBorderStyle.Sizable;
+		FormBorderStyle = FormBorderStyle.SizableToolWindow;
 		Icon = (Icon)resources.GetObject("$this.Icon");
 		Margin = new Padding(4, 3, 4, 3);
+		MaximizeBox = false;
 		MinimizeBox = false;
 		Name = "ObservationsForm";
 		StartPosition = FormStartPosition.CenterParent;
@@ -238,13 +838,18 @@ partial class ObservationsForm
 		Load += ObservationsForm_Load;
 		((ISupportInitialize)kryptonPanelMain).EndInit();
 		kryptonPanelMain.ResumeLayout(false);
+		contextMenuSaveToFile.ResumeLayout(false);
 		kryptonStatusStrip.ResumeLayout(false);
 		kryptonStatusStrip.PerformLayout();
 		toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
 		toolStripContainer.BottomToolStripPanel.PerformLayout();
 		toolStripContainer.ContentPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.PerformLayout();
 		toolStripContainer.ResumeLayout(false);
 		toolStripContainer.PerformLayout();
+		kryptonToolStripGenerateList.ResumeLayout(false);
+		kryptonToolStripGenerateList.PerformLayout();
 		ResumeLayout(false);
 	}
 
@@ -264,4 +869,50 @@ partial class ObservationsForm
 	private ToolStripStatusLabel labelInformation;
 	private ToolStripContainer toolStripContainer;
 	private KryptonManager kryptonManager;
+	private ContextMenuStrip contextMenuSaveToFile;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWord;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOds;
+	private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
+	private KryptonToolStrip kryptonToolStripGenerateList;
+	private ToolStripSeparator toolStripSeparator1;
+	private ToolStripDropDownButton toolStripDropDownButtonSaveList;
+	private ToolStripLabel toolStripLabelProgress;
+	private KryptonProgressBarToolStripItem kryptonProgressBar;
+	private ToolStripButton toolStripButtonReload;
 }

--- a/Forms/ObservationsForm.cs
+++ b/Forms/ObservationsForm.cs
@@ -360,7 +360,7 @@ public partial class ObservationsForm : BaseKryptonForm
 		try
 		{
 			Cursor.Current = Cursors.WaitCursor;
-			exportAction(listView, "List of readable designations", saveFileDialog.FileName, null);
+			exportAction(listView, "List of observations", saveFileDialog.FileName, null);
 		}
 		// Handle any exceptions that may occur during the export action
 		catch (Exception ex)

--- a/Forms/ObservationsForm.cs
+++ b/Forms/ObservationsForm.cs
@@ -25,9 +25,11 @@ public partial class ObservationsForm : BaseKryptonForm
 	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
 	/// <summary>Base URL used to query the Minor Planet Center database for a specific object.</summary>
+	/// <remarks>This URL is used to construct the full query URL by appending the minor planet identifier.</remarks>
 	private const string MpcBaseUrl = "https://www.minorplanetcenter.net/db_search/show_object?object_id=";
 
 	/// <summary>Base URL of the Minor Planet Center website, used to resolve relative download links.</summary>
+	/// <remarks>This URL is used to construct absolute URLs for resources that are specified with relative paths on the MPC website.</remarks>
 	private const string MpcRootUrl = "https://www.minorplanetcenter.net";
 
 	/// <summary>The packed minor planet number or provisional designation used to query the MPC database.</summary>
@@ -35,8 +37,10 @@ public partial class ObservationsForm : BaseKryptonForm
 	private string indexData = string.Empty;
 
 	/// <summary>Shared <see cref="HttpClient"/> for HTTP requests. Reused to avoid socket exhaustion.</summary>
+	/// <remarks>This <see cref="HttpClient"/> instance is shared across the application to improve performance and reduce resource usage.</remarks>
 	private static readonly HttpClient httpClient = new()
 	{
+		// Set a reasonable timeout for HTTP requests to prevent hanging indefinitely
 		Timeout = TimeSpan.FromSeconds(30)
 	};
 
@@ -44,33 +48,86 @@ public partial class ObservationsForm : BaseKryptonForm
 	/// <remarks>MPC observation records are fixed-width 80-character lines. Lines shorter than this are skipped.</remarks>
 	private const int MinimumObservationLineLength = 80;
 
-	// MPC observation record column positions (0-based start index, following 1-based spec)
+	/// <summary>Specifies the starting index for packed minor planet numbers.</summary>
+	/// <remarks>This constant is used as the base value when working with packed representations of minor planet numbers. The value is typically used in calculations or conversions involving minor planet identifiers.</remarks>
 	private const int PackedMinorPlanetNumberStart = 0;
+
+	/// <summary>The length of the packed minor planet number field in the MPC observation record.</summary>
+	/// <remarks>This constant is used to validate or format packed minor planet numbers to ensure consistency across the application.</remarks>
 	private const int PackedMinorPlanetNumberLength = 5;
+
+	/// <summary>The starting index of the packed provisional designation field in the MPC observation record.</summary>
+	/// <remarks>This constant is used to validate or format packed provisional designations to ensure consistency across the application.</remarks>
 	private const int PackedProvisionalDesignationStart = 5;
+
+	/// <summary>The length of the packed provisional designation field in the MPC observation record.</summary>
+	/// <remarks>This constant is used to validate or format packed provisional designations to ensure consistency across the application.</remarks>
 	private const int PackedProvisionalDesignationLength = 7;
+
+	/// <summary>Represents the starting index position of the discovery asterisk in the relevant data structure or format.</summary>
+	/// <remarks>This constant is used to identify where the discovery asterisk begins. The specific meaning and usage depend on the context in which it is applied.</remarks>
 	private const int DiscoveryAsteriskStart = 12;
+
+	/// <summary>Represents the length of the discovery asterisk used in parsing or formatting operations.</summary>
+	/// <remarks>This constant is used to validate or format the discovery asterisk to ensure consistency across the application.</remarks>
 	private const int DiscoveryAsteriskLength = 1;
+
+	/// <summary>Represents the start day of the observation period as a constant value.</summary>
+	/// <remarks>This constant is used to identify the starting day of the observation period in the MPC observation record.</remarks>
 	private const int DateOfObservationStart = 15;
+
+	/// <summary>Represents the length of the observation period date field.</summary>
+	/// <remarks>This constant is used to validate or format observation period date values to ensure consistency across the application.</remarks>
 	private const int DateOfObservationLength = 17;
+
+	/// <summary>Represents the starting value for observed rectascension measurements.</summary>
+	/// <remarks>This constant is used to validate or format observed rectascension data to ensure consistency across the application.</remarks>
 	private const int ObservedRectascensionStart = 32;
+
+	/// <summary>Represents the fixed length, in characters, of the observed rectascension value.</summary>
+	/// <remarks>This constant is used to validate or format observed rectascension data to ensure consistency across the application.</remarks>
 	private const int ObservedRectascensionLength = 12;
+
+	/// <summary>Represents the starting value for observed declination measurements.</summary>
+	/// <remarks>This constant is used to validate or format observed declination data to ensure consistency across the application.</remarks>
 	private const int ObservedDeclinationStart = 44;
+
+	/// <summary>Represents the required length for an observed declination value.</summary>
+	/// <remarks>This constant is typically used to validate or format observed declination data to ensure consistency across the application.</remarks>
 	private const int ObservedDeclinationLength = 12;
+
+	/// <summary>Represents the starting index for observed magnitude and band values in the data structure.</summary>
+	/// <remarks>This constant is used to validate or format observed magnitude and band data to ensure consistency across the application.</remarks>
 	private const int ObservedMagnitudeAndBandStart = 65;
+
+	/// <summary>Represents the fixed length used for observed magnitude and band values.</summary>
+	/// <remarks>This constant is used to validate or format observed magnitude and band data to ensure consistency across the application.</remarks>
 	private const int ObservedMagnitudeAndBandLength = 6;
+
+	/// <summary>Specifies the starting value for observatory codes.</summary>
+	/// <remarks>This constant is used as the initial value when generating or validating observatory codes. The specific meaning and usage of this value depend on the context in which observatory codes are assigned or processed.</remarks>
 	private const int ObservatoryCodeStart = 77;
+
+	/// <summary>Represents the required length, in characters, for an observatory code.</summary>
+	/// <remarks>This constant is used to validate or format observatory codes to ensure consistency across the application.</remarks>
 	private const int ObservatoryCodeLength = 3;
 
 	/// <summary>Stores the index of the currently sorted column.</summary>
+	/// <remarks>This field is used to keep track of which column is currently being used for sorting in the ListView.</remarks>
 	private int sortColumn = -1;
 
 	/// <summary>The value indicates how items in the currently sorted column are ordered.</summary>
+	/// <remarks>This field is used to determine the sort order (ascending, descending, or none) for the currently sorted column.</remarks>
 	private SortOrder sortOrder = SortOrder.None;
 
 	/// <summary>Gets the status label used for displaying information in the status bar.</summary>
 	/// <remarks>Overrides the base class property to return the form-specific status label.</remarks>
 	protected override ToolStripStatusLabel? StatusLabel => labelInformation;
+
+	/// <summary>Gets the compiled regular expression for matching the download link in the MPC observations section.</summary>
+	/// <returns>A <see cref="Regex"/> instance for matching download links.</returns>
+	[GeneratedRegex(pattern: @"<a\s+href=""([^""]+)""\s+target=""_blank"">download</a>", options: RegexOptions.IgnoreCase)]
+	private static partial Regex DownloadLinkRegex();
 
 	#region constructor
 
@@ -91,65 +148,67 @@ public partial class ObservationsForm : BaseKryptonForm
 	/// <summary>Sets the minor planet index data used to query the MPC observations page.</summary>
 	/// <param name="indexData">The packed minor planet number or provisional designation.</param>
 	/// <remarks>Call this method before showing the form so that the observation data is available on load.</remarks>
-	public void SetIndexData(string indexData) =>
-		this.indexData = indexData;
+	public void SetIndexData(string indexData) => this.indexData = indexData;
 
 	/// <summary>Fetches and parses the observation data from the MPC website, then populates the ListView.</summary>
-	/// <remarks>This method performs an HTTP GET request to the MPC website, locates the observations
-	/// download link, fetches the observation text file, and parses each line into the 8 observation fields.</remarks>
+	/// <remarks>This method performs an HTTP GET request to the MPC website, locates the observations download link, fetches the observation text file, and parses each line into the 8 observation fields.</remarks>
 	private async Task LoadObservationsAsync()
 	{
+		// Clear existing items and status
 		listView.Items.Clear();
 		ClearStatusBar(label: labelInformation);
-
+		// Validate that index data is provided before attempting to load observations
 		if (string.IsNullOrWhiteSpace(value: indexData))
 		{
+			// If no index data is provided, show an error message and return early
 			ShowErrorMessage(message: "No object identifier was provided.");
 			return;
 		}
-
+		// Set the cursor to a wait cursor to indicate that a loading operation is in progress
 		try
 		{
 			Cursor.Current = Cursors.WaitCursor;
-
 			// Fetch the HTML page for the object
 			string pageUrl = MpcBaseUrl + Uri.EscapeDataString(stringToEscape: indexData);
+			kryptonProgressBar.Text = "Loading observation data from " + pageUrl;
+			kryptonProgressBar.Style = ProgressBarStyle.Marquee;
 			string html = await httpClient.GetStringAsync(requestUri: pageUrl).ConfigureAwait(continueOnCapturedContext: true);
-
+			kryptonProgressBar.Text = "Parsing observation data...";
 			// Locate the <h2>Observations</h2> section and find the download link after it
 			int observationsHeadingIndex = html.IndexOf(value: "<h2>Observations</h2>", comparisonType: StringComparison.Ordinal);
+			// If the heading is not found, show an error message and return early
 			if (observationsHeadingIndex < 0)
 			{
+				// If the Observations section is not found, show an error message and return early
+				kryptonProgressBar.Style = ProgressBarStyle.Continuous;
+				kryptonProgressBar.Text = "Observations section not found.";
 				ShowErrorMessage(message: "Could not find the Observations section on the MPC page.");
 				return;
 			}
-
 			// Search for <a href="..." target="_blank">download</a> after the heading
 			string htmlAfterHeading = html[observationsHeadingIndex..];
-			Match downloadMatch = Regex.Match(
-				input: htmlAfterHeading,
-				pattern: @"<a\s+href=""([^""]+)""\s+target=""_blank"">download</a>",
-				options: RegexOptions.IgnoreCase);
-
+			// Use the generated regex to find the download link in the HTML after the Observations heading
+			Match downloadMatch = DownloadLinkRegex().Match(input: htmlAfterHeading);
+			// If the download link is not found, show an error message and return early
 			if (!downloadMatch.Success)
 			{
+				// If the download link is not found, show an error message and return early
+				kryptonProgressBar.Style = ProgressBarStyle.Continuous;
+				kryptonProgressBar.Text = "Observations download link not found.";
 				ShowErrorMessage(message: "Could not find the observations download link on the MPC page.");
 				return;
 			}
-
+			// Extract the relative URL from the regex match group
 			string relativeUrl = downloadMatch.Groups[groupnum: 1].Value;
-
 			// Convert relative URL to absolute URL
 			// e.g. ../tmp2/~0uY1.txt → https://www.minorplanetcenter.net/tmp2/~0uY1.txt
 			string absoluteUrl = ResolveUrl(baseUrl: MpcRootUrl, relativeUrl: relativeUrl);
-
 			// Fetch the observations text file
 			string obsText = await httpClient.GetStringAsync(requestUri: absoluteUrl).ConfigureAwait(continueOnCapturedContext: true);
-
 			// Parse lines and populate ListView
 			string[] lines = obsText.Split(separator: '\n');
 			listView.BeginUpdate();
-
+			// Each line is a fixed-width record with fields at specific character positions. We use the SafeSubstring helper to extract each field based on the defined constants for start index and length.
 			foreach (string rawLine in lines)
 			{
 				// Observation lines must be at least 80 characters according to the MPC format
@@ -157,9 +216,8 @@ public partial class ObservationsForm : BaseKryptonForm
 				{
 					continue;
 				}
-
+				// Trim any trailing carriage return characters from the line
 				string line = rawLine.TrimEnd(trimChars: ['\r']);
-
 				// Extract fields using 1-based column ranges specified in the issue
 				string packedMinorPlanetNumber = SafeSubstring(value: line, startIndex: PackedMinorPlanetNumberStart, length: PackedMinorPlanetNumberLength);
 				string packedProvisionalDesignation = SafeSubstring(value: line, startIndex: PackedProvisionalDesignationStart, length: PackedProvisionalDesignationLength);
@@ -169,7 +227,7 @@ public partial class ObservationsForm : BaseKryptonForm
 				string observedDeclination = SafeSubstring(value: line, startIndex: ObservedDeclinationStart, length: ObservedDeclinationLength);
 				string observedMagnitudeAndBand = SafeSubstring(value: line, startIndex: ObservedMagnitudeAndBandStart, length: ObservedMagnitudeAndBandLength);
 				string observatoryCode = SafeSubstring(value: line, startIndex: ObservatoryCodeStart, length: ObservatoryCodeLength);
-
+				// Create a ListViewItem with the packed minor planet number as the main text, and the other fields as subitems
 				ListViewItem item = new(text: packedMinorPlanetNumber);
 				item.SubItems.AddRange(items:
 				[
@@ -183,39 +241,51 @@ public partial class ObservationsForm : BaseKryptonForm
 				]);
 				listView.Items.Add(value: item);
 			}
-
+			// After adding all items, call EndUpdate to refresh the ListView display
 			listView.EndUpdate();
-
 			// Show summary information after loading
+			kryptonProgressBar.Style = ProgressBarStyle.Continuous;
+			kryptonProgressBar.Text = "Observation data loaded.";
+			// Display the number of observations and the date range of the observations in a message box
 			int count = listView.Items.Count;
+			// If there are observations, show the first and last observation dates; otherwise, indicate that no observations were found
 			if (count > 0)
 			{
+				// The date of observation is in the 4th column (index 3) of the ListView. We trim it to remove any extra whitespace.
 				string firstDate = listView.Items[index: 0].SubItems[index: 3].Text.Trim();
 				string lastDate = listView.Items[index: count - 1].SubItems[index: 3].Text.Trim();
+				// Show a message box with the count of observations and the date range
 				_ = MessageBox.Show(
 					text: $"Number of observations: {count}\nFirst observation: {firstDate}\nLast observation: {lastDate}",
 					caption: I18nStrings.InformationCaption,
 					buttons: MessageBoxButtons.OK,
 					icon: MessageBoxIcon.Information);
 			}
+			// If no observations were found, show an information message box indicating that
 			else
 			{
+				// Show a message box indicating that no observations were found
 				_ = MessageBox.Show(
 					text: "No observations found.",
 					caption: I18nStrings.InformationCaption,
 					buttons: MessageBoxButtons.OK,
 					icon: MessageBoxIcon.Information);
 			}
-
+			// Update the status bar with the count of loaded observations
 			SetStatusBar(label: labelInformation, text: $"{count} observation(s) loaded.");
 		}
+		// Handle any exceptions that may occur during the loading and parsing process, logging the error and showing an error message to the user
 		catch (Exception ex)
 		{
+			// Log the error with the exception details and the index data that was being loaded
 			logger.Error(exception: ex, message: $"Error loading observations for '{indexData}': {ex.Message}");
+			// Show an error message to the user indicating that an error occurred while loading observations, including the exception message for more details
 			ShowErrorMessage(message: $"Error loading observations: {ex.Message}");
 		}
+		// In the finally block, ensure that the cursor is reset to the default state regardless of whether the loading operation succeeds or fails. This ensures that the user interface remains responsive and provides appropriate feedback to the user.
 		finally
 		{
+			// Reset the cursor to the default state after the loading operation is complete
 			Cursor.Current = Cursors.Default;
 		}
 	}
@@ -227,11 +297,14 @@ public partial class ObservationsForm : BaseKryptonForm
 	/// <returns>The trimmed substring, or an empty string if out of range.</returns>
 	private static string SafeSubstring(string value, int startIndex, int length)
 	{
+		// If the start index is beyond the end of the string, return an empty string
 		if (startIndex >= value.Length)
 		{
 			return string.Empty;
 		}
+		// Calculate the available length to extract, ensuring we don't go past the end of the string
 		int availableLength = Math.Min(val1: length, val2: value.Length - startIndex);
+		// Extract the substring using the calculated available length and trim any whitespace
 		return value.Substring(startIndex: startIndex, length: availableLength).Trim();
 	}
 
@@ -244,7 +317,76 @@ public partial class ObservationsForm : BaseKryptonForm
 		// Use Uri to resolve relative paths correctly
 		Uri baseUri = new(uriString: baseUrl);
 		Uri resolved = new(baseUri: baseUri, relativeUri: relativeUrl);
+		// Return the absolute URI as a string
 		return resolved.AbsoluteUri;
+	}
+
+	/// <summary>Prepares the save dialog for exporting data.</summary>
+	/// <param name="dialog">The file dialog to prepare.</param>
+	/// <param name="ext">The file extension.</param>
+	/// <returns>True if the dialog was shown successfully; otherwise, false.</returns>
+	/// <remarks>This method is used to prepare the save dialog for exporting data.</remarks>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"Observations.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
+	/// <summary>Performs the save export operation by displaying a save dialog and invoking the specified export action.</summary>
+	/// <param name="filter">The file type filter for the save dialog.</param>
+	/// <param name="defaultExt">The default file extension.</param>
+	/// <param name="dialogTitle">The title of the save dialog.</param>
+	/// <param name="exportAction">The export action to invoke with the list view, title, file name, and an optional virtual row provider.</param>
+	/// <remarks>This method encapsulates the logic for displaying a save dialog and performing the export action based on the user's selection. It handles the preparation of the dialog, execution of the export action, and manages the cursor state during the operation.</remarks>
+	private void PerformSaveExport(string filter, string defaultExt, string dialogTitle, Action<ListView, string, string, Func<int, ListViewItem>?> exportAction)
+	{
+		// Create and configure the save file dialog with the specified filter, default extension, and title. The dialog allows the user to choose where to save the exported file and what name to give it.
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = filter,
+			DefaultExt = defaultExt,
+			Title = dialogTitle
+		};
+		// Prepare and show the save dialog. If the user cancels the dialog, the method returns without performing any export action.
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: defaultExt))
+		{
+			return;
+		}
+		// If the user selects a file and confirms the dialog, set the cursor to a wait cursor to indicate that an operation is in progress, and then invoke the specified export action with the text box containing the output, the title for the export, and the selected file name. After the export action is completed, reset the cursor to the default state.
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			exportAction(listView, "List of readable designations", saveFileDialog.FileName, null);
+		}
+		// Handle any exceptions that may occur during the export action
+		catch (Exception ex)
+		{
+			logger.Error(message: $"An error occurred during export: {ex}");
+			MessageBox.Show(text: $"An error has occurred during export: {ex.Message}", caption: "Export Error", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error);
+		}
+		// In the finally block, ensure that the cursor is reset to the default state regardless of whether the export action succeeds or fails. This ensures that the user interface remains responsive and provides appropriate feedback to the user.
+		finally
+		{
+			// Reset the cursor to the default state after the export operation is complete
+			Cursor.Current = Cursors.Default;
+		}
+	}
+
+	/// <summary>Initiates the asynchronous loading of observatory codes and updates the user interface to reflect the loading state.</summary>
+	/// <remarks>Disables relevant UI controls while loading is in progress to prevent user interaction, and re-enables them once loading is complete. Intended to be called from the UI thread.</remarks>
+	private async void LoadObservatoryCodes()
+	{
+		// Clear the status bar and disable relevant UI controls while loading is in progress
+		ClearStatusBar(label: labelInformation);
+		toolStripButtonReload.Enabled = false;
+		toolStripDropDownButtonSaveList.Enabled = false;
+		await LoadObservationsAsync().ConfigureAwait(continueOnCapturedContext: true);
+		toolStripButtonReload.Enabled = true;
+		toolStripDropDownButtonSaveList.Enabled = true;
 	}
 
 	#endregion
@@ -255,11 +397,9 @@ public partial class ObservationsForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>Clears the status bar and initiates the asynchronous loading of observation data.</remarks>
-	private async void ObservationsForm_Load(object sender, EventArgs e)
-	{
-		ClearStatusBar(label: labelInformation);
-		await LoadObservationsAsync().ConfigureAwait(continueOnCapturedContext: true);
-	}
+	private void ObservationsForm_Load(object sender, EventArgs e) =>
+		// Clear the status bar and load the observatory codes when the form loads
+		LoadObservatoryCodes();
 
 	#endregion
 
@@ -271,11 +411,12 @@ public partial class ObservationsForm : BaseKryptonForm
 	/// <remarks>This method determines the sort order and initiates the sorting process for the selected column.</remarks>
 	private void ListView_ColumnClick(object sender, ColumnClickEventArgs e)
 	{
+		// If there are no items in the ListView, do not attempt to sort
 		if (listView.Items.Count == 0)
 		{
 			return;
 		}
-
+		// Determine the new sort order based on whether the same column was clicked again or a different column was selected
 		if (e.Column == sortColumn)
 		{
 			sortOrder = sortOrder == SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
@@ -285,14 +426,17 @@ public partial class ObservationsForm : BaseKryptonForm
 			sortColumn = e.Column;
 			sortOrder = SortOrder.Ascending;
 		}
-
+		// Update the column headers to indicate the current sort column and order using arrow indicators (▲ for ascending, ▼ for descending)
 		for (int i = 0; i < listView.Columns.Count; i++)
 		{
+			// Get the current header text for the column, removing any existing sort indicators
 			string headerText = listView.Columns[index: i].Text;
+			// Remove existing sort indicators (▲ or ▼) from the header text
 			if (headerText.StartsWith(value: "▲ ") || headerText.StartsWith(value: "▼ "))
 			{
 				headerText = headerText[2..];
 			}
+			// If this column is the currently sorted column, prepend the appropriate sort indicator to the header text; otherwise, use the plain header text
 			if (i == sortColumn)
 			{
 				string indicator = sortOrder == SortOrder.Ascending ? "▲" : "▼";
@@ -303,10 +447,246 @@ public partial class ObservationsForm : BaseKryptonForm
 				listView.Columns[index: i].Text = headerText;
 			}
 		}
-
+		// Set the ListViewItemSorter to a new instance of ListViewItemComparer with the selected column and sort order, then call Sort to apply the sorting to the ListView
 		listView.ListViewItemSorter = new ListViewItemComparer(column: e.Column, order: sortOrder);
 		listView.Sort();
 	}
+
+	#endregion
+
+	#region Click event handlers
+
+	/// <summary>Handles the Click event to export the output as a CSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a CSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as CSV.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsCsv_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Comma-Separated Values (*.csv)|*.csv|All Files (*.*)|*.*", defaultExt: "csv", dialogTitle: "Save as CSV", exportAction: ListViewExporter.SaveAsCsv);
+
+	/// <summary>Handles the Click event to export the output as an HTML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an HTML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as HTML.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsHtml_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "HTML files (*.html)|*.html|All Files (*.*)|*.*", defaultExt: "html", dialogTitle: "Save as HTML", exportAction: ListViewExporter.SaveAsHtml);
+
+	/// <summary>Handles the Click event to export the output as an XML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an XML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as XML.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXml_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "XML files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as XML", exportAction: ListViewExporter.SaveAsXml);
+
+	/// <summary>Handles the Click event to export the output as a JSON file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a JSON file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as JSON.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsJson_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "JSON files (*.json)|*.json|All Files (*.*)|*.*", defaultExt: "json", dialogTitle: "Save as JSON", exportAction: ListViewExporter.SaveAsJson);
+
+	/// <summary>Handles the Click event to export the output as a SQL file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a SQL file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as SQL.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSql_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "SQL scripts (*.sql)|*.sql|All Files (*.*)|*.*", defaultExt: "sql", dialogTitle: "Save as SQL", exportAction: ListViewExporter.SaveAsSql);
+
+	/// <summary>Handles the Click event to export the output as a Markdown file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Markdown file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as Markdown.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Markdown files (*.md)|*.md|All Files (*.*)|*.*", defaultExt: "md", dialogTitle: "Save as Markdown", exportAction: ListViewExporter.SaveAsMarkdown);
+
+	/// <summary>Handles the Click event to export the output as a YAML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a YAML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as YAML.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsYaml_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "YAML files (*.yaml)|*.yaml|All Files (*.*)|*.*", defaultExt: "yaml", dialogTitle: "Save as YAML", exportAction: ListViewExporter.SaveAsYaml);
+
+	/// <summary>Handles the Click event to export the output as a TSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a TSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as TSV.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTsv_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Tab-Separated Values (*.tsv)|*.tsv|All Files (*.*)|*.*", defaultExt: "tsv", dialogTitle: "Save as TSV", exportAction: ListViewExporter.SaveAsTsv);
+
+	/// <summary>Handles the Click event to export the output as a PSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as PSV.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPsv_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Pipe-Separated Values (*.psv)|*.psv|All Files (*.*)|*.*", defaultExt: "psv", dialogTitle: "Save as PSV", exportAction: ListViewExporter.SaveAsPsv);
+
+	/// <summary>Handles the Click event to export the output as a LaTeX file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a LaTeX file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as LaTeX.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsLatex_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "LaTeX files (*.tex)|*.tex|All Files (*.*)|*.*", defaultExt: "tex", dialogTitle: "Save as LaTeX", exportAction: ListViewExporter.SaveAsLatex);
+
+	/// <summary>Handles the Click event to export the output as a PostScript file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PostScript file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as PostScript.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "PostScript files (*.ps)|*.ps|All Files (*.*)|*.*", defaultExt: "ps", dialogTitle: "Save as PostScript", exportAction: ListViewExporter.SaveAsPostScript);
+
+	/// <summary>Handles the Click event to export the output as a PDF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PDF file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as PDF.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPdf_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "PDF files (*.pdf)|*.pdf|All Files (*.*)|*.*", defaultExt: "pdf", dialogTitle: "Save as PDF", exportAction: ListViewExporter.SaveAsPdf);
+
+	/// <summary>Handles the Click event to export the output as an EPUB file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an EPUB file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as EPUB.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEpub_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "EPUB files (*.epub)|*.epub|All Files (*.*)|*.*", defaultExt: "epub", dialogTitle: "Save as EPUB", exportAction: ListViewExporter.SaveAsEpub);
+
+	/// <summary>Handles the Click event to export the output as a Word file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Word file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as Word.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWord_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Word documents (*.docx)|*.docx|All Files (*.*)|*.*", defaultExt: "docx", dialogTitle: "Save as Word", exportAction: ListViewExporter.SaveAsWord);
+
+	/// <summary>Handles the Click event to export the output as an Excel file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an Excel file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as Excel.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsExcel_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Excel Spreadsheet (*.xlsx)|*.xlsx|All Files (*.*)|*.*", defaultExt: "xlsx", dialogTitle: "Save as Excel", exportAction: ListViewExporter.SaveAsExcel);
+
+	/// <summary>Handles the Click event to export the output as an ODT file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ODT file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as ODT.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOdt_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "OpenDocument Text (*.odt)|*.odt|All Files (*.*)|*.*", defaultExt: "odt", dialogTitle: "Save as ODT", exportAction: ListViewExporter.SaveAsOdt);
+
+	/// <summary>Handles the Click event to export the output as an ODS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ODS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as ODS.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOds_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "OpenDocument Spreadsheet (*.ods)|*.ods|All Files (*.*)|*.*", defaultExt: "ods", dialogTitle: "Save as ODS", exportAction: ListViewExporter.SaveAsOds);
+
+	/// <summary>Handles the Click event to export the output as a MOBI file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a MOBI file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as MOBI.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMobi_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "MOBI files (*.mobi)|*.mobi|All Files (*.*)|*.*", defaultExt: "mobi", dialogTitle: "Save as MOBI", exportAction: ListViewExporter.SaveAsMobi);
+
+	/// <summary>Handles the Click event to export the output as an RTF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an RTF file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as RTF.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsRtf_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Rich Text Format (*.rtf)|*.rtf|All Files (*.*)|*.*", defaultExt: "rtf", dialogTitle: "Save as RTF", exportAction: ListViewExporter.SaveAsRtf);
+
+	/// <summary>Handles the Click event to export the output as a text file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsText_Click(object? sender, EventArgs? e)
+		=> PerformSaveExport(filter: "Text files (*.txt)|*.txt|All Files (*.*)|*.*", defaultExt: "txt", dialogTitle: "Save as Text", exportAction: ListViewExporter.SaveAsText);
+
+	/// <summary>Handles the Click event to export the output as an AsciiDoc file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an AsciiDoc file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as AsciiDoc.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "AsciiDoc files (*.adoc)|*.adoc|All Files (*.*)|*.*", defaultExt: "adoc", dialogTitle: "Save as AsciiDoc", exportAction: ListViewExporter.SaveAsAsciiDoc);
+
+	/// <summary>Handles the Click event to export the output as a reStructuredText file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a reStructuredText file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as reStructuredText.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "reStructuredText files (*.rst)|*.rst|All Files (*.*)|*.*", defaultExt: "rst", dialogTitle: "Save as reStructuredText", exportAction: ListViewExporter.SaveAsReStructuredText);
+
+	/// <summary>Handles the Click event to export the output as a Textile file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Textile file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as Textile.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Textile files (*.textile)|*.textile|All Files (*.*)|*.*", defaultExt: "textile", dialogTitle: "Save as Textile", exportAction: ListViewExporter.SaveAsTextile);
+
+	/// <summary>Handles the Click event to export the output as an Abiword file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an Abiword file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as Abiword.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Abiword files (*.abw)|*.abw|All Files (*.*)|*.*", defaultExt: "abw", dialogTitle: "Save as Abiword", exportAction: ListViewExporter.SaveAsAbiword);
+
+	/// <summary>Handles the Click event to export the output as a WPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a WPS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as WPS.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "WPS Writer files (*.wps)|*.wps|All Files (*.*)|*.*", defaultExt: "wps", dialogTitle: "Save as WPS Writer", exportAction: ListViewExporter.SaveAsWps);
+
+	/// <summary>Handles the Click event to export the output as an ET file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ET file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as ET.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "WPS Spreadsheets (*.et)|*.et|All Files (*.*)|*.*", defaultExt: "et", dialogTitle: "Save as WPS Spreadsheets", exportAction: ListViewExporter.SaveAsEt);
+
+	/// <summary>Handles the Click event to export the output as a DocBook file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a DocBook file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as DocBook.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as DocBook", exportAction: ListViewExporter.SaveAsDocBook);
+
+	/// <summary>Handles the Click event to export the output as a TOML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a TOML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as TOML.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*", defaultExt: "toml", dialogTitle: "Save as TOML", exportAction: ListViewExporter.SaveAsToml);
+
+	/// <summary>Handles the Click event to export the output as an XPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an XPS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as XPS.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*", defaultExt: "xps", dialogTitle: "Save as XPS", exportAction: ListViewExporter.SaveAsXps);
+
+	/// <summary>Handles the Click event to export the output as a FictionBook2 file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a FictionBook2 file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as FictionBook2.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "FictionBook2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*", defaultExt: "fb2", dialogTitle: "Save as FictionBook2", exportAction: ListViewExporter.SaveAsFictionBook2);
+
+	/// <summary>Handles the Click event to export the output as a CHM file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a CHM file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as CHM.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Compiled HTML Help (*.chm)|*.chm|All Files (*.*)|*.*", defaultExt: "chm", dialogTitle: "Save as CHM", exportAction: ListViewExporter.SaveAsChm);
+
+	/// <summary>Handles the Click event to export the output as a SQLite file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a SQLite file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as SQLite.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "SQLite Database (*.sqlite)|*.sqlite|All Files (*.*)|*.*", defaultExt: "sqlite", dialogTitle: "Save as SQLite", exportAction: ListViewExporter.SaveAsSqlite);
+
+	/// <summary>Handles the Click event of the Reload button to refresh the observatory codes displayed in the form.</summary>
+	/// <param name="sender">The source of the event, typically the Reload button.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>When the Reload button is clicked, this event handler clears the status bar and initiates the loading of observatory codes by calling the LoadObservatoryCodes method.</remarks>
+	private void ToolStripButtonReload_Click(object sender, EventArgs e) =>
+		// Clear the status bar and load the observatory codes when the form loads
+		LoadObservatoryCodes();
 
 	#endregion
 }

--- a/Forms/ObservationsForm.resx
+++ b/Forms/ObservationsForm.resx
@@ -117,17 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuSaveToFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>310, 17</value>
+  </metadata>
   <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="backgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 17</value>
-  </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>282, 17</value>
+    <value>168, 17</value>
+  </metadata>
+  <metadata name="kryptonToolStripGenerateList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>61</value>
+    <value>48</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -54,10 +54,10 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep1000 = new ToolStripMenuItem();
 		menuitemNavigateStep10000 = new ToolStripMenuItem();
 		menuitemNavigateStep100000 = new ToolStripMenuItem();
+		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
 		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		toolStripSplitButtonStepBackward = new ToolStripSplitButton();
 		menuitemNavigateSomeDataBackward = new ToolStripMenuItem();
-		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
 		tableLayoutPanelData = new KryptonTableLayoutPanel();
 		labelIndexData = new KryptonLabel();
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
@@ -123,8 +123,8 @@ partial class PlanetoidDbForm
 		menuitemRecordsRmsResidual = new ToolStripMenuItem();
 		menuitemRecordsComputername = new ToolStripMenuItem();
 		menuitemRecordsDateOfTheLastObservation = new ToolStripMenuItem();
-		menuitemRecords = new ToolStripMenuItem();
 		splitbuttonTopTenRecords = new ToolStripSplitButton();
+		menuitemRecords = new ToolStripMenuItem();
 		contextMenuDistributions = new ContextMenuStrip(components);
 		menuitemDistributionMeanAnomalyAtTheEpoch = new ToolStripMenuItem();
 		menuitemDistributionArgumentOfThePerihelion = new ToolStripMenuItem();
@@ -140,8 +140,8 @@ partial class PlanetoidDbForm
 		menuitemDistributionObservationSpan = new ToolStripMenuItem();
 		menuitemDistributionRmsResidual = new ToolStripMenuItem();
 		menuitemDistributionComputerName = new ToolStripMenuItem();
-		menuitemDistribution = new ToolStripMenuItem();
 		splitbuttonDistribution = new ToolStripSplitButton();
+		menuitemDistribution = new ToolStripMenuItem();
 		contextMenuFullCopyToClipboardOrbitalElements = new ContextMenuStrip(components);
 		menuitemCopyToClipboardIndexNumber = new ToolStripMenuItem();
 		menuitemCopyToClipboardReadableDesignation = new ToolStripMenuItem();
@@ -163,8 +163,8 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardComputerName = new ToolStripMenuItem();
 		menuitemCopyToClipboardDateOfTheLastObservation = new ToolStripMenuItem();
 		menuitemCopyToClipboardFlags = new ToolStripMenuItem();
-		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		menuitemCopytoClipboard = new ToolStripMenuItem();
+		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		menu = new MenuStrip();
 		menuitemFile = new ToolStripMenuItem();
 		toolStripMenuItemOpenLocalMpcorbDat = new ToolStripMenuItem();
@@ -202,7 +202,6 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOrbitElementsGrouping = new ToolStripMenuItem();
 		toolStripMenuItemAsteroidFamiliesDetection = new ToolStripMenuItem();
 		toolStripMenuItemObservations = new ToolStripMenuItem();
-		toolStripButtonObservations = new ToolStripButton();
 		menuitemUpdate = new ToolStripMenuItem();
 		menuitemCheckMpcorbDat = new ToolStripMenuItem();
 		menuitemDownloadMpcorbDat = new ToolStripMenuItem();
@@ -226,6 +225,7 @@ partial class PlanetoidDbForm
 		menuitemOpenWebsitePDB = new ToolStripMenuItem();
 		menuitemOpenWebsiteMPC = new ToolStripMenuItem();
 		menuitemOpenMPCORBWebsite = new ToolStripMenuItem();
+		toolStripButtonObservations = new ToolStripButton();
 		toolStripContainer = new ToolStripContainer();
 		kryptonStatusStrip = new KryptonStatusStrip();
 		toolStripStatusLabelUpdate = new ToolStripStatusLabel();
@@ -303,7 +303,7 @@ partial class PlanetoidDbForm
 		contextMenuNavigationStep.Font = new Font("Segoe UI", 9F);
 		contextMenuNavigationStep.Items.AddRange(new ToolStripItem[] { menuitemNavigateStep10, menuitemNavigateStep100, menuitemNavigateStep1000, menuitemNavigateStep10000, menuitemNavigateStep100000 });
 		contextMenuNavigationStep.Name = "contextMenu";
-		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataForward;
+		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataBackward;
 		contextMenuNavigationStep.ShowCheckMargin = true;
 		contextMenuNavigationStep.ShowImageMargin = false;
 		contextMenuNavigationStep.Size = new Size(111, 114);
@@ -386,6 +386,22 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep100000.MouseEnter += Control_Enter;
 		menuitemNavigateStep100000.MouseLeave += Control_Leave;
 		// 
+		// menuitemNavigateSomeDataForward
+		// 
+		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemNavigateSomeDataForward.AutoToolTip = true;
+		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
+		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
+		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
+		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
+		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
+		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
+		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
+		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
+		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
+		// 
 		// toolStripSplitButtonStepForward
 		// 
 		toolStripSplitButtonStepForward.AccessibleDescription = "Navigates some data forward";
@@ -433,22 +449,6 @@ partial class PlanetoidDbForm
 		menuitemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
 		menuitemNavigateSomeDataBackward.MouseEnter += Control_Enter;
 		menuitemNavigateSomeDataBackward.MouseLeave += Control_Leave;
-		// 
-		// menuitemNavigateSomeDataForward
-		// 
-		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemNavigateSomeDataForward.AutoToolTip = true;
-		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
-		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
-		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
-		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
-		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
-		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
-		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
-		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
-		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanelData
 		// 
@@ -1567,7 +1567,7 @@ partial class PlanetoidDbForm
 		contextMenuTopTenRecords.Font = new Font("Segoe UI", 9F);
 		contextMenuTopTenRecords.Items.AddRange(new ToolStripItem[] { menuitemRecordsSortDirection, toolStripSeparator12, menuitemRecordsMeanAnomalyAtTheEpoch, menuitemRecordsArgumentOfThePerihelion, menuitemRecordsLongitudeOfTheAscendingNode, menuitemRecordsInclination, menuitemRecordsOrbitalEccentricity, menuitemRecordsMeanDailyMotion, menuitemRecordsSemiMajorAxis, menuitemRecordsAbsoluteMagnitude, menuitemRecordsSlopeParameter, menuitemRecordsNumberOfOppositions, menuitemRecordsNumberOfObservations, menuitemRecordsObservationSpan, menuitemRecordsRmsResidual, menuitemRecordsComputername, menuitemRecordsDateOfTheLastObservation });
 		contextMenuTopTenRecords.Name = "contextMenuTopTenRecords";
-		contextMenuTopTenRecords.OwnerItem = splitbuttonTopTenRecords;
+		contextMenuTopTenRecords.OwnerItem = menuitemRecords;
 		contextMenuTopTenRecords.Size = new Size(250, 362);
 		contextMenuTopTenRecords.TabStop = true;
 		contextMenuTopTenRecords.Text = "Top ten records";
@@ -1840,6 +1840,23 @@ partial class PlanetoidDbForm
 		menuitemRecordsDateOfTheLastObservation.MouseEnter += Control_Enter;
 		menuitemRecordsDateOfTheLastObservation.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonTopTenRecords
+		// 
+		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
+		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
+		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
+		splitbuttonTopTenRecords.Enabled = false;
+		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
+		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
+		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
+		splitbuttonTopTenRecords.Size = new Size(32, 22);
+		splitbuttonTopTenRecords.Text = "Top ten records";
+		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
+		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
+		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
+		// 
 		// menuitemRecords
 		// 
 		menuitemRecords.AccessibleDescription = "Shows some topn ten records";
@@ -1858,23 +1875,6 @@ partial class PlanetoidDbForm
 		menuitemRecords.MouseEnter += Control_Enter;
 		menuitemRecords.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonTopTenRecords
-		// 
-		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
-		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
-		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
-		splitbuttonTopTenRecords.Enabled = false;
-		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
-		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
-		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
-		splitbuttonTopTenRecords.Size = new Size(32, 22);
-		splitbuttonTopTenRecords.Text = "Top ten records";
-		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
-		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
-		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
-		// 
 		// contextMenuDistributions
 		// 
 		contextMenuDistributions.AccessibleDescription = "Shows the context menu of the distributions";
@@ -1883,7 +1883,7 @@ partial class PlanetoidDbForm
 		contextMenuDistributions.Font = new Font("Segoe UI", 9F);
 		contextMenuDistributions.Items.AddRange(new ToolStripItem[] { menuitemDistributionMeanAnomalyAtTheEpoch, menuitemDistributionArgumentOfThePerihelion, menuitemDistributionLongitudeOfTheAscendingNode, menuitemDistributionInclination, menuitemDistributionOrbitalEccentricity, menuitemDistributionMeanDailyMotion, menuitemDistributionSemiMajorAxis, menuitemDistributionAbsoluteMagnitude, menuitemDistributionSlopeParameter, menuitemDistributionNumberOfOppositions, menuitemDistributionNumberOfObservations, menuitemDistributionObservationSpan, menuitemDistributionRmsResidual, menuitemDistributionComputerName });
 		contextMenuDistributions.Name = "contextMenuDistributions";
-		contextMenuDistributions.OwnerItem = splitbuttonDistribution;
+		contextMenuDistributions.OwnerItem = menuitemDistribution;
 		contextMenuDistributions.Size = new Size(250, 312);
 		contextMenuDistributions.Text = "Distributions";
 		contextMenuDistributions.Enter += Control_Enter;
@@ -2101,23 +2101,6 @@ partial class PlanetoidDbForm
 		menuitemDistributionComputerName.MouseEnter += Control_Enter;
 		menuitemDistributionComputerName.MouseLeave += Control_Leave;
 		// 
-		// menuitemDistribution
-		// 
-		menuitemDistribution.AccessibleDescription = "Shows some distributions";
-		menuitemDistribution.AccessibleName = "Distributions";
-		menuitemDistribution.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemDistribution.AutoToolTip = true;
-		menuitemDistribution.DropDown = contextMenuDistributions;
-		menuitemDistribution.Enabled = false;
-		menuitemDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
-		menuitemDistribution.Name = "menuitemDistribution";
-		menuitemDistribution.ShortcutKeys = Keys.Control | Keys.D;
-		menuitemDistribution.Size = new Size(277, 22);
-		menuitemDistribution.Text = "&Distributions";
-		menuitemDistribution.Click += MenuitemDistribution_Click;
-		menuitemDistribution.MouseEnter += Control_Enter;
-		menuitemDistribution.MouseLeave += Control_Leave;
-		// 
 		// splitbuttonDistribution
 		// 
 		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
@@ -2135,6 +2118,23 @@ partial class PlanetoidDbForm
 		splitbuttonDistribution.MouseEnter += Control_Enter;
 		splitbuttonDistribution.MouseLeave += Control_Leave;
 		// 
+		// menuitemDistribution
+		// 
+		menuitemDistribution.AccessibleDescription = "Shows some distributions";
+		menuitemDistribution.AccessibleName = "Distributions";
+		menuitemDistribution.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemDistribution.AutoToolTip = true;
+		menuitemDistribution.DropDown = contextMenuDistributions;
+		menuitemDistribution.Enabled = false;
+		menuitemDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
+		menuitemDistribution.Name = "menuitemDistribution";
+		menuitemDistribution.ShortcutKeys = Keys.Control | Keys.D;
+		menuitemDistribution.Size = new Size(277, 22);
+		menuitemDistribution.Text = "&Distributions";
+		menuitemDistribution.Click += MenuitemDistribution_Click;
+		menuitemDistribution.MouseEnter += Control_Enter;
+		menuitemDistribution.MouseLeave += Control_Leave;
+		// 
 		// contextMenuFullCopyToClipboardOrbitalElements
 		// 
 		contextMenuFullCopyToClipboardOrbitalElements.AccessibleDescription = "Shows the context menu of the orbital elements to copy to clipboard";
@@ -2143,7 +2143,7 @@ partial class PlanetoidDbForm
 		contextMenuFullCopyToClipboardOrbitalElements.Font = new Font("Segoe UI", 9F);
 		contextMenuFullCopyToClipboardOrbitalElements.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardIndexNumber, menuitemCopyToClipboardReadableDesignation, menuitemCopyToClipboardEpoch, menuitemCopyToClipboardMeanAnomalyAtTheEpoch, menuitemCopyToClipboardArgumentOfThePerihelion, menuitemCopyToClipboardLongitudeOfTheAscendingNode, menuitemCopyToClipboardInclinationToTheEcliptic, menuitemCopyToClipboardOrbitalEccentricity, menuitemCopyToClipboardMeanDailyMotion, menuitemCopyToClipboardSemiMajorAxis, menuitemCopyToClipboardAbsoluteMagnitude, menuitemCopyToClipboardSlopeParameter, menuitemCopyToClipboardReference, menuitemCopyToClipboardNumberOfOppositions, menuitemCopyToClipboardNumberOfObservations, menuitemCopyToClipboardObservationSpan, menuitemCopyToClipboardRmsResidual, menuitemCopyToClipboardComputerName, menuitemCopyToClipboardDateOfTheLastObservation, menuitemCopyToClipboardFlags });
 		contextMenuFullCopyToClipboardOrbitalElements.Name = "Context menu of copying to clipboard of orbital elements";
-		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = menuitemCopytoClipboard;
+		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripDropDownButtonCopyToClipboard;
 		contextMenuFullCopyToClipboardOrbitalElements.Size = new Size(309, 444);
 		contextMenuFullCopyToClipboardOrbitalElements.Text = "Copy to clipboard";
 		contextMenuFullCopyToClipboardOrbitalElements.Enter += Control_Enter;
@@ -2431,21 +2431,6 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardFlags.MouseEnter += Control_Enter;
 		menuitemCopyToClipboardFlags.MouseLeave += Control_Leave;
 		// 
-		// toolStripDropDownButtonCopyToClipboard
-		// 
-		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
-		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
-		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
-		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
-		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
-		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
-		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
-		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
-		// 
 		// menuitemCopytoClipboard
 		// 
 		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
@@ -2460,6 +2445,21 @@ partial class PlanetoidDbForm
 		menuitemCopytoClipboard.Text = "&Copy";
 		menuitemCopytoClipboard.MouseEnter += Control_Enter;
 		menuitemCopytoClipboard.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonCopyToClipboard
+		// 
+		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
+		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
+		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
+		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
+		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
+		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
+		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
 		// 
 		// menu
 		// 
@@ -2960,7 +2960,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemObservations.AccessibleName = "Observations";
 		toolStripMenuItemObservations.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemObservations.AutoToolTip = true;
-		toolStripMenuItemObservations.Image = FatcowIcons16px.fatcow_eye_16px;
+		toolStripMenuItemObservations.Image = FatcowIcons16px.fatcow_find_16px;
 		toolStripMenuItemObservations.Name = "toolStripMenuItemObservations";
 		toolStripMenuItemObservations.Size = new Size(277, 22);
 		toolStripMenuItemObservations.Text = "&Observations";
@@ -3293,6 +3293,21 @@ partial class PlanetoidDbForm
 		menuitemOpenMPCORBWebsite.Click += MenuitemOpenMPCORBWebsite_Click;
 		menuitemOpenMPCORBWebsite.MouseEnter += Control_Enter;
 		menuitemOpenMPCORBWebsite.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonObservations
+		// 
+		toolStripButtonObservations.AccessibleDescription = "Shows the observations of the minor planet from the MPC";
+		toolStripButtonObservations.AccessibleName = "Observations";
+		toolStripButtonObservations.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonObservations.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripButtonObservations.Image = FatcowIcons16px.fatcow_find_16px;
+		toolStripButtonObservations.ImageTransparentColor = Color.Magenta;
+		toolStripButtonObservations.Name = "toolStripButtonObservations";
+		toolStripButtonObservations.Size = new Size(23, 22);
+		toolStripButtonObservations.Text = "Observations";
+		toolStripButtonObservations.Click += ToolStripButtonObservations_Click;
+		toolStripButtonObservations.MouseEnter += Control_Enter;
+		toolStripButtonObservations.MouseLeave += Control_Leave;
 		// 
 		// toolStripContainer
 		// 
@@ -3981,21 +3996,6 @@ partial class PlanetoidDbForm
 		toolStripButtonFilter.Click += ToolStripButtonFilter_Click;
 		toolStripButtonFilter.MouseEnter += Control_Enter;
 		toolStripButtonFilter.MouseLeave += Control_Leave;
-		// 
-		// toolStripButtonObservations
-		// 
-		toolStripButtonObservations.AccessibleDescription = "Shows the observations of the minor planet from the MPC";
-		toolStripButtonObservations.AccessibleName = "Observations";
-		toolStripButtonObservations.AccessibleRole = AccessibleRole.PushButton;
-		toolStripButtonObservations.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripButtonObservations.Image = FatcowIcons16px.fatcow_eye_16px;
-		toolStripButtonObservations.ImageTransparentColor = Color.Magenta;
-		toolStripButtonObservations.Name = "toolStripButtonObservations";
-		toolStripButtonObservations.Size = new Size(23, 22);
-		toolStripButtonObservations.Text = "Observations";
-		toolStripButtonObservations.Click += ToolStripButtonObservations_Click;
-		toolStripButtonObservations.MouseEnter += Control_Enter;
-		toolStripButtonObservations.MouseLeave += Control_Leave;
 		// 
 		// toolStripSeparatorOptions2
 		// 


### PR DESCRIPTION
This pull request updates the WinForms UI to support a redesigned `ObservationsForm` experience and aligns the main application entry points (menu/toolbar) with the new observations UI.

**Changes:**
- Redesignes `ObservationsForm` UI: adds toolbar actions (reload + save/export menu) and a progress indicator.
- Refactors `ObservationsForm` logic to support progress feedback and many export formats via `ListViewExporter`.
- Updates `PlanetoidDBForm` designer wiring/iconography around the Observations entry point and some ToolStrip/ContextMenu ownership wiring.