### PR TITLE
Added decoding of the 4-hexdigit flags

### DIFF
--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -50,10 +50,10 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep1000 = new ToolStripMenuItem();
 		menuitemNavigateStep10000 = new ToolStripMenuItem();
 		menuitemNavigateStep100000 = new ToolStripMenuItem();
+		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
 		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		toolStripSplitButtonStepBackward = new ToolStripSplitButton();
 		menuitemNavigateSomeDataBackward = new ToolStripMenuItem();
-		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
 		tableLayoutPanelData = new KryptonTableLayoutPanel();
 		labelIndexData = new KryptonLabel();
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
@@ -119,8 +119,8 @@ partial class PlanetoidDbForm
 		menuitemRecordsRmsResidual = new ToolStripMenuItem();
 		menuitemRecordsComputername = new ToolStripMenuItem();
 		menuitemRecordsDateOfTheLastObservation = new ToolStripMenuItem();
-		menuitemRecords = new ToolStripMenuItem();
 		splitbuttonTopTenRecords = new ToolStripSplitButton();
+		menuitemRecords = new ToolStripMenuItem();
 		contextMenuDistributions = new ContextMenuStrip(components);
 		menuitemDistributionMeanAnomalyAtTheEpoch = new ToolStripMenuItem();
 		menuitemDistributionArgumentOfThePerihelion = new ToolStripMenuItem();
@@ -136,8 +136,8 @@ partial class PlanetoidDbForm
 		menuitemDistributionObservationSpan = new ToolStripMenuItem();
 		menuitemDistributionRmsResidual = new ToolStripMenuItem();
 		menuitemDistributionComputerName = new ToolStripMenuItem();
-		menuitemDistribution = new ToolStripMenuItem();
 		splitbuttonDistribution = new ToolStripSplitButton();
+		menuitemDistribution = new ToolStripMenuItem();
 		contextMenuFullCopyToClipboardOrbitalElements = new ContextMenuStrip(components);
 		menuitemCopyToClipboardIndexNumber = new ToolStripMenuItem();
 		menuitemCopyToClipboardReadableDesignation = new ToolStripMenuItem();
@@ -159,8 +159,8 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardComputerName = new ToolStripMenuItem();
 		menuitemCopyToClipboardDateOfTheLastObservation = new ToolStripMenuItem();
 		menuitemCopyToClipboardFlags = new ToolStripMenuItem();
-		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		menuitemCopytoClipboard = new ToolStripMenuItem();
+		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		menu = new MenuStrip();
 		menuitemFile = new ToolStripMenuItem();
 		toolStripMenuItemOpenLocalMpcorbDat = new ToolStripMenuItem();
@@ -214,6 +214,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemJplSmallBodyDatabase = new ToolStripMenuItem();
 		toolStripMenuItemLowellMinorPlanetServices = new ToolStripMenuItem();
 		toolStripMenuItemAsteroidsDynamicSite = new ToolStripMenuItem();
+		toolStripSeparator17 = new ToolStripSeparator();
+		toolStripMenuItemOpenAllDataPages = new ToolStripMenuItem();
 		menuitemUpdate = new ToolStripMenuItem();
 		menuitemCheckMpcorbDat = new ToolStripMenuItem();
 		menuitemDownloadMpcorbDat = new ToolStripMenuItem();
@@ -290,8 +292,6 @@ partial class PlanetoidDbForm
 		timerCheckForNewMpcorbDatFile = new Timer(components);
 		openFileDialog = new OpenFileDialog();
 		kryptonManager = new KryptonManager(components);
-		toolStripSeparator17 = new ToolStripSeparator();
-		toolStripMenuItemOpenAllDataPages = new ToolStripMenuItem();
 		contextMenuNavigationStep.SuspendLayout();
 		tableLayoutPanelData.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
