### PR TITLE
Updated suppress message attributes in `GlobalSuppressions.cs`

### DIFF
--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -1,11 +1,11 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage(category: "Performance", checkId: "CA1806:Methodenergebnisse nicht ignorieren", Justification = "<Ausstehend>", Scope = "member", Target = "~M:Planetoid_DB.Program.Main")]
 [assembly: SuppressMessage(category: "Interoperability", checkId: "SYSLIB1054:Verwenden Sie \\\"LibraryImportAttribute\\\" anstelle von \\\"DllImportAttribute\\\", um P/Invoke-Marshallingcode zur Kompilierzeit zu generieren.", Justification = "<Ausstehend>", Scope = "member", Target = "~M:Planetoid_DB.Program.CoInternetSetFeatureEnabled(System.Int32,System.Int32,System.Boolean)~System.Int32")]
 [assembly: SuppressMessage(category: "Performance", checkId: "CA1834:Verwendung von \"StringBuilder.Append(char)\" erwägen", Justification = "<Ausstehend>", Scope = "member", Target = "~M:Planetoid_DB.ExportDataSheetForm.ToolStripMenuItemExportAsPdf_Click(System.Object,System.EventArgs)")]
 [assembly: SuppressMessage(category: "Performance", checkId: "CA1834:Verwendung von \"StringBuilder.Append(char)\" erwägen", Justification = "<Ausstehend>", Scope = "member", Target = "~M:Planetoid_DB.ExportDataSheetForm.ToolStripMenuItemExportAsRtf_Click(System.Object,System.EventArgs)")]
+[assembly: SuppressMessage(category: "Performance", checkId: "SYSLIB1045:In „GeneratedRegexAttribute“ konvertieren.", Justification = "<Ausstehend>", Scope = "member", Target = "~M:Planetoid_DB.PlanetoidDbForm.ProcessDesignationForUrl(System.String)~System.String")]


### PR DESCRIPTION
Updates the project’s code-analysis suppression list in `GlobalSuppressions.cs` to reflect current analyzer warnings.

**Changes:**
- Removed an existing suppression for CA1806 on `Program.Main`.
- Added a new suppression entry intended for SYSLIB1045.