### PR TITLE
Optimized DoubleBuffering and added `Krypton.Navigator`

### DIFF
--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -50,10 +50,10 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep1000 = new ToolStripMenuItem();
 		menuitemNavigateStep10000 = new ToolStripMenuItem();
 		menuitemNavigateStep100000 = new ToolStripMenuItem();
-		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
-		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		toolStripSplitButtonStepBackward = new ToolStripSplitButton();
 		menuitemNavigateSomeDataBackward = new ToolStripMenuItem();
+		menuitemNavigateSomeDataForward = new ToolStripMenuItem();
+		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		tableLayoutPanelData = new KryptonTableLayoutPanel();
 		labelIndexData = new KryptonLabel();
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
@@ -209,6 +209,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemObservations = new ToolStripMenuItem();
 		toolStripMenuItemObservationLogs = new ToolStripMenuItem();
 		toolStripMenuItemBulkObservationsDataDownloader = new ToolStripMenuItem();
+		toolStripMenuItemObservatoryCodes = new ToolStripMenuItem();
 		toolStripMenuItemExternalDataPages = new ToolStripMenuItem();
 		toolStripMenuItemMpcDatabase = new ToolStripMenuItem();
 		toolStripMenuItemJplSmallBodyDatabase = new ToolStripMenuItem();
@@ -249,6 +250,8 @@ partial class PlanetoidDbForm
 		toolStripProgressBarBackgroundDownload = new ToolStripProgressBar();
 		toolStripStatusLabelCancelBackgroundDownload = new ToolStripStatusLabel();
 		labelInformation = new ToolStripStatusLabel();
+		kryptonNavigatorMain = new Krypton.Navigator.KryptonNavigator();
+		kryptonPageMpcorbDat = new Krypton.Navigator.KryptonPage();
 		kryptonToolStripIcons = new KryptonToolStrip();
 		toolStripButtonOpenLocalMpcorbDat = new ToolStripButton();
 		toolStripButtonExport = new ToolStripButton();
@@ -294,7 +297,6 @@ partial class PlanetoidDbForm
 		timerCheckForNewMpcorbDatFile = new Timer(components);
 		openFileDialog = new OpenFileDialog();
 		kryptonManager = new KryptonManager(components);
-		toolStripMenuItemObservatoryCodes = new ToolStripMenuItem();
 		contextMenuNavigationStep.SuspendLayout();
 		tableLayoutPanelData.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
@@ -308,6 +310,9 @@ partial class PlanetoidDbForm
 		toolStripContainer.TopToolStripPanel.SuspendLayout();
 		toolStripContainer.SuspendLayout();
 		kryptonStatusStrip.SuspendLayout();
+		((ISupportInitialize)kryptonNavigatorMain).BeginInit();
+		((ISupportInitialize)kryptonPageMpcorbDat).BeginInit();
+		kryptonPageMpcorbDat.SuspendLayout();
 		kryptonToolStripIcons.SuspendLayout();
 		kryptonToolStripNavigation.SuspendLayout();
 		SuspendLayout();
@@ -320,7 +325,7 @@ partial class PlanetoidDbForm
 		contextMenuNavigationStep.Font = new Font("Segoe UI", 9F);
 		contextMenuNavigationStep.Items.AddRange(new ToolStripItem[] { menuitemNavigateStep10, menuitemNavigateStep100, menuitemNavigateStep1000, menuitemNavigateStep10000, menuitemNavigateStep100000 });
 		contextMenuNavigationStep.Name = "contextMenu";
-		contextMenuNavigationStep.OwnerItem = menuitemNavigateSomeDataBackward;
+		contextMenuNavigationStep.OwnerItem = toolStripSplitButtonStepForward;
 		contextMenuNavigationStep.ShowCheckMargin = true;
 		contextMenuNavigationStep.ShowImageMargin = false;
 		contextMenuNavigationStep.Size = new Size(111, 114);
@@ -403,38 +408,6 @@ partial class PlanetoidDbForm
 		menuitemNavigateStep100000.MouseEnter += Control_Enter;
 		menuitemNavigateStep100000.MouseLeave += Control_Leave;
 		// 
