### PR TITLE
Added decoding of the MPCORB reference

### DIFF
--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -50,10 +50,10 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep1000 = new ToolStripMenuItem();
 		menuitemNavigateStep10000 = new ToolStripMenuItem();
 		menuitemNavigateStep100000 = new ToolStripMenuItem();
+		menuitemNavigateSomeDataBackward = new ToolStripMenuItem();
 		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
 		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		toolStripSplitButtonStepBackward = new ToolStripSplitButton();
-		menuitemNavigateSomeDataBackward = new ToolStripMenuItem();
 		tableLayoutPanelData = new KryptonTableLayoutPanel();
 		labelIndexData = new KryptonLabel();
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
@@ -119,8 +119,8 @@ partial class PlanetoidDbForm
 		menuitemRecordsRmsResidual = new ToolStripMenuItem();
 		menuitemRecordsComputername = new ToolStripMenuItem();
 		menuitemRecordsDateOfTheLastObservation = new ToolStripMenuItem();
-		splitbuttonTopTenRecords = new ToolStripSplitButton();
 		menuitemRecords = new ToolStripMenuItem();
+		splitbuttonTopTenRecords = new ToolStripSplitButton();
 		contextMenuDistributions = new ContextMenuStrip(components);
 		menuitemDistributionMeanAnomalyAtTheEpoch = new ToolStripMenuItem();
 		menuitemDistributionArgumentOfThePerihelion = new ToolStripMenuItem();
@@ -136,8 +136,8 @@ partial class PlanetoidDbForm
 		menuitemDistributionObservationSpan = new ToolStripMenuItem();
 		menuitemDistributionRmsResidual = new ToolStripMenuItem();
 		menuitemDistributionComputerName = new ToolStripMenuItem();
-		splitbuttonDistribution = new ToolStripSplitButton();
 		menuitemDistribution = new ToolStripMenuItem();
+		splitbuttonDistribution = new ToolStripSplitButton();
 		contextMenuFullCopyToClipboardOrbitalElements = new ContextMenuStrip(components);
 		menuitemCopyToClipboardIndexNumber = new ToolStripMenuItem();
 		menuitemCopyToClipboardReadableDesignation = new ToolStripMenuItem();
@@ -159,8 +159,8 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardComputerName = new ToolStripMenuItem();
 		menuitemCopyToClipboardDateOfTheLastObservation = new ToolStripMenuItem();
 		menuitemCopyToClipboardFlags = new ToolStripMenuItem();
-		menuitemCopytoClipboard = new ToolStripMenuItem();
 		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
+		menuitemCopytoClipboard = new ToolStripMenuItem();
 		menu = new MenuStrip();
 		menuitemFile = new ToolStripMenuItem();
 		toolStripMenuItemOpenLocalMpcorbDat = new ToolStripMenuItem();
@@ -317,7 +317,7 @@ partial class PlanetoidDbForm
 		contextMenuNavigationStep.Font = new Font("Segoe UI", 9F);
 		contextMenuNavigationStep.Items.AddRange(new ToolStripItem[] { menuitemNavigateStep10, menuitemNavigateStep100, menuitemNavigateStep1000, menuitemNavigateStep10000, menuitemNavigateStep100000 });
 		contextMenuNavigationStep.Name = "contextMenu";
-		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataBackward;
+		contextMenuNavigationStep.OwnerItem = toolStripSplitButtonStepBackward;
 		contextMenuNavigationStep.ShowCheckMargin = true;
 		contextMenuNavigationStep.ShowImageMargin = false;
 		contextMenuNavigationStep.Size = new Size(111, 114);
@@ -400,6 +400,22 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep100000.MouseEnter += Control_Enter;
 		menuitemNavigateStep100000.MouseLeave += Control_Leave;
 		// 