@@ -317,7 +317,7 @@ partial class PlanetoidDbForm
 		contextMenuNavigationStep.Font = new Font("Segoe UI", 9F);
 		contextMenuNavigationStep.Items.AddRange(new ToolStripItem[] { menuitemNavigateStep10, menuitemNavigateStep100, menuitemNavigateStep1000, menuitemNavigateStep10000, menuitemNavigateStep100000 });
 		contextMenuNavigationStep.Name = "contextMenu";
-		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataForward;
+		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataBackward;
 		contextMenuNavigationStep.ShowCheckMargin = true;
 		contextMenuNavigationStep.ShowImageMargin = false;
 		contextMenuNavigationStep.Size = new Size(111, 114);
@@ -400,6 +400,22 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep100000.MouseEnter += Control_Enter;
 		menuitemNavigateStep100000.MouseLeave += Control_Leave;
 		// 
+		// menuitemNavigateSomeDataForward
+		// 
+		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemNavigateSomeDataForward.AutoToolTip = true;
+		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
+		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
+		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
+		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
+		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
+		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
+		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
+		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
+		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
+		// 
 		// toolStripSplitButtonStepForward
 		// 
 		toolStripSplitButtonStepForward.AccessibleDescription = "Navigates some data forward";
@@ -447,22 +463,6 @@ partial class PlanetoidDbForm
 		menuitemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
 		menuitemNavigateSomeDataBackward.MouseEnter += Control_Enter;
 		menuitemNavigateSomeDataBackward.MouseLeave += Control_Leave;
-		// 
-		// menuitemNavigateSomeDataForward
-		// 
-		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemNavigateSomeDataForward.AutoToolTip = true;
-		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
-		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
-		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
-		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
-		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
-		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
-		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
-		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
-		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanelData
 		// 
@@ -991,6 +991,7 @@ partial class PlanetoidDbForm
 		labelFlagsData.AccessibleName = "Shows the information of \"4-hexdigit flags\"";
 		labelFlagsData.AccessibleRole = AccessibleRole.StaticText;
 		labelFlagsData.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelFlagsData.Cursor = Cursors.Hand;
 		labelFlagsData.Dock = DockStyle.Fill;
 		labelFlagsData.Location = new Point(675, 211);
 		labelFlagsData.Name = "labelFlagsData";
@@ -1001,6 +1002,7 @@ partial class PlanetoidDbForm
 		labelFlagsData.ToolTipValues.Heading = "4-hexdigit flags";
 		labelFlagsData.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
 		labelFlagsData.Values.Text = "..................";
+		labelFlagsData.Click += LabelFlagsData_Click;
 		labelFlagsData.DoubleClick += CopyToClipboard_DoubleClick;
 		labelFlagsData.Enter += Control_Enter;
 		labelFlagsData.Leave += Control_Leave;
@@ -1581,7 +1583,7 @@ partial class PlanetoidDbForm
 		contextMenuTopTenRecords.Font = new Font("Segoe UI", 9F);
 		contextMenuTopTenRecords.Items.AddRange(new ToolStripItem[] { menuitemRecordsSortDirection, toolStripSeparator12, menuitemRecordsMeanAnomalyAtTheEpoch, menuitemRecordsArgumentOfThePerihelion, menuitemRecordsLongitudeOfTheAscendingNode, menuitemRecordsInclination, menuitemRecordsOrbitalEccentricity, menuitemRecordsMeanDailyMotion, menuitemRecordsSemiMajorAxis, menuitemRecordsAbsoluteMagnitude, menuitemRecordsSlopeParameter, menuitemRecordsNumberOfOppositions, menuitemRecordsNumberOfObservations, menuitemRecordsObservationSpan, menuitemRecordsRmsResidual, menuitemRecordsComputername, menuitemRecordsDateOfTheLastObservation });
 		contextMenuTopTenRecords.Name = "contextMenuTopTenRecords";
-		contextMenuTopTenRecords.OwnerItem = splitbuttonTopTenRecords;
+		contextMenuTopTenRecords.OwnerItem = menuitemRecords;
 		contextMenuTopTenRecords.Size = new Size(250, 362);
 		contextMenuTopTenRecords.TabStop = true;
 		contextMenuTopTenRecords.Text = "Top ten records";