-		// menuitemNavigateSomeDataForward
-		// 
-		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
-		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemNavigateSomeDataForward.AutoToolTip = true;
-		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
-		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
-		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
-		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
-		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
-		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
-		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
-		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
-		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
-		// 
-		// toolStripSplitButtonStepForward
-		// 
-		toolStripSplitButtonStepForward.AccessibleDescription = "Navigates some data forward";
-		toolStripSplitButtonStepForward.AccessibleName = "Navigate some data forward";
-		toolStripSplitButtonStepForward.AccessibleRole = AccessibleRole.SplitButton;
-		toolStripSplitButtonStepForward.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripSplitButtonStepForward.DropDown = contextMenuNavigationStep;
-		toolStripSplitButtonStepForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
-		toolStripSplitButtonStepForward.ImageTransparentColor = Color.Magenta;
-		toolStripSplitButtonStepForward.Name = "toolStripSplitButtonStepForward";
-		toolStripSplitButtonStepForward.Size = new Size(32, 22);
-		toolStripSplitButtonStepForward.Text = "Navigate some data forward";
-		toolStripSplitButtonStepForward.ButtonClick += ToolStripButtonStepForward_Click;
-		toolStripSplitButtonStepForward.MouseEnter += Control_Enter;
-		toolStripSplitButtonStepForward.MouseLeave += Control_Leave;
-		// 
 		// toolStripSplitButtonStepBackward
 		// 
 		toolStripSplitButtonStepBackward.AccessibleDescription = "Navigates some data backward";
@@ -466,6 +439,38 @@ partial class PlanetoidDbForm
 		menuitemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
 		menuitemNavigateSomeDataBackward.MouseEnter += Control_Enter;
 		menuitemNavigateSomeDataBackward.MouseLeave += Control_Leave;
+		// 
+		// menuitemNavigateSomeDataForward
+		// 
+		menuitemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
+		menuitemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemNavigateSomeDataForward.AutoToolTip = true;
+		menuitemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
+		menuitemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
+		menuitemNavigateSomeDataForward.Name = "menuitemNavigateSomeDataForward";
+		menuitemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
+		menuitemNavigateSomeDataForward.Size = new Size(275, 22);
+		menuitemNavigateSomeDataForward.Text = "Navigate some data &forward";
+		menuitemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
+		menuitemNavigateSomeDataForward.MouseEnter += Control_Enter;
+		menuitemNavigateSomeDataForward.MouseLeave += Control_Leave;
+		// 
+		// toolStripSplitButtonStepForward
+		// 
+		toolStripSplitButtonStepForward.AccessibleDescription = "Navigates some data forward";
+		toolStripSplitButtonStepForward.AccessibleName = "Navigate some data forward";
+		toolStripSplitButtonStepForward.AccessibleRole = AccessibleRole.SplitButton;
+		toolStripSplitButtonStepForward.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripSplitButtonStepForward.DropDown = contextMenuNavigationStep;
+		toolStripSplitButtonStepForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
+		toolStripSplitButtonStepForward.ImageTransparentColor = Color.Magenta;
+		toolStripSplitButtonStepForward.Name = "toolStripSplitButtonStepForward";
+		toolStripSplitButtonStepForward.Size = new Size(32, 22);
+		toolStripSplitButtonStepForward.Text = "Navigate some data forward";
+		toolStripSplitButtonStepForward.ButtonClick += ToolStripButtonStepForward_Click;
+		toolStripSplitButtonStepForward.MouseEnter += Control_Enter;
+		toolStripSplitButtonStepForward.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanelData
 		// 
@@ -533,7 +538,7 @@ partial class PlanetoidDbForm
 		tableLayoutPanelData.RowStyles.Add(new RowStyle());
 		tableLayoutPanelData.RowStyles.Add(new RowStyle());
 		tableLayoutPanelData.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-		tableLayoutPanelData.Size = new Size(852, 288);
+		tableLayoutPanelData.Size = new Size(850, 287);
 		tableLayoutPanelData.TabIndex = 0;
 		tableLayoutPanelData.TabStop = true;
 		tableLayoutPanelData.Enter += Control_Enter;