+		// menuitemNavigateSomeDataBackward
+		// 
+		menuitemNavigateSomeDataBackward.AccessibleDescription = "Navigates some data backward";
+		menuitemNavigateSomeDataBackward.AccessibleName = "Navigates some data backward";
+		menuitemNavigateSomeDataBackward.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemNavigateSomeDataBackward.AutoToolTip = true;
+		menuitemNavigateSomeDataBackward.DropDown = contextMenuNavigationStep;
+		menuitemNavigateSomeDataBackward.Image = FatcowIcons16px.fatcow_control_rewind_blue_16px;
+		menuitemNavigateSomeDataBackward.Name = "menuitemNavigateSomeDataBackward";
+		menuitemNavigateSomeDataBackward.ShortcutKeys = Keys.Control | Keys.D2;
+		menuitemNavigateSomeDataBackward.Size = new Size(275, 22);
+		menuitemNavigateSomeDataBackward.Text = "Navigate some data back&ward";
+		menuitemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
+		menuitemNavigateSomeDataBackward.MouseEnter += Control_Enter;
+		menuitemNavigateSomeDataBackward.MouseLeave += Control_Leave;
+		// 
 		// menuitemNavigateSomeDataForward
 		// 
 		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
@@ -447,22 +463,6 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonStepBackward.ButtonClick += ToolStripButtonStepBackward_Click;
 		toolStripSplitButtonStepBackward.MouseEnter += Control_Enter;
 		toolStripSplitButtonStepBackward.MouseLeave += Control_Leave;
-		// 
-		// menuitemNavigateSomeDataBackward
-		// 
-		menuitemNavigateSomeDataBackward.AccessibleDescription = "Navigates some data backward";
-		menuitemNavigateSomeDataBackward.AccessibleName = "Navigates some data backward";
-		menuitemNavigateSomeDataBackward.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemNavigateSomeDataBackward.AutoToolTip = true;
-		menuitemNavigateSomeDataBackward.DropDown = contextMenuNavigationStep;
-		menuitemNavigateSomeDataBackward.Image = FatcowIcons16px.fatcow_control_rewind_blue_16px;
-		menuitemNavigateSomeDataBackward.Name = "menuitemNavigateSomeDataBackward";
-		menuitemNavigateSomeDataBackward.ShortcutKeys = Keys.Control | Keys.D2;
-		menuitemNavigateSomeDataBackward.Size = new Size(275, 22);
-		menuitemNavigateSomeDataBackward.Text = "Navigate some data back&ward";
-		menuitemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
-		menuitemNavigateSomeDataBackward.MouseEnter += Control_Enter;
-		menuitemNavigateSomeDataBackward.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanelData
 		// 
@@ -853,6 +853,7 @@ partial class PlanetoidDbForm
 		labelReferenceData.AccessibleName = "Shows the information of \"Reference\"";
 		labelReferenceData.AccessibleRole = AccessibleRole.StaticText;
 		labelReferenceData.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelReferenceData.Cursor = Cursors.Hand;
 		labelReferenceData.Dock = DockStyle.Fill;
 		labelReferenceData.Location = new Point(675, 55);
 		labelReferenceData.Name = "labelReferenceData";
@@ -863,6 +864,7 @@ partial class PlanetoidDbForm
 		labelReferenceData.ToolTipValues.Heading = "Reference";
 		labelReferenceData.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
 		labelReferenceData.Values.Text = "..................";
+		labelReferenceData.Click += LabelReferenceData_Click;
 		labelReferenceData.DoubleClick += CopyToClipboard_DoubleClick;
 		labelReferenceData.Enter += Control_Enter;
 		labelReferenceData.Leave += Control_Leave;
@@ -1583,7 +1585,7 @@ partial class PlanetoidDbForm
 		contextMenuTopTenRecords.Font = new Font("Segoe UI", 9F);
 		contextMenuTopTenRecords.Items.AddRange(new ToolStripItem[] { menuitemRecordsSortDirection, toolStripSeparator12, menuitemRecordsMeanAnomalyAtTheEpoch, menuitemRecordsArgumentOfThePerihelion, menuitemRecordsLongitudeOfTheAscendingNode, menuitemRecordsInclination, menuitemRecordsOrbitalEccentricity, menuitemRecordsMeanDailyMotion, menuitemRecordsSemiMajorAxis, menuitemRecordsAbsoluteMagnitude, menuitemRecordsSlopeParameter, menuitemRecordsNumberOfOppositions, menuitemRecordsNumberOfObservations, menuitemRecordsObservationSpan, menuitemRecordsRmsResidual, menuitemRecordsComputername, menuitemRecordsDateOfTheLastObservation });
 		contextMenuTopTenRecords.Name = "contextMenuTopTenRecords";