@@ -1854,6 +1856,23 @@ partial class PlanetoidDbForm
 		menuitemRecordsDateOfTheLastObservation.MouseEnter += Control_Enter;
 		menuitemRecordsDateOfTheLastObservation.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonTopTenRecords
+		// 
+		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
+		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
+		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
+		splitbuttonTopTenRecords.Enabled = false;
+		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
+		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
+		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
+		splitbuttonTopTenRecords.Size = new Size(32, 22);
+		splitbuttonTopTenRecords.Text = "Top ten records";
+		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
+		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
+		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
+		// 
 		// menuitemRecords
 		// 
 		menuitemRecords.AccessibleDescription = "Shows some top ten records";
@@ -1872,23 +1891,6 @@ partial class PlanetoidDbForm
 		menuitemRecords.MouseEnter += Control_Enter;
 		menuitemRecords.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonTopTenRecords
-		// 
-		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
-		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
-		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
-		splitbuttonTopTenRecords.Enabled = false;
-		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
-		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
-		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
-		splitbuttonTopTenRecords.Size = new Size(32, 22);
-		splitbuttonTopTenRecords.Text = "Top ten records";
-		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
-		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
-		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
-		// 
 		// contextMenuDistributions
 		// 
 		contextMenuDistributions.AccessibleDescription = "Shows the context menu of the distributions";
@@ -1897,7 +1899,7 @@ partial class PlanetoidDbForm
 		contextMenuDistributions.Font = new Font("Segoe UI", 9F);
 		contextMenuDistributions.Items.AddRange(new ToolStripItem[] { menuitemDistributionMeanAnomalyAtTheEpoch, menuitemDistributionArgumentOfThePerihelion, menuitemDistributionLongitudeOfTheAscendingNode, menuitemDistributionInclination, menuitemDistributionOrbitalEccentricity, menuitemDistributionMeanDailyMotion, menuitemDistributionSemiMajorAxis, menuitemDistributionAbsoluteMagnitude, menuitemDistributionSlopeParameter, menuitemDistributionNumberOfOppositions, menuitemDistributionNumberOfObservations, menuitemDistributionObservationSpan, menuitemDistributionRmsResidual, menuitemDistributionComputerName });
 		contextMenuDistributions.Name = "contextMenuDistributions";
-		contextMenuDistributions.OwnerItem = splitbuttonDistribution;
+		contextMenuDistributions.OwnerItem = menuitemDistribution;
 		contextMenuDistributions.Size = new Size(250, 312);
 		contextMenuDistributions.Text = "Distributions";
 		contextMenuDistributions.Enter += Control_Enter;
@@ -2115,23 +2117,6 @@ partial class PlanetoidDbForm
 		menuitemDistributionComputerName.MouseEnter += Control_Enter;
 		menuitemDistributionComputerName.MouseLeave += Control_Leave;
 		// 
-		// menuitemDistribution
-		// 
-		menuitemDistribution.AccessibleDescription = "Shows some distributions";
-		menuitemDistribution.AccessibleName = "Distributions";
-		menuitemDistribution.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemDistribution.AutoToolTip = true;
-		menuitemDistribution.DropDown = contextMenuDistributions;
-		menuitemDistribution.Enabled = false;
-		menuitemDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
-		menuitemDistribution.Name = "menuitemDistribution";
-		menuitemDistribution.ShortcutKeys = Keys.Control | Keys.D;
-		menuitemDistribution.Size = new Size(227, 22);
-		menuitemDistribution.Text = "&Distributions";
-		menuitemDistribution.Click += MenuitemDistribution_Click;
-		menuitemDistribution.MouseEnter += Control_Enter;
-		menuitemDistribution.MouseLeave += Control_Leave;
-		// 
 		// splitbuttonDistribution
 		// 
 		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