@@ -3135,6 +3140,19 @@ partial class PlanetoidDbForm
 		toolStripMenuItemBulkObservationsDataDownloader.MouseEnter += Control_Enter;
 		toolStripMenuItemBulkObservationsDataDownloader.MouseLeave += Control_Leave;
 		// 
+		// toolStripMenuItemObservatoryCodes
+		// 
+		toolStripMenuItemObservatoryCodes.AccessibleDescription = "Lists the observatory codes";
+		toolStripMenuItemObservatoryCodes.AccessibleName = "Observatory codes";
+		toolStripMenuItemObservatoryCodes.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemObservatoryCodes.AutoToolTip = true;
+		toolStripMenuItemObservatoryCodes.Name = "toolStripMenuItemObservatoryCodes";
+		toolStripMenuItemObservatoryCodes.Size = new Size(259, 22);
+		toolStripMenuItemObservatoryCodes.Text = "Observatory codes";
+		toolStripMenuItemObservatoryCodes.Click += ToolStripMenuItemObservatoryCodes_Click;
+		toolStripMenuItemObservatoryCodes.MouseEnter += Control_Enter;
+		toolStripMenuItemObservatoryCodes.MouseLeave += Control_Leave;
+		// 
 		// toolStripMenuItemExternalDataPages
 		// 
 		toolStripMenuItemExternalDataPages.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemMpcDatabase, toolStripMenuItemJplSmallBodyDatabase, toolStripMenuItemLowellMinorPlanetServices, toolStripMenuItemAsteroidsDynamicSite, toolStripMenuItemNearEarthObjectsDynamicSite, toolStripMenuItemNearEarthObjectCoordinationCentre, toolStripSeparator17, toolStripMenuItemOpenAllDataPages });
@@ -3610,10 +3628,10 @@ partial class PlanetoidDbForm
 		toolStripContainer.ContentPanel.AccessibleRole = AccessibleRole.Pane;
 		toolStripContainer.ContentPanel.AutoScroll = true;
 		toolStripContainer.ContentPanel.BackColor = Color.Transparent;
-		toolStripContainer.ContentPanel.Controls.Add(tableLayoutPanelData);
+		toolStripContainer.ContentPanel.Controls.Add(kryptonNavigatorMain);
 		toolStripContainer.ContentPanel.Margin = new Padding(4, 3, 4, 3);
 		toolStripContainer.ContentPanel.RenderMode = ToolStripRenderMode.ManagerRenderMode;
-		toolStripContainer.ContentPanel.Size = new Size(852, 288);
+		toolStripContainer.ContentPanel.Size = new Size(852, 314);
 		toolStripContainer.Dock = DockStyle.Fill;
 		// 
 		// toolStripContainer.LeftToolStripPanel
@@ -3629,7 +3647,7 @@ partial class PlanetoidDbForm
 		toolStripContainer.RightToolStripPanel.AccessibleDescription = "Right part of the container panel";
 		toolStripContainer.RightToolStripPanel.AccessibleName = "Right part of the container panel";
 		toolStripContainer.RightToolStripPanel.AccessibleRole = AccessibleRole.Pane;
-		toolStripContainer.Size = new Size(852, 384);
+		toolStripContainer.Size = new Size(852, 410);
 		toolStripContainer.TabIndex = 16;
 		// 
 		// toolStripContainer.TopToolStripPanel
@@ -3749,6 +3767,60 @@ partial class PlanetoidDbForm
 		labelInformation.ToolTipText = "Shows some information";
 		labelInformation.MouseEnter += Control_Enter;
 		labelInformation.MouseLeave += Control_Leave;