-		contextMenuTopTenRecords.OwnerItem = menuitemRecords;
+		contextMenuTopTenRecords.OwnerItem = splitbuttonTopTenRecords;
 		contextMenuTopTenRecords.Size = new Size(250, 362);
 		contextMenuTopTenRecords.TabStop = true;
 		contextMenuTopTenRecords.Text = "Top ten records";
@@ -1856,23 +1858,6 @@ partial class PlanetoidDbForm
 		menuitemRecordsDateOfTheLastObservation.MouseEnter += Control_Enter;
 		menuitemRecordsDateOfTheLastObservation.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonTopTenRecords
-		// 
-		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
-		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
-		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
-		splitbuttonTopTenRecords.Enabled = false;
-		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
-		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
-		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
-		splitbuttonTopTenRecords.Size = new Size(32, 22);
-		splitbuttonTopTenRecords.Text = "Top ten records";
-		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
-		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
-		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
-		// 
 		// menuitemRecords
 		// 
 		menuitemRecords.AccessibleDescription = "Shows some top ten records";
@@ -1891,6 +1876,23 @@ partial class PlanetoidDbForm
 		menuitemRecords.MouseEnter += Control_Enter;
 		menuitemRecords.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonTopTenRecords
+		// 
+		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
+		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
+		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
+		splitbuttonTopTenRecords.Enabled = false;
+		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
+		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
+		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
+		splitbuttonTopTenRecords.Size = new Size(32, 22);
+		splitbuttonTopTenRecords.Text = "Top ten records";
+		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
+		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
+		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
+		// 
 		// contextMenuDistributions
 		// 
 		contextMenuDistributions.AccessibleDescription = "Shows the context menu of the distributions";
@@ -1899,7 +1901,7 @@ partial class PlanetoidDbForm
 		contextMenuDistributions.Font = new Font("Segoe UI", 9F);
 		contextMenuDistributions.Items.AddRange(new ToolStripItem[] { menuitemDistributionMeanAnomalyAtTheEpoch, menuitemDistributionArgumentOfThePerihelion, menuitemDistributionLongitudeOfTheAscendingNode, menuitemDistributionInclination, menuitemDistributionOrbitalEccentricity, menuitemDistributionMeanDailyMotion, menuitemDistributionSemiMajorAxis, menuitemDistributionAbsoluteMagnitude, menuitemDistributionSlopeParameter, menuitemDistributionNumberOfOppositions, menuitemDistributionNumberOfObservations, menuitemDistributionObservationSpan, menuitemDistributionRmsResidual, menuitemDistributionComputerName });
 		contextMenuDistributions.Name = "contextMenuDistributions";
-		contextMenuDistributions.OwnerItem = menuitemDistribution;
+		contextMenuDistributions.OwnerItem = splitbuttonDistribution;
 		contextMenuDistributions.Size = new Size(250, 312);
 		contextMenuDistributions.Text = "Distributions";
 		contextMenuDistributions.Enter += Control_Enter;
@@ -2117,23 +2119,6 @@ partial class PlanetoidDbForm
 		menuitemDistributionComputerName.MouseEnter += Control_Enter;
 		menuitemDistributionComputerName.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonDistribution
-		// 
-		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
-		splitbuttonDistribution.AccessibleName = "Distributions";
-		splitbuttonDistribution.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonDistribution.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonDistribution.DropDown = contextMenuDistributions;
-		splitbuttonDistribution.Enabled = false;
-		splitbuttonDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
-		splitbuttonDistribution.ImageTransparentColor = Color.Magenta;
-		splitbuttonDistribution.Name = "splitbuttonDistribution";
-		splitbuttonDistribution.Size = new Size(32, 22);
-		splitbuttonDistribution.Text = "Distributions";
-		splitbuttonDistribution.ButtonClick += SplitButtonDistribution_ButtonClick;
-		splitbuttonDistribution.MouseEnter += Control_Enter;
-		splitbuttonDistribution.MouseLeave += Control_Leave;
-		// 
 		// menuitemDistribution
 		// 
 		menuitemDistribution.AccessibleDescription = "Shows some distributions";
@@ -2151,6 +2136,23 @@ partial class PlanetoidDbForm
 		menuitemDistribution.MouseEnter += Control_Enter;
 		menuitemDistribution.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonDistribution
+		// 
+		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
+		splitbuttonDistribution.AccessibleName = "Distributions";
+		splitbuttonDistribution.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonDistribution.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonDistribution.DropDown = contextMenuDistributions;
+		splitbuttonDistribution.Enabled = false;
+		splitbuttonDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
+		splitbuttonDistribution.ImageTransparentColor = Color.Magenta;
+		splitbuttonDistribution.Name = "splitbuttonDistribution";
+		splitbuttonDistribution.Size = new Size(32, 22);
+		splitbuttonDistribution.Text = "Distributions";
+		splitbuttonDistribution.ButtonClick += SplitButtonDistribution_ButtonClick;
+		splitbuttonDistribution.MouseEnter += Control_Enter;
+		splitbuttonDistribution.MouseLeave += Control_Leave;
+		// 
 		// contextMenuFullCopyToClipboardOrbitalElements
 		// 
 		contextMenuFullCopyToClipboardOrbitalElements.AccessibleDescription = "Shows the context menu of the orbital elements to copy to clipboard";
@@ -2159,7 +2161,7 @@ partial class PlanetoidDbForm
 		contextMenuFullCopyToClipboardOrbitalElements.Font = new Font("Segoe UI", 9F);
 		contextMenuFullCopyToClipboardOrbitalElements.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardIndexNumber, menuitemCopyToClipboardReadableDesignation, menuitemCopyToClipboardEpoch, menuitemCopyToClipboardMeanAnomalyAtTheEpoch, menuitemCopyToClipboardArgumentOfThePerihelion, menuitemCopyToClipboardLongitudeOfTheAscendingNode, menuitemCopyToClipboardInclinationToTheEcliptic, menuitemCopyToClipboardOrbitalEccentricity, menuitemCopyToClipboardMeanDailyMotion, menuitemCopyToClipboardSemiMajorAxis, menuitemCopyToClipboardAbsoluteMagnitude, menuitemCopyToClipboardSlopeParameter, menuitemCopyToClipboardReference, menuitemCopyToClipboardNumberOfOppositions, menuitemCopyToClipboardNumberOfObservations, menuitemCopyToClipboardObservationSpan, menuitemCopyToClipboardRmsResidual, menuitemCopyToClipboardComputerName, menuitemCopyToClipboardDateOfTheLastObservation, menuitemCopyToClipboardFlags });
 		contextMenuFullCopyToClipboardOrbitalElements.Name = "Context menu of copying to clipboard of orbital elements";
-		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripDropDownButtonCopyToClipboard;
+		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = menuitemCopytoClipboard;
 		contextMenuFullCopyToClipboardOrbitalElements.Size = new Size(309, 444);
 		contextMenuFullCopyToClipboardOrbitalElements.Text = "Copy to clipboard";
 		contextMenuFullCopyToClipboardOrbitalElements.Enter += Control_Enter;
@@ -2447,21 +2449,6 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardFlags.MouseEnter += Control_Enter;
 		menuitemCopyToClipboardFlags.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopytoClipboard
-		// 
-		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
-		menuitemCopytoClipboard.AccessibleName = "Copy to clipboard";
-		menuitemCopytoClipboard.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopytoClipboard.AutoToolTip = true;
-		menuitemCopytoClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
-		menuitemCopytoClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
-		menuitemCopytoClipboard.Name = "menuitemCopytoClipboard";
-		menuitemCopytoClipboard.ShortcutKeys = Keys.Control | Keys.C;
-		menuitemCopytoClipboard.Size = new Size(151, 22);
-		menuitemCopytoClipboard.Text = "&Copy";
-		menuitemCopytoClipboard.MouseEnter += Control_Enter;
-		menuitemCopytoClipboard.MouseLeave += Control_Leave;
-		// 
 		// toolStripDropDownButtonCopyToClipboard
 		// 
 		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
@@ -2476,6 +2463,21 @@ partial class PlanetoidDbForm
 		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
 		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
 		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
+		// 
+		// menuitemCopytoClipboard
+		// 
+		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
+		menuitemCopytoClipboard.AccessibleName = "Copy to clipboard";
+		menuitemCopytoClipboard.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopytoClipboard.AutoToolTip = true;
+		menuitemCopytoClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
+		menuitemCopytoClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
+		menuitemCopytoClipboard.Name = "menuitemCopytoClipboard";
+		menuitemCopytoClipboard.ShortcutKeys = Keys.Control | Keys.C;
+		menuitemCopytoClipboard.Size = new Size(151, 22);
+		menuitemCopytoClipboard.Text = "&Copy";
+		menuitemCopytoClipboard.MouseEnter += Control_Enter;
+		menuitemCopytoClipboard.MouseLeave += Control_Leave;
 		// 
 		// menu
 		// 

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -1463,13 +1463,256 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		catch (OverflowException ex)
 		{
 			logger.Error(exception: ex, message: $"Error decoding MPCORB flag: {ex.Message}");
-			_ = MessageBox.Show(
+			_ = KryptonMessageBox.Show(
 				text: $"An error occurred while decoding the flag.\n\nError: {ex.Message}",
 				caption: I18nStrings.ErrorCaption,
-				buttons: MessageBoxButtons.OK,
-				icon: MessageBoxIcon.Error);
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Error);
 		}
 	}