@@ -2149,6 +2134,23 @@ partial class PlanetoidDbForm
 		splitbuttonDistribution.MouseEnter += Control_Enter;
 		splitbuttonDistribution.MouseLeave += Control_Leave;
 		// 
+		// menuitemDistribution
+		// 
+		menuitemDistribution.AccessibleDescription = "Shows some distributions";
+		menuitemDistribution.AccessibleName = "Distributions";
+		menuitemDistribution.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemDistribution.AutoToolTip = true;
+		menuitemDistribution.DropDown = contextMenuDistributions;
+		menuitemDistribution.Enabled = false;
+		menuitemDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
+		menuitemDistribution.Name = "menuitemDistribution";
+		menuitemDistribution.ShortcutKeys = Keys.Control | Keys.D;
+		menuitemDistribution.Size = new Size(227, 22);
+		menuitemDistribution.Text = "&Distributions";
+		menuitemDistribution.Click += MenuitemDistribution_Click;
+		menuitemDistribution.MouseEnter += Control_Enter;
+		menuitemDistribution.MouseLeave += Control_Leave;
+		// 
 		// contextMenuFullCopyToClipboardOrbitalElements
 		// 
 		contextMenuFullCopyToClipboardOrbitalElements.AccessibleDescription = "Shows the context menu of the orbital elements to copy to clipboard";
@@ -2157,7 +2159,7 @@ partial class PlanetoidDbForm
 		contextMenuFullCopyToClipboardOrbitalElements.Font = new Font("Segoe UI", 9F);
 		contextMenuFullCopyToClipboardOrbitalElements.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardIndexNumber, menuitemCopyToClipboardReadableDesignation, menuitemCopyToClipboardEpoch, menuitemCopyToClipboardMeanAnomalyAtTheEpoch, menuitemCopyToClipboardArgumentOfThePerihelion, menuitemCopyToClipboardLongitudeOfTheAscendingNode, menuitemCopyToClipboardInclinationToTheEcliptic, menuitemCopyToClipboardOrbitalEccentricity, menuitemCopyToClipboardMeanDailyMotion, menuitemCopyToClipboardSemiMajorAxis, menuitemCopyToClipboardAbsoluteMagnitude, menuitemCopyToClipboardSlopeParameter, menuitemCopyToClipboardReference, menuitemCopyToClipboardNumberOfOppositions, menuitemCopyToClipboardNumberOfObservations, menuitemCopyToClipboardObservationSpan, menuitemCopyToClipboardRmsResidual, menuitemCopyToClipboardComputerName, menuitemCopyToClipboardDateOfTheLastObservation, menuitemCopyToClipboardFlags });
 		contextMenuFullCopyToClipboardOrbitalElements.Name = "Context menu of copying to clipboard of orbital elements";
-		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = menuitemCopytoClipboard;
+		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripDropDownButtonCopyToClipboard;
 		contextMenuFullCopyToClipboardOrbitalElements.Size = new Size(309, 444);
 		contextMenuFullCopyToClipboardOrbitalElements.Text = "Copy to clipboard";
 		contextMenuFullCopyToClipboardOrbitalElements.Enter += Control_Enter;
@@ -2445,21 +2447,6 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardFlags.MouseEnter += Control_Enter;
 		menuitemCopyToClipboardFlags.MouseLeave += Control_Leave;
 		// 
-		// toolStripDropDownButtonCopyToClipboard
-		// 
-		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
-		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
-		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
-		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
-		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
-		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
-		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
-		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
-		// 
 		// menuitemCopytoClipboard
 		// 
 		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
@@ -2474,6 +2461,21 @@ partial class PlanetoidDbForm
 		menuitemCopytoClipboard.Text = "&Copy";
 		menuitemCopytoClipboard.MouseEnter += Control_Enter;
 		menuitemCopytoClipboard.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonCopyToClipboard
+		// 
+		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
+		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
+		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
+		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
+		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
+		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
+		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
 		// 
 		// menu
 		// 
