### PR TITLE
Updated `BulkObservationsDataDownloaderForm`

### DIFF
--- a/Forms/BaseKryptonForm.cs
+++ b/Forms/BaseKryptonForm.cs
@@ -114,7 +114,7 @@ public class BaseKryptonForm : KryptonForm
 	/// <param name="sender">Event source — expected to be a <see cref="Control"/> or <see cref="ToolStripItem"/>.</param>
 	/// <param name="e">Event arguments.</param>
 	/// <remarks>This method is called when the mouse pointer enters a control or the control receives focus.</remarks>
-	protected void Control_Enter(object sender, EventArgs e)
+	protected void Control_Enter(object? sender, EventArgs e)
 	{
 		// Check if the sender is null
 		ArgumentNullException.ThrowIfNull(argument: sender);
@@ -142,7 +142,7 @@ public class BaseKryptonForm : KryptonForm
 	/// <param name="sender">Event source.</param>
 	/// <param name="e">Event arguments.</param>
 	/// <remarks>This method is called when the mouse pointer leaves a control or the control loses focus.</remarks>
-	protected void Control_Leave(object sender, EventArgs e)
+	protected void Control_Leave(object? sender, EventArgs e)
 	{
 		// Check if the status label is not null
 		if (StatusLabel != null)

--- a/Forms/BulkObservationsDataDownloaderForm.Designer.cs
+++ b/Forms/BulkObservationsDataDownloaderForm.Designer.cs
@@ -26,9 +26,35 @@ partial class BulkObservationsDataDownloaderForm
 	/// <remarks>This method is called by the runtime to release resources used by the form.</remarks>
 	protected override void Dispose(bool disposing)
 	{
-		if (disposing && (components != null))
+		if (disposing)
 		{
-			components.Dispose();
+			// Signal that we're disposing to prevent new HTTP operations
+			_isDisposing = true;
+			// Cancel and wait for any active download to complete before disposing resources
+			_cancellationTokenSource?.Cancel();
+			// Resume any awaiting pause so the download task can observe the cancellation
+			_isPaused = false;
+			_resumeTcs?.TrySetResult(result: true);
+			// Stop the UI timer
+			_uiTimer?.Stop();
+			// Wait for the download task to complete (with timeout to prevent hanging)
+			if (_downloadTask != null && !_downloadTask.IsCompleted)
+			{
+				try
+				{
+					// Wait up to 10 seconds for graceful shutdown
+					_ = _downloadTask.Wait(millisecondsTimeout: 10000);
+				}
+				catch
+				{
+					// Ignore exceptions during cleanup
+				}
+			}
+			// Now dispose managed resources
+			_httpClient?.Dispose();
+			_cancellationTokenSource?.Dispose();
+			_uiTimer?.Dispose();
+			components?.Dispose();
 		}
 		base.Dispose(disposing);
 	}
@@ -133,7 +159,7 @@ partial class BulkObservationsDataDownloaderForm
 		kryptonPanelMain.Location = new Point(0, 0);
 		kryptonPanelMain.Name = "kryptonPanelMain";
 		kryptonPanelMain.PanelBackStyle = PaletteBackStyle.FormMain;
-		kryptonPanelMain.Size = new Size(620, 137);
+		kryptonPanelMain.Size = new Size(675, 137);
 		kryptonPanelMain.TabIndex = 0;
 		kryptonPanelMain.TabStop = true;
 		kryptonPanelMain.Text = "Main Panel";
@@ -171,7 +197,7 @@ partial class BulkObservationsDataDownloaderForm
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
-		tableLayoutPanel.Size = new Size(620, 137);
+		tableLayoutPanel.Size = new Size(675, 137);
 		tableLayoutPanel.TabIndex = 0;
 		tableLayoutPanel.Enter += Control_Enter;
 		tableLayoutPanel.Leave += Control_Leave;
@@ -770,7 +796,7 @@ partial class BulkObservationsDataDownloaderForm
 		labelStatusValue.Dock = DockStyle.Fill;
 		labelStatusValue.Location = new Point(133, 3);
 		labelStatusValue.Name = "labelStatusValue";
-		labelStatusValue.Size = new Size(484, 22);
+		labelStatusValue.Size = new Size(539, 22);
 		labelStatusValue.TabIndex = 1;
 		labelStatusValue.ToolTipValues.Description = "Shows the current download status.\r\nDouble-click to copy to clipboard.";
 		labelStatusValue.ToolTipValues.EnableToolTips = true;
@@ -812,7 +838,7 @@ partial class BulkObservationsDataDownloaderForm
 		labelFileCountValue.Dock = DockStyle.Fill;
 		labelFileCountValue.Location = new Point(133, 31);
 		labelFileCountValue.Name = "labelFileCountValue";
-		labelFileCountValue.Size = new Size(484, 22);
+		labelFileCountValue.Size = new Size(539, 22);
 		labelFileCountValue.TabIndex = 3;
 		labelFileCountValue.ToolTipValues.Description = "Shows the number of downloaded files vs. total files.\r\nDouble-click to copy to clipboard.";
 		labelFileCountValue.ToolTipValues.EnableToolTips = true;
@@ -854,7 +880,7 @@ partial class BulkObservationsDataDownloaderForm
 		labelFileSizeValue.Dock = DockStyle.Fill;
 		labelFileSizeValue.Location = new Point(133, 59);
 		labelFileSizeValue.Name = "labelFileSizeValue";
-		labelFileSizeValue.Size = new Size(484, 22);
+		labelFileSizeValue.Size = new Size(539, 22);
 		labelFileSizeValue.TabIndex = 5;
 		labelFileSizeValue.ToolTipValues.Description = "Shows the file size of the current download vs. total size.\r\nDouble-click to copy to clipboard.";
 		labelFileSizeValue.ToolTipValues.EnableToolTips = true;
@@ -896,7 +922,7 @@ partial class BulkObservationsDataDownloaderForm
 		labelTimeValue.Dock = DockStyle.Fill;
 		labelTimeValue.Location = new Point(133, 87);
 		labelTimeValue.Name = "labelTimeValue";
-		labelTimeValue.Size = new Size(484, 22);
+		labelTimeValue.Size = new Size(539, 22);
 		labelTimeValue.TabIndex = 7;
 		labelTimeValue.ToolTipValues.Description = "Shows elapsed time and estimated remaining time.\r\nDouble-click to copy to clipboard.";
 		labelTimeValue.ToolTipValues.EnableToolTips = true;
@@ -938,7 +964,7 @@ partial class BulkObservationsDataDownloaderForm
 		labelErrorCountValue.Dock = DockStyle.Fill;
 		labelErrorCountValue.Location = new Point(133, 115);
 		labelErrorCountValue.Name = "labelErrorCountValue";
-		labelErrorCountValue.Size = new Size(484, 22);
+		labelErrorCountValue.Size = new Size(539, 22);
 		labelErrorCountValue.TabIndex = 9;
 		labelErrorCountValue.ToolTipValues.Description = "Shows the number of download errors.\r\nDouble-click to copy to clipboard.";
 		labelErrorCountValue.ToolTipValues.EnableToolTips = true;
@@ -965,7 +991,7 @@ partial class BulkObservationsDataDownloaderForm
 		kryptonStatusStrip.ProgressBars = null;
 		kryptonStatusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
 		kryptonStatusStrip.ShowItemToolTips = true;
-		kryptonStatusStrip.Size = new Size(620, 22);
+		kryptonStatusStrip.Size = new Size(675, 22);
 		kryptonStatusStrip.TabIndex = 0;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
@@ -1013,7 +1039,7 @@ partial class BulkObservationsDataDownloaderForm
 		toolStripContainer.ContentPanel.AccessibleName = "ContentPanel";
 		toolStripContainer.ContentPanel.AccessibleRole = AccessibleRole.Pane;
 		toolStripContainer.ContentPanel.Controls.Add(kryptonPanelMain);
-		toolStripContainer.ContentPanel.Size = new Size(620, 137);
+		toolStripContainer.ContentPanel.Size = new Size(675, 137);
 		toolStripContainer.Dock = DockStyle.Fill;
 		// 
 		// toolStripContainer.LeftToolStripPanel
@@ -1029,7 +1055,7 @@ partial class BulkObservationsDataDownloaderForm
 		toolStripContainer.RightToolStripPanel.AccessibleDescription = "RightToolStripPanel";
 		toolStripContainer.RightToolStripPanel.AccessibleName = "RightToolStripPanel";
 		toolStripContainer.RightToolStripPanel.AccessibleRole = AccessibleRole.Pane;
-		toolStripContainer.Size = new Size(620, 185);
+		toolStripContainer.Size = new Size(675, 185);
 		toolStripContainer.TabIndex = 0;
 		toolStripContainer.Text = "toolStripContainer";
 		// 
@@ -1052,7 +1078,7 @@ partial class BulkObservationsDataDownloaderForm
 		kryptonToolStrip.Items.AddRange(new ToolStripItem[] { toolStripLabelMinimum, numericUpDownMinimum, toolStripLabelMaximum, numericUpDownMaximum, toolStripSeparator1, buttonStart, buttonCancel, buttonErrorLog, toolStripSeparator2, toolStripLabelProgress, kryptonProgressBar });
 		kryptonToolStrip.Location = new Point(0, 0);
 		kryptonToolStrip.Name = "kryptonToolStrip";
-		kryptonToolStrip.Size = new Size(620, 26);
+		kryptonToolStrip.Size = new Size(675, 26);
 		kryptonToolStrip.Stretch = true;
 		kryptonToolStrip.TabIndex = 0;
 		kryptonToolStrip.TabStop = true;
@@ -1170,7 +1196,7 @@ partial class BulkObservationsDataDownloaderForm
 		buttonErrorLog.Image = FatcowIcons16px.fatcow_report_16px;
 		buttonErrorLog.ImageTransparentColor = Color.Magenta;
 		buttonErrorLog.Name = "buttonErrorLog";
-		buttonErrorLog.Size = new Size(77, 23);
+		buttonErrorLog.Size = new Size(72, 23);
 		buttonErrorLog.Text = "Error &log";
 		buttonErrorLog.Click += ButtonErrorLog_Click;
 		buttonErrorLog.MouseEnter += Control_Enter;
@@ -1221,7 +1247,7 @@ partial class BulkObservationsDataDownloaderForm
 		AccessibleRole = AccessibleRole.Dialog;
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
-		ClientSize = new Size(620, 185);
+		ClientSize = new Size(675, 185);
 		ControlBox = false;
 		Controls.Add(toolStripContainer);
 		FormBorderStyle = FormBorderStyle.SizableToolWindow;

--- a/Forms/BulkObservationsDataDownloaderForm.cs
+++ b/Forms/BulkObservationsDataDownloaderForm.cs
@@ -34,13 +34,9 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 	/// <remarks>Files are saved as <c>%USERPROFILE%\Planetoid-DB\Observations\Data\&lt;filename&gt;</c>.</remarks>
 	private const string ObservationsDataSubPath = "Planetoid-DB/Observations/Data";
 
-	/// <summary>Shared <see cref="HttpClient"/> for HTTP requests. Reused to avoid socket exhaustion.</summary>
-	/// <remarks>This <see cref="HttpClient"/> instance is shared across the application to improve performance and reduce resource usage.</remarks>
-	private static readonly HttpClient httpClient = new()
-	{
-		// Set a reasonable timeout for HTTP requests to prevent hanging indefinitely
-		Timeout = TimeSpan.FromSeconds(value: 60)
-	};
+	/// <summary><see cref="HttpClient"/> instance for HTTP requests.</summary>
+	/// <remarks>This <see cref="HttpClient"/> instance is initialized in the constructor and disposed when the form closes.</remarks>
+	private readonly HttpClient _httpClient;
 
 	/// <summary>The read-only list of raw MPCORB database records to process.</summary>
 	/// <remarks>Each element is one line from the MPCORB file. Passed in by the caller via the constructor.</remarks>
@@ -49,6 +45,14 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 	/// <summary>Cancellation token source for the running download task.</summary>
 	/// <remarks>Set to <c>null</c> when no download is running.</remarks>
 	private CancellationTokenSource? _cancellationTokenSource;
+
+	/// <summary>The currently running download task.</summary>
+	/// <remarks>Used to ensure proper cleanup by waiting for the task to complete before disposing resources.</remarks>
+	private Task? _downloadTask;
+
+	/// <summary>Indicates whether the form is being disposed.</summary>
+	/// <remarks>Checked before HttpClient operations to prevent ObjectDisposedException.</remarks>
+	private volatile bool _isDisposing;
 
 	/// <summary>Indicates whether the download is currently paused.</summary>
 	/// <remarks>Checked before processing each planetoid. Set to <c>true</c> by the Start/Pause button when the download is active, and back to <c>false</c> on resume.</remarks>
@@ -100,6 +104,11 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 	{
 		InitializeComponent();
 		_planetoids = planetoids;
+		// Initialize HttpClient with reasonable timeout
+		_httpClient = new HttpClient
+		{
+			Timeout = TimeSpan.FromSeconds(value: 60)
+		};
 		// Configure UI timer (fires every second to update elapsed/estimated time labels)
 		_uiTimer = new System.Windows.Forms.Timer { Interval = 1000 };
 		_uiTimer.Tick += UiTimer_Tick;
@@ -347,6 +356,11 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 				string currentUrl = string.Empty;
 				try
 				{
+					// Check if we're disposing before starting HTTP operations
+					if (_isDisposing)
+					{
+						token.ThrowIfCancellationRequested();
+					}
 					// Build the MPC query URL for this object
 					string pageUrl = MpcBaseUrl + Uri.EscapeDataString(stringToEscape: packedNumber);
 					currentUrl = pageUrl;
@@ -354,7 +368,7 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 					UpdateStatusLabels(status: statusMsg, downloaded: downloaded, total: total);
 					logger.Debug(message: statusMsg);
 					// Fetch the HTML page
-					string html = await httpClient.GetStringAsync(requestUri: pageUrl, cancellationToken: token).ConfigureAwait(continueOnCapturedContext: true);
+					string html = await _httpClient.GetStringAsync(requestUri: pageUrl, cancellationToken: token).ConfigureAwait(continueOnCapturedContext: true);
 					// Locate the Observations section heading
 					int observationsHeadingIndex = html.IndexOf(value: "<h2>Observations</h2>", comparisonType: StringComparison.Ordinal);
 					if (observationsHeadingIndex < 0)
@@ -384,8 +398,13 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 					string downloadStatus = $"Downloading: {absoluteUrl}";
 					UpdateStatusLabels(status: downloadStatus, downloaded: downloaded, total: total);
 					logger.Debug(message: downloadStatus);
+					// Check if we're disposing before starting download
+					if (_isDisposing)
+					{
+						token.ThrowIfCancellationRequested();
+					}
 					// Download the file and save it to disk
-					using HttpResponseMessage response = await httpClient.GetAsync(requestUri: absoluteUrl, completionOption: HttpCompletionOption.ResponseHeadersRead, cancellationToken: token).ConfigureAwait(continueOnCapturedContext: true);
+					using HttpResponseMessage response = await _httpClient.GetAsync(requestUri: absoluteUrl, completionOption: HttpCompletionOption.ResponseHeadersRead, cancellationToken: token).ConfigureAwait(continueOnCapturedContext: true);
 					_ = response.EnsureSuccessStatusCode();
 					// Track file size for the status display
 					_currentFileSize = response.Content.Headers.ContentLength ?? 0;
@@ -407,6 +426,11 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 				{
 					// Propagate cancellation so the outer try/catch can handle it
 					throw;
+				}
+				catch (ObjectDisposedException) when (_isDisposing)
+				{
+					// HttpClient was disposed during shutdown - treat as cancellation
+					throw new OperationCanceledException();
 				}
 				catch (Exception ex)
 				{
@@ -474,20 +498,16 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 	/// <summary>Handles the FormClosing event. Cancels any active download and disposes resources.</summary>
 	/// <param name="sender">Event source (the form).</param>
 	/// <param name="e">The <see cref="FormClosingEventArgs"/> instance containing the event data.</param>
-	/// <remarks>Ensures the background download and timer are stopped when the form is closed.</remarks>
+	/// <remarks>Ensures the background download is stopped when the form is closed. Resources are disposed in the Dispose method.</remarks>
 	private void BulkObservationsDataDownloaderForm_FormClosing(object sender, FormClosingEventArgs e)
 	{
 		// Signal cancellation to the running download
 		_cancellationTokenSource?.Cancel();
-		_cancellationTokenSource?.Dispose();
-		_cancellationTokenSource = null;
 		// Resume any awaiting pause so the download task can observe the cancellation
 		_isPaused = false;
 		_resumeTcs?.TrySetResult(result: true);
-		_resumeTcs = null;
-		// Stop and dispose the UI timer
+		// Stop the UI timer
 		_uiTimer.Stop();
-		_uiTimer.Dispose();
 	}
 
 	#endregion
@@ -558,7 +578,8 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 		// Run the download in a background task to keep the UI responsive
 		try
 		{
-			await DownloadAllAsync(token: token).ConfigureAwait(continueOnCapturedContext: true);
+			_downloadTask = DownloadAllAsync(token: token);
+			await _downloadTask.ConfigureAwait(continueOnCapturedContext: true);
 		}
 		// Handle cancellation gracefully
 		catch (OperationCanceledException)
@@ -586,6 +607,7 @@ public partial class BulkObservationsDataDownloaderForm : BaseKryptonForm
 			_cancellationTokenSource = null;
 			_isPaused = false;
 			_resumeTcs = null;
+			_downloadTask = null;
 		}
 	}
 

--- a/Forms/BulkObservationsDownloadErrorsForm.cs
+++ b/Forms/BulkObservationsDownloadErrorsForm.cs
@@ -1,15 +1,20 @@
-using System.Globalization;
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
 
-using Planetoid_DB.Forms;
 using Planetoid_DB.Resources;
 
-namespace Planetoid_DB;
+using System.Globalization;
+
+namespace Planetoid_DB.Forms;
 
 /// <summary>Represents a single error entry produced during bulk observations download.</summary>
 /// <param name="Timestamp">Date and time when the error occurred.</param>
 /// <param name="Url">URL that was being requested or processed.</param>
 /// <param name="ErrorType">Error type/category.</param>
 /// <param name="ErrorDescription">Detailed error explanation.</param>
+/// <remarks>Instances of this record are immutable and intended for display purposes only.</remarks>
 internal sealed record BulkObservationsDownloadErrorEntry(
 	DateTime Timestamp,
 	string Url,
@@ -17,21 +22,25 @@ internal sealed record BulkObservationsDownloadErrorEntry(
 	string ErrorDescription);
 
 /// <summary>Dialog form that displays detailed bulk-download errors in a list view.</summary>
+/// <remarks>This form is used to present a list of errors that occurred during the bulk download process.</remarks>
 internal sealed class BulkObservationsDownloadErrorsForm : BaseKryptonForm
 {
 	/// <summary>Gets the status label used for displaying information in the status bar.</summary>
+	/// <remarks>Overrides the base class property to provide the specific status label used in this form.</remarks>
 	protected override ToolStripStatusLabel? StatusLabel => _toolStripStatusLabel;
 
 	/// <summary>Initializes a new instance of the <see cref="BulkObservationsDownloadErrorsForm"/> class.</summary>
 	/// <param name="entries">The error entries to display.</param>
+	/// <remarks>Configures the form's appearance and populates the list view with the provided error entries.</remarks>
 	internal BulkObservationsDownloadErrorsForm(IReadOnlyList<BulkObservationsDownloadErrorEntry> entries)
 	{
+		// Form configuration
 		Text = "Bulk Download Errors";
 		StartPosition = FormStartPosition.CenterParent;
 		FormBorderStyle = FormBorderStyle.SizableToolWindow;
 		Size = new Size(width: 1000, height: 450);
 		MinimumSize = new Size(width: 700, height: 300);
-
+		// ListView configuration
 		_listView.Dock = DockStyle.Fill;
 		_listView.View = View.Details;
 		_listView.FullRowSelect = true;
@@ -40,12 +49,12 @@ internal sealed class BulkObservationsDownloadErrorsForm : BaseKryptonForm
 		_listView.HideSelection = false;
 		_listView.AccessibleName = "Error list";
 		_listView.AccessibleDescription = "Shows all logged download errors with timestamp, URL and details";
-		_listView.Columns.Add(headerText: "Datum / Uhrzeit", width: 170);
-		_listView.Columns.Add(headerText: "URL", width: 390);
-		_listView.Columns.Add(headerText: "Fehler", width: 420);
+		_listView.Columns.Add(text: "Datum / Uhrzeit", width: 170);
+		_listView.Columns.Add(text: "URL", width: 390);
+		_listView.Columns.Add(text: "Fehler", width: 420);
 		_listView.MouseEnter += Control_Enter;
 		_listView.MouseLeave += Control_Leave;
-
+		// Populate ListView with error entries
 		foreach (BulkObservationsDownloadErrorEntry entry in entries)
 		{
 			string timestampText = entry.Timestamp.ToString(format: "yyyy-MM-dd HH:mm:ss", provider: CultureInfo.InvariantCulture);
@@ -53,23 +62,31 @@ internal sealed class BulkObservationsDownloadErrorsForm : BaseKryptonForm
 			ListViewItem item = new(text: timestampText);
 			_ = item.SubItems.Add(text: entry.Url);
 			_ = item.SubItems.Add(text: errorText);
-			_ = _listView.Items.Add(item);
+			_ = _listView.Items.Add(value: item);
 		}
-
+		// StatusStrip configuration
 		_statusStrip.Dock = DockStyle.Bottom;
 		_statusStrip.Items.Add(value: _toolStripStatusLabel);
 		_toolStripStatusLabel.Text = $"{entries.Count} error(s)";
-		_toolStripStatusLabel.Image = Resources.FatcowIcons16px.fatcow_information_16px;
+		_toolStripStatusLabel.Image = FatcowIcons16px.fatcow_information_16px;
 		_toolStripStatusLabel.MouseEnter += Control_Enter;
 		_toolStripStatusLabel.MouseLeave += Control_Leave;
 		_statusStrip.MouseEnter += Control_Enter;
 		_statusStrip.MouseLeave += Control_Leave;
-
-		Controls.Add(_listView);
-		Controls.Add(_statusStrip);
+		// Add controls to form
+		Controls.Add(value: _listView);
+		Controls.Add(value: _statusStrip);
 	}
 
+	/// <summary>Represents the ListView control used to display a collection of items in the user interface.</summary>
+	/// <remarks>This control is configured to show detailed information about bulk download errors, including timestamp, URL, and error details.</remarks>
 	private readonly ListView _listView = new();
+
+	/// <summary>Represents the status strip control used to display status information in the user interface.</summary>
+	/// <remarks>This control is configured to show the number of errors and provide additional information through a status label.</remarks>
 	private readonly StatusStrip _statusStrip = new();
+
+	/// <summary>Represents the status label displayed in the associated ToolStrip control.</summary>
+	/// <remarks>This label is used to show the count of errors and can also display an icon for visual indication.</remarks>
 	private readonly ToolStripStatusLabel _toolStripStatusLabel = new();
 }

--- a/Forms/BulkObservationsDownloadErrorsForm.resx
+++ b/Forms/BulkObservationsDownloadErrorsForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
This PR updates the bulk observations downloader workflow by improving error reporting UI and adjusting download lifecycle/cleanup behavior during shutdown/disposal.

**Changes:**
- Added a dedicated “Bulk Download Errors” dialog form (and resource file) to display per-item download failures.
- Refactored `BulkObservationsDataDownloaderForm` to use an instance `HttpClient`, track the active download task, and attempt cleanup during disposal/closing.
- Updated `BaseKryptonForm` enter/leave handlers to use nullable sender signatures consistent with WinForms `EventHandler`.