+		// 
+		// kryptonNavigatorMain
+		// 
+		kryptonNavigatorMain.AccessibleDescription = "Shows the database navigator";
+		kryptonNavigatorMain.AccessibleName = "Database navigator";
+		kryptonNavigatorMain.AccessibleRole = AccessibleRole.Grouping;
+		kryptonNavigatorMain.Button.ButtonDisplayLogic = Krypton.Navigator.ButtonDisplayLogic.ContextNextPrevious;
+		kryptonNavigatorMain.Button.CloseButtonAction = Krypton.Navigator.CloseButtonAction.HidePage;
+		kryptonNavigatorMain.Button.CloseButtonDisplay = Krypton.Navigator.ButtonDisplay.Hide;
+		// 
+		// 
+		// 
+		kryptonNavigatorMain.Button.ContextButton.HeaderLocation = HeaderLocation.PrimaryHeader;
+		kryptonNavigatorMain.Button.ContextButton.ToolTipBody = "Lists the pages";
+		kryptonNavigatorMain.Button.ContextButton.ToolTipTitle = "Pages";
+		kryptonNavigatorMain.Button.ContextButton.UniqueName = "52db7c412c0f4b61a32620bad237b020";
+		kryptonNavigatorMain.Button.ContextButtonAction = Krypton.Navigator.ContextButtonAction.SelectPage;
+		kryptonNavigatorMain.Button.ContextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+		kryptonNavigatorMain.Button.ContextMenuMapImage = Krypton.Navigator.MapKryptonPageImage.Small;
+		kryptonNavigatorMain.Button.ContextMenuMapText = Krypton.Navigator.MapKryptonPageText.TextTitle;
+		kryptonNavigatorMain.Button.NextButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
+		kryptonNavigatorMain.Button.NextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+		kryptonNavigatorMain.Button.PreviousButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
+		kryptonNavigatorMain.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+		kryptonNavigatorMain.ControlKryptonFormFeatures = true;
+		kryptonNavigatorMain.Dock = DockStyle.Fill;
+		kryptonNavigatorMain.Location = new Point(0, 0);
+		kryptonNavigatorMain.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
+		kryptonNavigatorMain.Owner = this;
+		kryptonNavigatorMain.PageBackStyle = PaletteBackStyle.PanelClient;
+		kryptonNavigatorMain.Pages.AddRange(new Krypton.Navigator.KryptonPage[] { kryptonPageMpcorbDat });
+		kryptonNavigatorMain.SelectedIndex = 0;
+		kryptonNavigatorMain.Size = new Size(852, 314);
+		kryptonNavigatorMain.TabIndex = 2;
+		kryptonNavigatorMain.Text = "kryptonNavigatorMain";
+		// 
+		// kryptonPageMpcorbDat
+		// 
+		kryptonPageMpcorbDat.AccessibleDescription = "Shows the MPCORB.DAT page tab";
+		kryptonPageMpcorbDat.AccessibleName = "MPCORB.DAT page tab";
+		kryptonPageMpcorbDat.AccessibleRole = AccessibleRole.PageTab;
+		kryptonPageMpcorbDat.AutoHiddenSlideSize = new Size(200, 200);
+		kryptonPageMpcorbDat.Controls.Add(tableLayoutPanelData);
+		kryptonPageMpcorbDat.Flags = 65534;
+		kryptonPageMpcorbDat.LastVisibleSet = true;
+		kryptonPageMpcorbDat.MinimumSize = new Size(200, 50);
+		kryptonPageMpcorbDat.Name = "kryptonPageMpcorbDat";
+		kryptonPageMpcorbDat.Size = new Size(850, 287);
+		kryptonPageMpcorbDat.Text = "MPCORB.DAT";
+		kryptonPageMpcorbDat.TextDescription = "Shows the MPCORB.DAT";
+		kryptonPageMpcorbDat.TextTitle = "MPCORB.DAT";
+		kryptonPageMpcorbDat.ToolTipBody = "Shows the MPCORB.DAT";
+		kryptonPageMpcorbDat.ToolTipTitle = "Shows the MPCORB.DAT";
+		kryptonPageMpcorbDat.UniqueName = "a274f72e6e8644f4813b33d68e278dd1";
 		// 
 		// kryptonToolStripIcons
 		// 
@@ -4334,19 +4406,6 @@ partial class PlanetoidDbForm
 		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
 		// 