@@ -3190,6 +3192,30 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAsteroidsDynamicSite.Click += ToolStripMenuItemAsteroidsDynamicSite_Click;
 		toolStripMenuItemAsteroidsDynamicSite.MouseEnter += Control_Enter;
 		toolStripMenuItemAsteroidsDynamicSite.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator17
+		// 
+		toolStripSeparator17.AccessibleDescription = "Just a separator";
+		toolStripSeparator17.AccessibleName = "Separator";
+		toolStripSeparator17.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator17.Name = "toolStripSeparator17";
+		toolStripSeparator17.Size = new Size(251, 6);
+		toolStripSeparator17.MouseEnter += Control_Enter;
+		toolStripSeparator17.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemOpenAllDataPages
+		// 
+		toolStripMenuItemOpenAllDataPages.AccessibleDescription = "Opens all data pages";
+		toolStripMenuItemOpenAllDataPages.AccessibleName = "Open all data pages";
+		toolStripMenuItemOpenAllDataPages.AccessibleRole = AccessibleRole.MenuBar;
+		toolStripMenuItemOpenAllDataPages.AutoToolTip = true;
+		toolStripMenuItemOpenAllDataPages.Image = FatcowIcons16px.fatcow_external_16px;
+		toolStripMenuItemOpenAllDataPages.Name = "toolStripMenuItemOpenAllDataPages";
+		toolStripMenuItemOpenAllDataPages.Size = new Size(254, 22);
+		toolStripMenuItemOpenAllDataPages.Text = "Open all data pages";
+		toolStripMenuItemOpenAllDataPages.Click += ToolStripMenuItemOpenAllDataPages_Click;
+		toolStripMenuItemOpenAllDataPages.MouseEnter += Control_Enter;
+		toolStripMenuItemOpenAllDataPages.MouseLeave += Control_Leave;
 		// 
 		// menuitemUpdate
 		// 
@@ -4275,25 +4301,6 @@ partial class PlanetoidDbForm
 		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
-		// 
-		// toolStripSeparator17
-		// 
-		toolStripSeparator17.Name = "toolStripSeparator17";
-		toolStripSeparator17.Size = new Size(251, 6);
-		// 
-		// toolStripMenuItemOpenAllDataPages
-		// 
-		toolStripMenuItemOpenAllDataPages.AccessibleDescription = "Opens all data pages";
-		toolStripMenuItemOpenAllDataPages.AccessibleName = "Open all data pages";
-		toolStripMenuItemOpenAllDataPages.AccessibleRole = AccessibleRole.MenuBar;
-		toolStripMenuItemOpenAllDataPages.AutoToolTip = true;
-		toolStripMenuItemOpenAllDataPages.Image = FatcowIcons16px.fatcow_external_16px;
-		toolStripMenuItemOpenAllDataPages.Name = "toolStripMenuItemOpenAllDataPages";
-		toolStripMenuItemOpenAllDataPages.Size = new Size(254, 22);
-		toolStripMenuItemOpenAllDataPages.Text = "Open all data pages";
-		toolStripMenuItemOpenAllDataPages.Click += ToolStripMenuItemOpenAllDataPages_Click;
-		toolStripMenuItemOpenAllDataPages.MouseEnter += Control_Enter;
-		toolStripMenuItemOpenAllDataPages.MouseLeave += Control_Leave;
 		// 
 		// PlanetoidDbForm
 		// 

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -3,6 +3,8 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
+using Krypton.Toolkit;
+
 using NLog;
 
 using Planetoid_DB.Forms;
@@ -1356,6 +1358,119 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 	}
 