+
+	/// <summary>Decodes the compressed reference code from MPCORB.DAT and displays the full reference in a MessageBox.</summary>
+	/// <remarks>Decodes various reference formats according to MPC specifications at http://www.minorplanetcenter.org/iau/info/References.html</remarks>
+	private void DecodeMpcorbReference()
+	{
+		// Get the reference text from the label
+		string referenceText = labelReferenceData.Text;
+		// Validate that the reference text is not empty
+		if (string.IsNullOrWhiteSpace(value: referenceText))
+		{
+			logger.Warn(message: "Reference text is empty or whitespace");
+			_ = KryptonMessageBox.Show(
+				text: "No reference data available.",
+				caption: "Reference Decoder",
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Warning);
+			return;
+		}
+		// Attempt to decode the reference and handle any exceptions that may occur during decoding
+		try
+		{
+			string decodedReference = DecodeReference(compressedRef: referenceText.Trim());
+			// Build the result message
+			System.Text.StringBuilder result = new();
+			_ = result.AppendLine(value: "MPCORB Reference Decoder");
+			_ = result.AppendLine(value: "========================");
+			_ = result.AppendLine(value: $"Compressed: {referenceText}");
+			_ = result.AppendLine();
+			_ = result.AppendLine(value: "Full Reference:");
+			_ = result.AppendLine(value: $"  {decodedReference}");
+			// Display the result in a MessageBox
+			_ = KryptonMessageBox.Show(
+				text: result.ToString(),
+				caption: "MPCORB Reference Decoder",
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Information);
+			logger.Info(message: $"Decoded MPCORB reference: '{referenceText}' → '{decodedReference}'");
+		}
+		catch (Exception ex)
+		{
+			logger.Error(exception: ex, message: $"Error decoding MPCORB reference '{referenceText}': {ex.Message}");
+			_ = KryptonMessageBox.Show(
+				text: $"An error occurred while decoding the reference:\n\n{ex.Message}",
+				caption: I18nStrings.ErrorCaption,
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Error);
+		}
+	}
+
+	/// <summary>Decodes a compressed MPC reference string to its full form.</summary>
+	/// <param name="compressedRef">The compressed reference string (typically 5 characters).</param>
+	/// <returns>The full reference description.</returns>
+	private static string DecodeReference(string compressedRef)
+	{
+		if (string.IsNullOrWhiteSpace(value: compressedRef))
+		{
+			return "Unknown reference";
+		}
+		// Ensure the reference is exactly 5 characters for proper parsing
+		compressedRef = compressedRef.PadRight(totalWidth: 5);
+		char firstChar = compressedRef[index: 0];
+		// 1: Temporary MPEC References (E + half-month + number)
+		if (firstChar == 'E')
+		{
+			string halfMonth = compressedRef.Substring(startIndex: 1, length: 1);
+			string circularNumber = compressedRef.Substring(startIndex: 2, length: 3).TrimStart(trimChar: '0');
+			return $"MPEC (temporary) - Half-month {halfMonth}, Circular {circularNumber}";
+		}
+		// 2A: Five-digit MPC numbers (00001-99999)
+		if (char.IsDigit(c: firstChar) && compressedRef.All(predicate: c => char.IsDigit(c: c) || char.IsWhiteSpace(c: c)))
+		{
+			if (int.TryParse(s: compressedRef.Trim(), result: out int mpcNumber))
+			{
+				return $"Minor Planet Circular (MPC) {mpcNumber}";
+			}
+		}
+		// 2B: @ + four digits (MPC 100000-109999)
+		if (firstChar == '@')
+		{
+			string digits = compressedRef.Substring(startIndex: 1, length: 4);
+			if (int.TryParse(s: digits, result: out int excess))
+			{
+				return $"Minor Planet Circular (MPC) {100000 + excess}";
+			}
+		}
+		// 2C: # + four Base-62 characters (MPC 110000+)
+		if (firstChar == '#')
+		{
+			string base62 = compressedRef.Substring(startIndex: 1, length: 4);
+			int value = DecodeBase62(encoded: base62);
+			return $"Minor Planet Circular (MPC) {110000 + value}";
+		}
+		// 2D: Lowercase letter + four digits (MPS)
+		if (char.IsLower(c: firstChar))
+		{
+			int multiplier = firstChar - 'a';
+			string digits = compressedRef.Substring(startIndex: 1, length: 4);
+			if (int.TryParse(s: digits, result: out int remainder))
+			{
+				int mpsNumber = (multiplier * 10000) + remainder;
+				return $"Minor Planet Supplement (MPS) {mpsNumber}";
+			}
+		}
+		// 2E: Tilde + four Base-62 characters (MPS 260000+)
+		if (firstChar == '~')
+		{
+			string base62 = compressedRef.Substring(startIndex: 1, length: 4);
+			int value = DecodeBase62(encoded: base62);
+			return $"Minor Planet Supplement (MPS) {260000 + value}";
+		}
+		// 2F: Single uppercase letter + four digits (various journals)
+		if (char.IsUpper(c: firstChar) && compressedRef.Length >= 2 && char.IsDigit(c: compressedRef[index: 1]))
+		{
+			string digits = compressedRef.Substring(startIndex: 1, length: 4);
+			if (int.TryParse(s: digits, result: out int number))
+			{
+				return firstChar switch
+				{
+					'H' => $"Harvard Announcement Card (HAC) {number}",
+					'I' => $"IAU Circular (IAUC) {number}",
+					'M' => $"Minor Planet Circular (MPC) {number}",
+					'R' => $"Planetenzirkular des Astronomischen Rechen-Institut (RI) {number}",
+					_ => $"Journal '{firstChar}' #{number}"
+				};
+			}
+		}
+		// 2G: Two or more letters (various journals)
+		if (compressedRef.Length >= 2)
+		{
+			string journalCode = compressedRef[..2].Trim();
+			string remainder = compressedRef.Length > 2 ? compressedRef[2..].Trim() : "";
+			// Attempt to get the journal name from the code
+			string journalName = GetJournalName(code: journalCode);
+			if (!string.IsNullOrEmpty(value: journalName))
+			{
+				return !string.IsNullOrEmpty(value: remainder) && int.TryParse(s: remainder, result: out int volOrCirc)
+					? $"{journalName}, Vol./Circ. {volOrCirc}"
+					: journalName;
+			}
+		}
+		// If no known format matches, return the original compressed reference with a note
+		return $"Unknown reference format: {compressedRef.Trim()}";
+	}
+
+	/// <summary>Decodes a Base-62 encoded string to an integer.</summary>
+	/// <param name="encoded">The Base-62 encoded string.</param>
+	/// <returns>The decoded integer value.</returns>
+	/// <remarks>Uses characters 0-9, A-Z, a-z to represent digits 0-61.</remarks>
+	private static int DecodeBase62(string encoded)
+	{
+		// Define the character set for Base-62 encoding
+		const string base62Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+		int result = 0;
+		// Process each character in the encoded string
+		foreach (char c in encoded)
+		{
+			// Find the index of the character in the Base-62 character set
+			int digit = base62Chars.IndexOf(value: c);
+			if (digit == -1)
+			{
+				// If the character is not found in the Base-62 set, throw a format exception
+				throw new FormatException(message: $"Invalid Base-62 character: {c}");
+			}
+			result = (result * 62) + digit;
+		}
+		// Return the decoded integer value
+		return result;
+	}
+
+	/// <summary>Gets the full journal name from a two-letter journal code.</summary>
+	/// <param name="code">The two-letter journal code.</param>
+	/// <returns>The full journal name, or an empty string if not found.</returns>
+	private static string GetJournalName(string code) => code switch
+	{
+		"AA" => "Astronomy and Astrophysics",
+		"AB" => "Bulletin des Astrophysikalischen Observatoriums Abastumani",
+		"AC" => "Astronomisches Zirkular der Akademie der Wissenschaften der UdSSR",
+		"AE" => "Astronomical Papers prepared for the use of the American Ephemeris and Nautical Almanac",
+		"AJ" => "Astronomical Journal",
+		"AN" => "Astronomische Nachrichten",
+		"AP" => "Astrophysical Journal Supplement",
+		"As" => "Astronomy and Astrophysics Supplement",
+		"BA" => "Bulletin Astronomique",
+		"BB" => "Bulletin Astronomique de l'Observatoire Royal de Belgique, Uccle",
+		"BC" => "Bulletin of the Astronomical Institutes of Czechoslovakia",
+		"BG" => "Bulletin de l'Observatoire Astronomique de Beograd",
+		"BN" => "Bulletin of the Astronomical Institutes of the Netherlands",
+		"BP" => "Bulletin de la Societe des amis des sciences et des lettres de Poznan",
+		"BZ" => "Beobachtungs-Zirkulare der Astronomischen Nachrichten",
+		"CB" => "Comet Bulletin of the Orient Astronomical Association",
+		"CC" => "Observatorio Astronomico de Cordoba, Serie Contribuciones",
+		"CD" => "Tsirkulyari Rasadkhonai Stalinobod",
+		"CK" => "Izvestiya Krymskoj Astrofizicheskoj Observatorii",
+		"CM" => "Circulaire de l'Observatoire de Marseille",
+		"CO" => "Odesskij Gosudarstvennyj Universitet Izvestiya Astronomicheskoj Observattorii",
+		"CR" => "Comptes Rendus hebdomadaires de l'academie des sciences de Paris",
+		"CS" => "Soobshcheniya Gosudarstvennogo Astronomicheskogo Instituta imeni P. K. Shternberga",
+		"GO" => "Greenwich Observations",
+		"HA" => "Harvard Annal",
+		"HD" => "Veröffentlichungen der Landessternwarte Heidelberg",
+		"HTCDR" => "Hipparcos-Tycho CD-ROM",
+		"IHW" => "International Halley Watch CD-ROM",
+		"Ic" => "Icarus",
+		"JB" => "Journal of the British Astronomial Association",
+		"JC" => "Japan Astronomical Study Association Circular",
+		"JO" => "Journal des Observateurs",
+		"KB" => "Bulletin of the Kwasan Observatory, Kyoto",
+		"KK" => "Kiev Komet Tsirkular",
+		"LB" => "Lick Observatory Bulletin",
+		"LO" => "Lowell Observatory Bulletin",
+		"LP" => "Publicaciones Observatorio Astronomico de La Plata",
+		"MN" => "Monthly Notices of the Royal Astronomical Society",
+		"NA" => "Annales de l'Observatoire de Nice",
+		"NC" => "Nihondaira Observatory Circular",
+		"NO" => "Publications of the U.S. Naval Observatory, Second Series",
+		"NZ" => "Nachrichtenblatt der Astronomischen Zentralstelle",
+		"OB" => "The Observatory",
+		"PA" => "Publications of the Astronomical Society of the Pacific",
+		"PC" => "Poulkovo Observatory Circular",
+		"PD" => "Tartu Astronoonmia Observatooriumi Publikatsioonid",
+		"PK" => "Pyublikatsii Kievskoj Astronomicheskoj Observatorii",
+		"PO" => "Perth Observatory Communication",
+		"PP" => "Izvestiya Glavnoj Astronomicheskoj Observatorii v Pulkove",
+		"PT" => "Pubblicazioni del Osservatorio di Torino",
+		"PZ" => "Zirkular des Astronomischen Hauptobservatoriums Pulkowo",
+		"RA" => "Ricerche Astronomiche",
+		"RM" => "Memoirs of the Royal Astronomical Society",
+		"SA" => "Monthly Notices of the Astronomical Society of Southern Africa",
+		"SOB" => "Observatory Bulletin",
+		"TB" => "Tokyo Astronomical Bulletin",
+		"TC" => "Transval Observatory Circular",
+		"TI" => "Astronomia-Optika Institucio, Universitato de Turku, Informo",
+		"UC" => "Circular of the Union Observatory, Johannesburg",
+		"WO" => "Astronomical Observations of the U.S. Naval Observatory, Washington",
+		"WiA" => "Annalen der Sternwarte der Universität Wien",
+		"pM" => "Mitteilungen der Nikolai-Hauptsternwarte zu Pulkowo",
+		"CMC" => "Carlsberg Meridian Circle Publications",
+		"APO" => "Annales de l'Observatoire de Paris: Observations",
+		"AS" => "Acta Astronomica Sinica",
+		"AZ" => "Astronomicheskij Zhurnal",
+		"AcA" => "Acta Astronomica",
+		_ => string.Empty
+	};
 
 	#endregion
 