-		// toolStripMenuItemObservatoryCodes
-		// 
-		toolStripMenuItemObservatoryCodes.AccessibleDescription = "Lists the observatory codes";
-		toolStripMenuItemObservatoryCodes.AccessibleName = "Observatory codes";
-		toolStripMenuItemObservatoryCodes.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemObservatoryCodes.AutoToolTip = true;
-		toolStripMenuItemObservatoryCodes.Name = "toolStripMenuItemObservatoryCodes";
-		toolStripMenuItemObservatoryCodes.Size = new Size(259, 22);
-		toolStripMenuItemObservatoryCodes.Text = "Observatory codes";
-		toolStripMenuItemObservatoryCodes.Click += ToolStripMenuItemObservatoryCodes_Click;
-		toolStripMenuItemObservatoryCodes.MouseEnter += Control_Enter;
-		toolStripMenuItemObservatoryCodes.MouseLeave += Control_Leave;
-		// 
 		// PlanetoidDbForm
 		// 
 		AccessibleDescription = "Viewer for the MPC Orbit (MPCORB) Database";
@@ -4355,7 +4414,7 @@ partial class PlanetoidDbForm
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
 		AutoValidate = AutoValidate.EnablePreventFocusChange;
-		ClientSize = new Size(852, 384);
+		ClientSize = new Size(852, 410);
 		Controls.Add(toolStripContainer);
 		FormBorderStyle = FormBorderStyle.FixedSingle;
 		Icon = (Icon)resources.GetObject("$this.Icon");
@@ -4391,6 +4450,9 @@ partial class PlanetoidDbForm
 		toolStripContainer.PerformLayout();
 		kryptonStatusStrip.ResumeLayout(false);
 		kryptonStatusStrip.PerformLayout();
+		((ISupportInitialize)kryptonNavigatorMain).EndInit();
+		((ISupportInitialize)kryptonPageMpcorbDat).EndInit();
+		kryptonPageMpcorbDat.ResumeLayout(false);
 		kryptonToolStripIcons.ResumeLayout(false);
 		kryptonToolStripIcons.PerformLayout();
 		kryptonToolStripNavigation.ResumeLayout(false);
@@ -4650,4 +4712,6 @@ partial class PlanetoidDbForm
 	private ToolStripMenuItem toolStripMenuItemNearEarthObjectsDynamicSite;
 	private ToolStripMenuItem toolStripMenuItemNearEarthObjectCoordinationCentre;
 	private ToolStripMenuItem toolStripMenuItemObservatoryCodes;
+	private Krypton.Navigator.KryptonNavigator kryptonNavigatorMain;
+	private Krypton.Navigator.KryptonPage kryptonPageMpcorbDat;
 }

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -135,6 +135,8 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		InitializeComponent();
 		TextExtra = $"{Assembly.GetExecutingAssembly().GetName().Version}";
+		// Apply comprehensive flicker reduction for the TableLayoutPanel
+		OptimizeTableLayoutPanelForFlickerReduction();
 	}
 
 	/// <summary>Initializes a new instance of the <see cref="PlanetoidDbForm"/> class with a specified MPCORB.DAT file path.</summary>
@@ -147,6 +149,48 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		TextExtra = $"{Assembly.GetExecutingAssembly().GetName().Version}";
 		ClearStatusBar(label: labelInformation);
 		MpcOrbDatFilePath = mpcorbDatFilePath;