+	/// <summary>Decodes the 4-hexdigit flag from MPCORB.DAT and displays the result in a MessageBox.</summary>
+	/// <remarks>The flag encodes orbit type in the lower 6 bits and additional information in bits 6-15 according to MPC specifications.</remarks>
+	private void DecodeMpcorbFlags()
+	{
+		// Get the flag text from the label
+		string flagText = labelFlagsData.Text;
+		// Validate that the flag text is not empty
+		if (string.IsNullOrWhiteSpace(value: flagText))
+		{
+			logger.Warn(message: "Flag text is empty or whitespace");
+			_ = MessageBox.Show(
+				text: "No flag data available.",
+				caption: "Flag Decoder",
+				buttons: MessageBoxButtons.OK,
+				icon: MessageBoxIcon.Warning);
+			return;
+		}
+		// Validate that the flag text is a valid 4-hexdigit string
+		try
+		{
+			// Parse the hex string to an integer
+			int flagValue = Convert.ToInt32(value: flagText, fromBase: 16);
+			// Extract orbit type (lower 6 bits)
+			int orbitType = flagValue & 0x3F; // 0x3F = 0011 1111 (bits 0-5)
+											  // Extract individual flag bits
+			bool isNeo = (flagValue & 2048) != 0;          // Bit 11
+			bool isLargeNeo = (flagValue & 4096) != 0;     // Bit 12
+			bool isOneOppObject = (flagValue & 8192) != 0; // Bit 13
+			bool isCriticalList = (flagValue & 16384) != 0;// Bit 14
+			bool isPha = (flagValue & 32768) != 0;         // Bit 15
+														   // Build the result message
+			System.Text.StringBuilder result = new();
+			_ = result.AppendLine(value: $"MPCORB Flag Decoder");
+			_ = result.AppendLine(value: $"==================");
+			_ = result.AppendLine(value: $"Hex Value: {flagText}");
+			_ = result.AppendLine(value: $"Decimal Value: {flagValue}");
+			_ = result.AppendLine();
+			// Orbit type classification
+			_ = result.AppendLine(value: "Orbit Classification:");
+			string orbitTypeName = orbitType switch
+			{
+				1 => "Atira",
+				2 => "Aten",
+				3 => "Apollo",
+				4 => "Amor",
+				5 => "Object with q < 1.665 AU",
+				6 => "Hungaria",
+				7 => "Unused or internal MPC use only",
+				8 => "Hilda",
+				9 => "Jupiter Trojan",
+				10 => "Distant object",
+				_ => $"Undefined (value: {orbitType})"
+			};
+			_ = result.AppendLine(value: $"  {orbitTypeName}");
+			_ = result.AppendLine();
+			// Additional flags
+			_ = result.AppendLine(value: "Additional Flags:");
+			if (isNeo)
+			{
+				_ = result.AppendLine(value: "  ✓ Near-Earth Object (NEO)");
+			}
+			if (isLargeNeo)
+			{
+				_ = result.AppendLine(value: "  ✓ 1-km (or larger) NEO");
+			}
+			if (isOneOppObject)
+			{
+				_ = result.AppendLine(value: "  ✓ 1-opposition object seen at earlier opposition");
+			}
+			if (isCriticalList)
+			{
+				_ = result.AppendLine(value: "  ✓ Critical list numbered object");
+			}
+			if (isPha)
+			{
+				_ = result.AppendLine(value: "  ✓ Potentially Hazardous Asteroid (PHA)");
+			}
+			// If no additional flags are set
+			if (!isNeo && !isLargeNeo && !isOneOppObject && !isCriticalList && !isPha)
+			{
+				_ = result.AppendLine(value: "  (none)");
+			}
+			// Display the result in a MessageBox
+			_ = KryptonMessageBox.Show(
+				text: result.ToString(),
+				caption: "MPCORB Flag Decoder",
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Information);
+
+			logger.Info(message: $"Decoded MPCORB flag: {flagText} = {flagValue} ({orbitTypeName})");
+		}
+		// Handle format exceptions when parsing the hex string
+		catch (FormatException ex)
+		{
+			logger.Error(exception: ex, message: $"Failed to parse flag value '{flagText}': {ex.Message}");
+			_ = MessageBox.Show(
+				text: $"Failed to parse flag value '{flagText}'.\n\nThe flag must be a valid hexadecimal number.\n\nError: {ex.Message}",
+				caption: I18nStrings.ErrorCaption,
+				buttons: MessageBoxButtons.OK,
+				icon: MessageBoxIcon.Error);
+		}
+		// Handle overflow exceptions when the hex value is too large to fit in an integer
+		catch (Exception ex)
+		{
+			logger.Error(exception: ex, message: $"Error decoding MPCORB flag: {ex.Message}");
+			_ = MessageBox.Show(
+				text: $"An error occurred while decoding the flag.\n\nError: {ex.Message}",
+				caption: I18nStrings.ErrorCaption,
+				buttons: MessageBoxButtons.OK,
+				icon: MessageBoxIcon.Error);
+		}
+	}
+
 	#endregion
 
 	#region form event handlers