@@ -2804,6 +3047,12 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="e">An EventArgs object that contains the event data.</param>
 	/// <remarks>This method decodes the MPCORB flags when the label is clicked.</remarks>
 	private void LabelFlagsData_Click(object sender, EventArgs e) => DecodeMpcorbFlags();
+
+	/// <summary>Handles the Click event for the label that displays MPCORB reference data and initiates decoding of the reference.</summary>
+	/// <param name="sender">The source of the event, typically the label control that was clicked.</param>
+	/// <param name="e">An EventArgs object that contains the event data.</param>
+	/// <remarks>This method decodes the MPCORB reference when the label is clicked.</remarks>
+	private void LabelReferenceData_Click(object sender, EventArgs e) => DecodeMpcorbReference();
 
 	#endregion
 


### PR DESCRIPTION
This PR adds a UI-triggered decoder for the MPCORB “Reference” field so users can click the Reference value and see a human-readable expansion of the compressed code.

**Changes:**
- Added reference decoding logic (`DecodeMpcorbReference`, `DecodeReference`, Base-62 decoding, and journal-code mapping).
- Made the Reference label appear clickable (hand cursor) and wired a click handler to trigger decoding.
- Adjusted a few ToolStrip/context-menu `OwnerItem` assignments and standardized one error dialog to `KryptonMessageBox`.