+		// Apply comprehensive flicker reduction for the TableLayoutPanel
+		OptimizeTableLayoutPanelForFlickerReduction();
+	}
+
+	/// <summary>Optimizes the TableLayoutPanel to eliminate flickering during label updates.</summary>
+	/// <remarks>This method enables double buffering and optimized painting styles on the panel and all child labels.</remarks>
+	private void OptimizeTableLayoutPanelForFlickerReduction()
+	{
+		try
+		{
+			// Enable double buffering for the TableLayoutPanel itself
+			PropertyInfo? doubleBufferedProperty = typeof(Control).GetProperty(name: "DoubleBuffered", bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance);
+			MethodInfo? setStyleMethod = typeof(Control).GetMethod(name: "SetStyle", bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance);
+
+			// Apply to the main panel
+			doubleBufferedProperty?.SetValue(obj: tableLayoutPanelData, value: true, index: null);
+			setStyleMethod?.Invoke(obj: tableLayoutPanelData, parameters: [
+				ControlStyles.OptimizedDoubleBuffer |
+				ControlStyles.AllPaintingInWmPaint |
+				ControlStyles.UserPaint |
+				ControlStyles.ResizeRedraw,
+				true
+			]);
+
+			// Apply double buffering to all label controls within the panel to prevent individual label flickering
+			foreach (Control control in tableLayoutPanelData.Controls)
+			{
+				if (control is Label or KryptonLabel)
+				{
+					doubleBufferedProperty?.SetValue(obj: control, value: true, index: null);
+					setStyleMethod?.Invoke(obj: control, parameters: [
+						ControlStyles.OptimizedDoubleBuffer |
+						ControlStyles.AllPaintingInWmPaint,
+						true
+					]);
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.Warn(exception: ex, message: "Failed to enable comprehensive double buffering on tableLayoutPanel. UI may experience flickering.");
+		}
 	}
 
 	#endregion
@@ -274,29 +318,50 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		//Achtung: Wenn später die Teilstrings in Zahlen konvertiert werden, dann muss darauf geachtet werden, dass die eingelesenen Zeichenketten keine Leerstrings sind.
 		// if (teilstring == "0") zahl = 0; ...
 
-		toolStripLabelIndexPosition.ToolTipText = $"Index: {currentPosition + 1}/{planetoidsDatabase.Count}";
-		object? entry = planetoidsDatabase[index: position];
-		labelIndexData.Text = entry?.ToString() is string entryStr ? entryStr[..7].Trim() : string.Empty;
-		labelAbsoluteMagnitudeData.Text = entry?.ToString() is string entryStr1 ? entryStr1.Substring(startIndex: 8, length: 5).Trim() : string.Empty;
-		labelSlopeParameterData.Text = entry?.ToString() is string entryStr2 ? entryStr2.Substring(startIndex: 14, length: 5).Trim() : string.Empty;
-		labelEpochData.Text = entry?.ToString() is string entryStr3 ? entryStr3.Substring(startIndex: 20, length: 5).Trim() : string.Empty;
-		labelMeanAnomalyAtTheEpochData.Text = entry?.ToString() is string entryStr4 ? entryStr4.Substring(startIndex: 26, length: 9).Trim() : string.Empty;
-		labelArgumentOfThePerihelionData.Text = entry?.ToString() is string entryStr5 ? entryStr5.Substring(startIndex: 37, length: 9).Trim() : string.Empty;
-		labelLongitudeOfTheAscendingNodeData.Text = entry?.ToString() is string entryStr6 ? entryStr6.Substring(startIndex: 48, length: 9).Trim() : string.Empty;
-		labelInclinationToTheEclipticData.Text = entry?.ToString() is string entryStr7 ? entryStr7.Substring(startIndex: 59, length: 9).Trim() : string.Empty;
-		labelOrbitalEccentricityData.Text = entry?.ToString() is string entryStr8 ? entryStr8.Substring(startIndex: 70, length: 9).Trim() : string.Empty;
-		labelMeanDailyMotionData.Text = entry?.ToString() is string entryStr9 ? entryStr9.Substring(startIndex: 80, length: 11).Trim() : string.Empty;
-		labelSemiMajorAxisData.Text = entry?.ToString() is string entryStr10 ? entryStr10.Substring(startIndex: 92, length: 11).Trim() : string.Empty;
-		labelReferenceData.Text = entry?.ToString() is string entryStr11 ? entryStr11.Substring(startIndex: 107, length: 9).Trim() : string.Empty;
-		labelNumberOfObservationsData.Text = entry?.ToString() is string entryStr12 ? entryStr12.Substring(startIndex: 117, length: 5).Trim() : string.Empty;
-		labelNumberOfOppositionsData.Text = entry?.ToString() is string entryStr13 ? entryStr13.Substring(startIndex: 123, length: 3).Trim() : string.Empty;
-		labelObservationSpanData.Text = entry?.ToString() is string entryStr14 ? entryStr14.Substring(startIndex: 127, length: 9).Trim() : string.Empty;
-		labelRmsResidualData.Text = entry?.ToString() is string entryStr15 ? entryStr15.Substring(startIndex: 137, length: 4).Trim() : string.Empty;
-		labelComputerNameData.Text = entry?.ToString() is string entryStr16 ? entryStr16.Substring(startIndex: 150, length: 10).Trim() : string.Empty;
-		labelFlagsData.Text = entry?.ToString() is string entryStr17 ? entryStr17.Substring(startIndex: 161, length: 4).Trim() : string.Empty;
-		labelReadableDesignationData.Text = entry?.ToString() is string entryStr18 ? entryStr18.Substring(startIndex: 166, length: 28).Trim() : string.Empty;
-		labelDateLastObservationData.Text = entry?.ToString() is string entryStr19 ? entryStr19.Substring(startIndex: 194, length: 8).Trim() : string.Empty;
-		toolStripLabelIndexPosition.Text = $@"{I18nStrings.Index}: {position + 1:N0} / {planetoidsDatabase.Count:N0}";
+		// Get entry string once to avoid repeated ToString() calls
+		string? entryStr = planetoidsDatabase[index: position]?.ToString();
+		if (string.IsNullOrEmpty(entryStr))
+		{
+			toolStripLabelIndexPosition.ToolTipText = "Index: 0";
+			return;
+		}
+
+		// Suspend both the panel layout and painting to eliminate all flicker
+		tableLayoutPanelData.SuspendLayout();
+		try
+		{
+			// Batch all text updates with minimal overhead
+			toolStripLabelIndexPosition.ToolTipText = $"Index: {currentPosition + 1}/{planetoidsDatabase.Count}";
+			// Update all labels in one go - use cached string reference
+			labelIndexData.Text = entryStr[..7].Trim();
+			labelAbsoluteMagnitudeData.Text = entryStr.Substring(startIndex: 8, length: 5).Trim();
+			labelSlopeParameterData.Text = entryStr.Substring(startIndex: 14, length: 5).Trim();
+			labelEpochData.Text = entryStr.Substring(startIndex: 20, length: 5).Trim();
+			labelMeanAnomalyAtTheEpochData.Text = entryStr.Substring(startIndex: 26, length: 9).Trim();
+			labelArgumentOfThePerihelionData.Text = entryStr.Substring(startIndex: 37, length: 9).Trim();
+			labelLongitudeOfTheAscendingNodeData.Text = entryStr.Substring(startIndex: 48, length: 9).Trim();
+			labelInclinationToTheEclipticData.Text = entryStr.Substring(startIndex: 59, length: 9).Trim();
+			labelOrbitalEccentricityData.Text = entryStr.Substring(startIndex: 70, length: 9).Trim();
+			labelMeanDailyMotionData.Text = entryStr.Substring(startIndex: 80, length: 11).Trim();
+			labelSemiMajorAxisData.Text = entryStr.Substring(startIndex: 92, length: 11).Trim();
+			labelReferenceData.Text = entryStr.Substring(startIndex: 107, length: 9).Trim();
+			labelNumberOfObservationsData.Text = entryStr.Substring(startIndex: 117, length: 5).Trim();
+			labelNumberOfOppositionsData.Text = entryStr.Substring(startIndex: 123, length: 3).Trim();
+			labelObservationSpanData.Text = entryStr.Substring(startIndex: 127, length: 9).Trim();
+			labelRmsResidualData.Text = entryStr.Substring(startIndex: 137, length: 4).Trim();
+			labelComputerNameData.Text = entryStr.Substring(startIndex: 150, length: 10).Trim();
+			labelFlagsData.Text = entryStr.Substring(startIndex: 161, length: 4).Trim();
+			labelReadableDesignationData.Text = entryStr.Substring(startIndex: 166, length: 28).Trim();
+			labelDateLastObservationData.Text = entryStr.Substring(startIndex: 194, length: 8).Trim();
+			toolStripLabelIndexPosition.Text = $@"{I18nStrings.Index}: {position + 1:N0} / {planetoidsDatabase.Count:N0}";
+		}
+		finally
+		{
+			// Resume layout with immediate repaint to avoid intermediate states
+			tableLayoutPanelData.ResumeLayout(performLayout: true);
+			// Force immediate refresh to prevent any pending paint messages
+			tableLayoutPanelData.Refresh();
+		}
 		/* Original code:
 		labelAbsoluteMagnitudeData.Text = planetoidsDatabase[index: position].ToString().Substring(startIndex: 8, length: 5).Trim();
 		labelSlopeParameterData.Text = planetoidsDatabase[index: position].ToString().Substring(startIndex: 14, length: 5).Trim();
@@ -1696,12 +1761,18 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	private void PlanetoidDBForm_Load(object sender, EventArgs e)
 	{
 		ClearStatusBar(label: labelInformation);
+		kryptonPageMpcorbDat.Text = $"MPCORB.DAT ({I18nStrings.DataLoading})";
 		backgroundWorkerLoadingDatabase.WorkerReportsProgress = true;
 		backgroundWorkerLoadingDatabase.WorkerSupportsCancellation = true;
 		backgroundWorkerLoadingDatabase.ProgressChanged += BackgroundWorkerLoadingDatabase_ProgressChanged;
 		backgroundWorkerLoadingDatabase.RunWorkerCompleted += BackgroundWorkerLoadingDatabase_RunWorkerCompleted;
 		backgroundWorkerLoadingDatabase.RunWorkerAsync();
 		formSplashScreen.Show();
+		// Get the last modified date of the local file
+		FileInfo fileInfo = new(fileName: MpcOrbDatFilePath);
+		// Get the last modified date of the local file
+		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
+		kryptonPageMpcorbDat.Text = $"MPCORB.DAT ({datetimeFileLocal.ToString(provider: CultureInfo.CurrentCulture)})";
 	}
 
 	/// <summary>Handles the shown event of the PlanetoidDBForm.</summary>

--- a/Forms/PlanetoidDBForm.resx
+++ b/Forms/PlanetoidDBForm.resx
@@ -534,27 +534,6 @@
   <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>470, 17</value>
   </metadata>
-  <metadata name="kryptonToolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="kryptonToolStripNavigation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>186, 17</value>
-  </metadata>
-  <metadata name="backgroundWorkerLoadingDatabase.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>150, 54</value>
-  </metadata>
-  <metadata name="timerBlinkForUpdateAvailable.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>621, 17</value>
-  </metadata>
-  <metadata name="timerCheckForNewMpcorbDatFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1052, 17</value>
-  </metadata>
-  <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 54</value>
-  </metadata>
-  <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>397, 54</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>99</value>
   </metadata>
@@ -6601,4 +6580,25 @@
         AAAATwAAAD8AAAAcAACADAAAAAYAAIADAADAAQAAwAAAAKAAAAAAAAAAiAAAAPYAAAD3AQAA
 </value>
   </data>
+  <metadata name="kryptonToolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="kryptonToolStripNavigation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>186, 17</value>
+  </metadata>
+  <metadata name="backgroundWorkerLoadingDatabase.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>150, 54</value>
+  </metadata>
+  <metadata name="timerBlinkForUpdateAvailable.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>621, 17</value>
+  </metadata>
+  <metadata name="timerCheckForNewMpcorbDatFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1052, 17</value>
+  </metadata>
+  <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 54</value>
+  </metadata>
+  <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>397, 54</value>
+  </metadata>
 </root>


### PR DESCRIPTION
This PR updates the main `PlanetoidDbForm` UI to reduce flicker during frequent label updates and introduces a `KryptonNavigator` container to host the MPCORB.DAT view as a tabbed page.

**Changes:**
- Added reflection-based double-buffering/styling for `tableLayoutPanelData` and its child labels to reduce flicker.
- Refactored the main content area to use `Krypton.Navigator.KryptonNavigator` with an `MPCORB.DAT` page hosting the existing `tableLayoutPanelData`.
- Tweaked navigation UI wiring and updated the MPCORB.DAT page title during form load.