@@ -2632,6 +2747,63 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method allows the user to select a custom local MPCORB.DAT file instead of using the default one.</remarks>
 	private void ToolStripButtonOpenLocalMpcorbDat_Click(object sender, EventArgs e) => OpenLocalMpcorbDat();
 
+	/// <summary>Handles the Click event for the MPC Database menu item and opens the Minor Planet Center database page for the selected object.</summary>
+	/// <remarks>This method constructs a URL to the Minor Planet Center database using the current object's identifier and opens it in the default web browser.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemMpcDatabase_Click(object sender, EventArgs e)
+	{
+		string dataPageUrl = "https://www.minorplanetcenter.net/db_search/show_object?utf8=%E2%9C%93&object_id=" + labelIndexData.Text;
+		OpenWebsite(fileName: dataPageUrl);
+	}
+
+	/// <summary>Handles the Click event for the JPL Small-Body Database menu item and opens the corresponding web page in the default browser.</summary>
+	/// <remarks>This event handler constructs a URL to the JPL Small-Body Database using the current value of the index label and opens it in the user's default web browser.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemJplSmallBodyDatabase_Click(object sender, EventArgs e)
+	{
+		string dataPageUrl = "https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=" + labelIndexData.Text + "&view=OPDA";
+		OpenWebsite(fileName: dataPageUrl);
+	}
+
+	/// <summary>Handles the Click event for the Lowell Minor Planet Services menu item, opening the corresponding asteroid data page in a web browser.</summary>
+	/// <remarks>This event handler constructs a URL for the Lowell Observatory's asteroid search page based on the current designation and opens it in the default web browser.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemLowellMinorPlanetServices_Click(object sender, EventArgs e)
+	{
+		string dataPageUrl = "https://asteroid.lowell.edu/gui/search/" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
+		OpenWebsite(fileName: dataPageUrl);
+	}
+
+	/// <summary>Handles the Click event for the Asteroids Dynamic Site menu item, opening the corresponding asteroid data page in a web browser.</summary>
+	/// <remarks>This event handler constructs a URL for the selected asteroid using its readable designation and opens the associated data page in the default web browser.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemAsteroidsDynamicSite_Click(object sender, EventArgs e)
+	{
+		string dataPageUrl = "https://newton.spacedys.com/astdys/index.php?pc=1.1.0&n=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
+		OpenWebsite(fileName: dataPageUrl);
+	}
+
+	/// <summary>Handles the Click event for the menu item that opens all relevant data pages for the selected object in the default web browser.</summary>
+	/// <remarks>This method constructs URLs for multiple astronomical data sources using the current object's identifiers and opens each page in the default web browser. The method is intended to provide quick access to external resources for further information about the selected object.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	private void ToolStripMenuItemOpenAllDataPages_Click(object sender, EventArgs e)
+	{
+		ToolStripMenuItemMpcDatabase_Click(sender: sender, e: e);
+		ToolStripMenuItemJplSmallBodyDatabase_Click(sender: sender, e: e);
+		ToolStripMenuItemLowellMinorPlanetServices_Click(sender: sender, e: e);
+		ToolStripMenuItemAsteroidsDynamicSite_Click(sender: sender, e: e);
+	}
+
+	/// <summary>Handles the Click event for the label that displays MPCORB flag data and initiates decoding of the flags.</summary>
+	/// <param name="sender">The source of the event, typically the label control that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method decodes the MPCORB flags when the label is clicked.</remarks>
+	private void LabelFlagsData_Click(object sender, EventArgs e) => DecodeMpcorbFlags();
 
 	#endregion
 
@@ -2714,58 +2886,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// TODO: Implement enable/disable linking to terminology
 		_ = MessageBox.Show(text: "Enable linking to terminology not implemented yet", caption: I18nStrings.InformationCaption, buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Information);
-	}
-
-	/// <summary>Handles the Click event for the MPC Database menu item and opens the Minor Planet Center database page for the selected object.</summary>
-	/// <remarks>This method constructs a URL to the Minor Planet Center database using the current object's identifier and opens it in the default web browser.</remarks>
-	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemMpcDatabase_Click(object sender, EventArgs e)
-	{
-		string dataPageUrl = "https://www.minorplanetcenter.net/db_search/show_object?utf8=%E2%9C%93&object_id=" + labelIndexData.Text;
-		OpenWebsite(fileName: dataPageUrl);
-	}
-
-	/// <summary>Handles the Click event for the JPL Small-Body Database menu item and opens the corresponding web page in the default browser.</summary>
-	/// <remarks>This event handler constructs a URL to the JPL Small-Body Database using the current value of the index label and opens it in the user's default web browser.</remarks>
-	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemJplSmallBodyDatabase_Click(object sender, EventArgs e)
-	{
-		string dataPageUrl = "https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=" + labelIndexData.Text + "&view=OPDA";
-		OpenWebsite(fileName: dataPageUrl);
-	}
-
-	/// <summary>Handles the Click event for the Lowell Minor Planet Services menu item, opening the corresponding asteroid data page in a web browser.</summary>
-	/// <remarks>This event handler constructs a URL for the Lowell Observatory's asteroid search page based on the current designation and opens it in the default web browser.</remarks>
-	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemLowellMinorPlanetServices_Click(object sender, EventArgs e)
-	{
-		string dataPageUrl = "https://asteroid.lowell.edu/gui/search/" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
-		OpenWebsite(fileName: dataPageUrl);
-	}
-
-	/// <summary>Handles the Click event for the Asteroids Dynamic Site menu item, opening the corresponding asteroid data page in a web browser.</summary>
-	/// <remarks>This event handler constructs a URL for the selected asteroid using its readable designation and opens the associated data page in the default web browser.</remarks>
-	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemAsteroidsDynamicSite_Click(object sender, EventArgs e)
-	{
-		string dataPageUrl = "https://newton.spacedys.com/astdys/index.php?pc=1.1.0&n=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
-		OpenWebsite(fileName: dataPageUrl);
-	}
-
-	/// <summary>Handles the Click event for the menu item that opens all relevant data pages for the selected object in the default web browser.</summary>
-	/// <remarks>This method constructs URLs for multiple astronomical data sources using the current object's identifiers and opens each page in the default web browser. The method is intended to provide quick access to external resources for further information about the selected object.</remarks>
-	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemOpenAllDataPages_Click(object sender, EventArgs e)
-	{
-		ToolStripMenuItemMpcDatabase_Click(sender, e);
-		ToolStripMenuItemJplSmallBodyDatabase_Click(sender, e);
-		ToolStripMenuItemLowellMinorPlanetServices_Click(sender, e);
-		ToolStripMenuItemAsteroidsDynamicSite_Click(sender, e);
 	}
 
 	#endregion


### PR DESCRIPTION
Adds an interactive decoder for the MPCORB “4-hexdigit flags” field in the main Planetoid DB viewer, so users can interpret the encoded orbit classification and related bits directly from the UI.

**Changes:**
- Added a click-to-decode flow for the Flags label, showing a decoded summary in a (Krypton) message box.
- Added `DecodeMpcorbFlags()` plus a new `LabelFlagsData_Click` handler, and wired the click event in the designer.
- Designer refactor/reordering of several ToolStrip/Menu items and context-menu owner hookups.