### PR TITLE
Redesigned update entries in the status bar

### DIFF
--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -118,8 +118,8 @@ partial class PlanetoidDbForm
 		menuitemRecordsRmsResidual = new ToolStripMenuItem();
 		menuitemRecordsComputername = new ToolStripMenuItem();
 		menuitemRecordsDateOfTheLastObservation = new ToolStripMenuItem();
-		splitbuttonTopTenRecords = new ToolStripSplitButton();
 		menuitemRecords = new ToolStripMenuItem();
+		splitbuttonTopTenRecords = new ToolStripSplitButton();
 		contextMenuDistributions = new ContextMenuStrip(components);
 		menuitemDistributionMeanAnomalyAtTheEpoch = new ToolStripMenuItem();
 		menuitemDistributionArgumentOfThePerihelion = new ToolStripMenuItem();
@@ -135,8 +135,8 @@ partial class PlanetoidDbForm
 		menuitemDistributionObservationSpan = new ToolStripMenuItem();
 		menuitemDistributionRmsResidual = new ToolStripMenuItem();
 		menuitemDistributionComputerName = new ToolStripMenuItem();
-		splitbuttonDistribution = new ToolStripSplitButton();
 		menuitemDistribution = new ToolStripMenuItem();
+		splitbuttonDistribution = new ToolStripSplitButton();
 		contextMenuFullCopyToClipboardOrbitalElements = new ContextMenuStrip(components);
 		menuitemCopyToClipboardIndexNumber = new ToolStripMenuItem();
 		menuitemCopyToClipboardReadableDesignation = new ToolStripMenuItem();
@@ -158,8 +158,8 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardComputerName = new ToolStripMenuItem();
 		menuitemCopyToClipboardDateOfTheLastObservation = new ToolStripMenuItem();
 		menuitemCopyToClipboardFlags = new ToolStripMenuItem();
-		menuitemCopytoClipboard = new ToolStripMenuItem();
 		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
+		menuitemCopytoClipboard = new ToolStripMenuItem();
 		menu = new MenuStrip();
 		menuitemFile = new ToolStripMenuItem();
 		toolStripMenuItemOpenLocalMpcorbDat = new ToolStripMenuItem();
@@ -247,11 +247,9 @@ partial class PlanetoidDbForm
 		toolStripButtonObservations = new ToolStripButton();
 		toolStripContainer = new ToolStripContainer();
 		kryptonStatusStrip = new KryptonStatusStrip();
-		toolStripStatusLabelUpdate = new ToolStripStatusLabel();
-		toolStripStatusLabelBackgroundDownload = new ToolStripStatusLabel();
-		toolStripProgressBarBackgroundDownload = new ToolStripProgressBar();
-		toolStripStatusLabelCancelBackgroundDownload = new ToolStripStatusLabel();
 		labelInformation = new ToolStripStatusLabel();
+		toolStripStatusLabelAstorbDatUpdate = new ToolStripStatusLabel();
+		toolStripStatusLabelMpcorbDatUpdate = new ToolStripStatusLabel();
 		kryptonNavigatorMain = new Krypton.Navigator.KryptonNavigator();
 		kryptonPageMpcorbDat = new Krypton.Navigator.KryptonPage();
 		kryptonToolStripIcons = new KryptonToolStrip();
@@ -295,10 +293,10 @@ partial class PlanetoidDbForm
 		toolStripSeparatorOptions2 = new ToolStripSeparator();
 		toolStripSeparatorOptions1 = new ToolStripSeparator();
 		backgroundWorkerLoadingDatabase = new BackgroundWorker();
-		timerBlinkForUpdateAvailable = new Timer(components);
 		timerCheckForNewMpcorbDatFile = new Timer(components);
 		openFileDialog = new OpenFileDialog();
 		kryptonManager = new KryptonManager(components);
+		timerCheckForNewAstorbDatFile = new Timer(components);
 		contextMenuNavigationStep.SuspendLayout();
 		tableLayoutPanelData.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
@@ -1595,7 +1593,7 @@ partial class PlanetoidDbForm
 		contextMenuTopTenRecords.Font = new Font("Segoe UI", 9F);
 		contextMenuTopTenRecords.Items.AddRange(new ToolStripItem[] { menuitemRecordsSortDirection, toolStripSeparator12, menuitemRecordsMeanAnomalyAtTheEpoch, menuitemRecordsArgumentOfThePerihelion, menuitemRecordsLongitudeOfTheAscendingNode, menuitemRecordsInclination, menuitemRecordsOrbitalEccentricity, menuitemRecordsMeanDailyMotion, menuitemRecordsSemiMajorAxis, menuitemRecordsAbsoluteMagnitude, menuitemRecordsSlopeParameter, menuitemRecordsNumberOfOppositions, menuitemRecordsNumberOfObservations, menuitemRecordsObservationSpan, menuitemRecordsRmsResidual, menuitemRecordsComputername, menuitemRecordsDateOfTheLastObservation });
 		contextMenuTopTenRecords.Name = "contextMenuTopTenRecords";
-		contextMenuTopTenRecords.OwnerItem = menuitemRecords;
+		contextMenuTopTenRecords.OwnerItem = splitbuttonTopTenRecords;
 		contextMenuTopTenRecords.Size = new Size(250, 362);
 		contextMenuTopTenRecords.TabStop = true;
 		contextMenuTopTenRecords.Text = "Top ten records";
@@ -1868,23 +1866,6 @@ partial class PlanetoidDbForm
 		menuitemRecordsDateOfTheLastObservation.MouseEnter += Control_Enter;
 		menuitemRecordsDateOfTheLastObservation.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonTopTenRecords
-		// 
-		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
-		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
-		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
-		splitbuttonTopTenRecords.Enabled = false;
-		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
-		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
-		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
-		splitbuttonTopTenRecords.Size = new Size(32, 22);
-		splitbuttonTopTenRecords.Text = "Top ten records";
-		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
-		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
-		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
-		// 
 		// menuitemRecords
 		// 
 		menuitemRecords.AccessibleDescription = "Shows some top ten records";
@@ -1903,6 +1884,23 @@ partial class PlanetoidDbForm
 		menuitemRecords.MouseEnter += Control_Enter;
 		menuitemRecords.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonTopTenRecords
+		// 
+		splitbuttonTopTenRecords.AccessibleDescription = "Shows the top ten records";
+		splitbuttonTopTenRecords.AccessibleName = "Top ten records";
+		splitbuttonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonTopTenRecords.DropDown = contextMenuTopTenRecords;
+		splitbuttonTopTenRecords.Enabled = false;
+		splitbuttonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
+		splitbuttonTopTenRecords.ImageTransparentColor = Color.Magenta;
+		splitbuttonTopTenRecords.Name = "splitbuttonTopTenRecords";
+		splitbuttonTopTenRecords.Size = new Size(32, 22);
+		splitbuttonTopTenRecords.Text = "Top ten records";
+		splitbuttonTopTenRecords.ButtonClick += SplitButtonTopTenRecords_ButtonClick;
+		splitbuttonTopTenRecords.MouseEnter += Control_Enter;
+		splitbuttonTopTenRecords.MouseLeave += Control_Leave;
+		// 
 		// contextMenuDistributions
 		// 
 		contextMenuDistributions.AccessibleDescription = "Shows the context menu of the distributions";
@@ -1911,7 +1909,7 @@ partial class PlanetoidDbForm
 		contextMenuDistributions.Font = new Font("Segoe UI", 9F);
 		contextMenuDistributions.Items.AddRange(new ToolStripItem[] { menuitemDistributionMeanAnomalyAtTheEpoch, menuitemDistributionArgumentOfThePerihelion, menuitemDistributionLongitudeOfTheAscendingNode, menuitemDistributionInclination, menuitemDistributionOrbitalEccentricity, menuitemDistributionMeanDailyMotion, menuitemDistributionSemiMajorAxis, menuitemDistributionAbsoluteMagnitude, menuitemDistributionSlopeParameter, menuitemDistributionNumberOfOppositions, menuitemDistributionNumberOfObservations, menuitemDistributionObservationSpan, menuitemDistributionRmsResidual, menuitemDistributionComputerName });
 		contextMenuDistributions.Name = "contextMenuDistributions";
-		contextMenuDistributions.OwnerItem = menuitemDistribution;
+		contextMenuDistributions.OwnerItem = splitbuttonDistribution;
 		contextMenuDistributions.Size = new Size(250, 312);
 		contextMenuDistributions.Text = "Distributions";
 		contextMenuDistributions.Enter += Control_Enter;
@@ -2129,23 +2127,6 @@ partial class PlanetoidDbForm
 		menuitemDistributionComputerName.MouseEnter += Control_Enter;
 		menuitemDistributionComputerName.MouseLeave += Control_Leave;
 		// 
-		// splitbuttonDistribution
-		// 
-		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
-		splitbuttonDistribution.AccessibleName = "Distributions";
-		splitbuttonDistribution.AccessibleRole = AccessibleRole.SplitButton;
-		splitbuttonDistribution.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		splitbuttonDistribution.DropDown = contextMenuDistributions;
-		splitbuttonDistribution.Enabled = false;
-		splitbuttonDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
-		splitbuttonDistribution.ImageTransparentColor = Color.Magenta;
-		splitbuttonDistribution.Name = "splitbuttonDistribution";
-		splitbuttonDistribution.Size = new Size(32, 22);
-		splitbuttonDistribution.Text = "Distributions";
-		splitbuttonDistribution.ButtonClick += SplitButtonDistribution_ButtonClick;
-		splitbuttonDistribution.MouseEnter += Control_Enter;
-		splitbuttonDistribution.MouseLeave += Control_Leave;
-		// 
 		// menuitemDistribution
 		// 
 		menuitemDistribution.AccessibleDescription = "Shows some distributions";
@@ -2163,6 +2144,23 @@ partial class PlanetoidDbForm
 		menuitemDistribution.MouseEnter += Control_Enter;
 		menuitemDistribution.MouseLeave += Control_Leave;
 		// 
+		// splitbuttonDistribution
+		// 
+		splitbuttonDistribution.AccessibleDescription = "Shows some distributions";
+		splitbuttonDistribution.AccessibleName = "Distributions";
+		splitbuttonDistribution.AccessibleRole = AccessibleRole.SplitButton;
+		splitbuttonDistribution.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		splitbuttonDistribution.DropDown = contextMenuDistributions;
+		splitbuttonDistribution.Enabled = false;
+		splitbuttonDistribution.Image = FatcowIcons16px.fatcow_chart_bar_16px;
+		splitbuttonDistribution.ImageTransparentColor = Color.Magenta;
+		splitbuttonDistribution.Name = "splitbuttonDistribution";
+		splitbuttonDistribution.Size = new Size(32, 22);
+		splitbuttonDistribution.Text = "Distributions";
+		splitbuttonDistribution.ButtonClick += SplitButtonDistribution_ButtonClick;
+		splitbuttonDistribution.MouseEnter += Control_Enter;
+		splitbuttonDistribution.MouseLeave += Control_Leave;
+		// 
 		// contextMenuFullCopyToClipboardOrbitalElements
 		// 
 		contextMenuFullCopyToClipboardOrbitalElements.AccessibleDescription = "Shows the context menu of the orbital elements to copy to clipboard";
@@ -2171,7 +2169,7 @@ partial class PlanetoidDbForm
 		contextMenuFullCopyToClipboardOrbitalElements.Font = new Font("Segoe UI", 9F);
 		contextMenuFullCopyToClipboardOrbitalElements.Items.AddRange(new ToolStripItem[] { menuitemCopyToClipboardIndexNumber, menuitemCopyToClipboardReadableDesignation, menuitemCopyToClipboardEpoch, menuitemCopyToClipboardMeanAnomalyAtTheEpoch, menuitemCopyToClipboardArgumentOfThePerihelion, menuitemCopyToClipboardLongitudeOfTheAscendingNode, menuitemCopyToClipboardInclinationToTheEcliptic, menuitemCopyToClipboardOrbitalEccentricity, menuitemCopyToClipboardMeanDailyMotion, menuitemCopyToClipboardSemiMajorAxis, menuitemCopyToClipboardAbsoluteMagnitude, menuitemCopyToClipboardSlopeParameter, menuitemCopyToClipboardReference, menuitemCopyToClipboardNumberOfOppositions, menuitemCopyToClipboardNumberOfObservations, menuitemCopyToClipboardObservationSpan, menuitemCopyToClipboardRmsResidual, menuitemCopyToClipboardComputerName, menuitemCopyToClipboardDateOfTheLastObservation, menuitemCopyToClipboardFlags });
 		contextMenuFullCopyToClipboardOrbitalElements.Name = "Context menu of copying to clipboard of orbital elements";
-		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripDropDownButtonCopyToClipboard;
+		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = menuitemCopytoClipboard;
 		contextMenuFullCopyToClipboardOrbitalElements.Size = new Size(309, 444);
 		contextMenuFullCopyToClipboardOrbitalElements.Text = "Copy to clipboard";
 		contextMenuFullCopyToClipboardOrbitalElements.Enter += Control_Enter;
@@ -2459,21 +2457,6 @@ partial class PlanetoidDbForm
 		menuitemCopyToClipboardFlags.MouseEnter += Control_Enter;
 		menuitemCopyToClipboardFlags.MouseLeave += Control_Leave;
 		// 
-		// menuitemCopytoClipboard
-		// 
-		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
-		menuitemCopytoClipboard.AccessibleName = "Copy to clipboard";
-		menuitemCopytoClipboard.AccessibleRole = AccessibleRole.MenuItem;
-		menuitemCopytoClipboard.AutoToolTip = true;
-		menuitemCopytoClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
-		menuitemCopytoClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
-		menuitemCopytoClipboard.Name = "menuitemCopytoClipboard";
-		menuitemCopytoClipboard.ShortcutKeys = Keys.Control | Keys.C;
-		menuitemCopytoClipboard.Size = new Size(151, 22);
-		menuitemCopytoClipboard.Text = "&Copy";
-		menuitemCopytoClipboard.MouseEnter += Control_Enter;
-		menuitemCopytoClipboard.MouseLeave += Control_Leave;
-		// 
 		// toolStripDropDownButtonCopyToClipboard
 		// 
 		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
@@ -2488,6 +2471,21 @@ partial class PlanetoidDbForm
 		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
 		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
 		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
+		// 
+		// menuitemCopytoClipboard
+		// 
+		menuitemCopytoClipboard.AccessibleDescription = "Copies to clipboard";
+		menuitemCopytoClipboard.AccessibleName = "Copy to clipboard";
+		menuitemCopytoClipboard.AccessibleRole = AccessibleRole.MenuItem;
+		menuitemCopytoClipboard.AutoToolTip = true;
+		menuitemCopytoClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
+		menuitemCopytoClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
+		menuitemCopytoClipboard.Name = "menuitemCopytoClipboard";
+		menuitemCopytoClipboard.ShortcutKeys = Keys.Control | Keys.C;
+		menuitemCopytoClipboard.Size = new Size(151, 22);
+		menuitemCopytoClipboard.Text = "&Copy";
+		menuitemCopytoClipboard.MouseEnter += Control_Enter;
+		menuitemCopytoClipboard.MouseLeave += Control_Leave;
 		// 
 		// menu
 		// 
@@ -3715,9 +3713,8 @@ partial class PlanetoidDbForm
 		kryptonStatusStrip.AllowItemReorder = true;
 		kryptonStatusStrip.Dock = DockStyle.None;
 		kryptonStatusStrip.Font = new Font("Segoe UI", 9F);
-		kryptonStatusStrip.GripStyle = ToolStripGripStyle.Visible;
-		kryptonStatusStrip.Items.AddRange(new ToolStripItem[] { toolStripStatusLabelUpdate, toolStripStatusLabelBackgroundDownload, toolStripProgressBarBackgroundDownload, toolStripStatusLabelCancelBackgroundDownload, labelInformation });
-		kryptonStatusStrip.LayoutStyle = ToolStripLayoutStyle.Flow;
+		kryptonStatusStrip.Items.AddRange(new ToolStripItem[] { labelInformation, toolStripStatusLabelAstorbDatUpdate, toolStripStatusLabelMpcorbDatUpdate });
+		kryptonStatusStrip.LayoutStyle = ToolStripLayoutStyle.HorizontalStackWithOverflow;
 		kryptonStatusStrip.Location = new Point(0, 0);
 		kryptonStatusStrip.Name = "kryptonStatusStrip";
 		kryptonStatusStrip.ProgressBars = null;
@@ -3733,69 +3730,6 @@ partial class PlanetoidDbForm
 		kryptonStatusStrip.MouseEnter += Control_Enter;
 		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
-		// toolStripStatusLabelUpdate
-		// 
-		toolStripStatusLabelUpdate.AccessibleDescription = "Shows that an MPCORB.DAT update is aviable";
-		toolStripStatusLabelUpdate.AccessibleName = "Update information";
-		toolStripStatusLabelUpdate.AccessibleRole = AccessibleRole.StaticText;
-		toolStripStatusLabelUpdate.AutoToolTip = true;
-		toolStripStatusLabelUpdate.Image = FatcowIcons16px.fatcow_database_lightning_16px;
-		toolStripStatusLabelUpdate.IsLink = true;
-		toolStripStatusLabelUpdate.LinkBehavior = LinkBehavior.HoverUnderline;
-		toolStripStatusLabelUpdate.LinkColor = SystemColors.ControlText;
-		toolStripStatusLabelUpdate.Name = "toolStripStatusLabelUpdate";
-		toolStripStatusLabelUpdate.Size = new Size(185, 16);
-		toolStripStatusLabelUpdate.Text = "MPCORB.DAT update available";
-		toolStripStatusLabelUpdate.ToolTipText = "MPCORB.DAT update aviable";
-		toolStripStatusLabelUpdate.Click += ToolStripStatusLabelUpdate_Click;
-		toolStripStatusLabelUpdate.MouseEnter += Control_Enter;
-		toolStripStatusLabelUpdate.MouseLeave += Control_Leave;
-		// 
-		// toolStripStatusLabelBackgroundDownload
-		// 
-		toolStripStatusLabelBackgroundDownload.AccessibleDescription = "Shows the download progress";
-		toolStripStatusLabelBackgroundDownload.AccessibleName = "Download progress";
-		toolStripStatusLabelBackgroundDownload.AccessibleRole = AccessibleRole.StatusBar;
-		toolStripStatusLabelBackgroundDownload.AutoToolTip = true;
-		toolStripStatusLabelBackgroundDownload.Image = FatcowIcons16px.fatcow_package_go_16px;
-		toolStripStatusLabelBackgroundDownload.Name = "toolStripStatusLabelBackgroundDownload";
-		toolStripStatusLabelBackgroundDownload.Size = new Size(80, 16);
-		toolStripStatusLabelBackgroundDownload.Text = "Download:";
-		toolStripStatusLabelBackgroundDownload.ToolTipText = "Show the download progress";
-		toolStripStatusLabelBackgroundDownload.DoubleClick += EasterEgg_DoubleClick;
-		toolStripStatusLabelBackgroundDownload.MouseEnter += Control_Enter;
-		toolStripStatusLabelBackgroundDownload.MouseLeave += Control_Leave;
-		// 
-		// toolStripProgressBarBackgroundDownload
-		// 
-		toolStripProgressBarBackgroundDownload.AccessibleDescription = "Shows the download progress";
-		toolStripProgressBarBackgroundDownload.AccessibleName = "Download progress";
-		toolStripProgressBarBackgroundDownload.AccessibleRole = AccessibleRole.ProgressBar;
-		toolStripProgressBarBackgroundDownload.AutoToolTip = true;
-		toolStripProgressBarBackgroundDownload.Enabled = false;
-		toolStripProgressBarBackgroundDownload.Name = "toolStripProgressBarBackgroundDownload";
-		toolStripProgressBarBackgroundDownload.Size = new Size(100, 16);
-		toolStripProgressBarBackgroundDownload.Style = ProgressBarStyle.Continuous;
-		toolStripProgressBarBackgroundDownload.ToolTipText = "Show the download progress";
-		toolStripProgressBarBackgroundDownload.DoubleClick += EasterEgg_DoubleClick;
-		toolStripProgressBarBackgroundDownload.MouseEnter += Control_Enter;
-		toolStripProgressBarBackgroundDownload.MouseLeave += Control_Leave;
-		// 
-		// toolStripStatusLabelCancelBackgroundDownload
-		// 
-		toolStripStatusLabelCancelBackgroundDownload.AccessibleDescription = "Cancels the background download";
-		toolStripStatusLabelCancelBackgroundDownload.AccessibleName = "Cancel download";
-		toolStripStatusLabelCancelBackgroundDownload.AccessibleRole = AccessibleRole.Graphic;
-		toolStripStatusLabelCancelBackgroundDownload.AutoToolTip = true;
-		toolStripStatusLabelCancelBackgroundDownload.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripStatusLabelCancelBackgroundDownload.Image = FatcowIcons16px.fatcow_cancel_16px;
-		toolStripStatusLabelCancelBackgroundDownload.Name = "toolStripStatusLabelCancelBackgroundDownload";
-		toolStripStatusLabelCancelBackgroundDownload.Size = new Size(16, 16);
-		toolStripStatusLabelCancelBackgroundDownload.Text = "Cancel background download";
-		toolStripStatusLabelCancelBackgroundDownload.Click += ToolStripStatusLabelCancelBackgroundDownload_Click;
-		toolStripStatusLabelCancelBackgroundDownload.MouseEnter += Control_Enter;
-		toolStripStatusLabelCancelBackgroundDownload.MouseLeave += Control_Leave;
-		// 
 		// labelInformation
 		// 
 		labelInformation.AccessibleDescription = "Shows some information";
@@ -3804,12 +3738,50 @@ partial class PlanetoidDbForm
 		labelInformation.AutoToolTip = true;
 		labelInformation.Image = FatcowIcons16px.fatcow_lightbulb_16px;
 		labelInformation.Name = "labelInformation";
-		labelInformation.Size = new Size(144, 16);
+		labelInformation.Size = new Size(144, 17);
 		labelInformation.Spring = true;
 		labelInformation.Text = "some information here";
 		labelInformation.ToolTipText = "Shows some information";
 		labelInformation.MouseEnter += Control_Enter;
 		labelInformation.MouseLeave += Control_Leave;
+		// 
+		// toolStripStatusLabelAstorbDatUpdate
+		// 
+		toolStripStatusLabelAstorbDatUpdate.AccessibleDescription = "Shows whether an ASTORB.DAT update is available";
+		toolStripStatusLabelAstorbDatUpdate.AccessibleName = "ASTORB.DAT update available";
+		toolStripStatusLabelAstorbDatUpdate.AccessibleRole = AccessibleRole.StaticText;
+		toolStripStatusLabelAstorbDatUpdate.Alignment = ToolStripItemAlignment.Right;
+		toolStripStatusLabelAstorbDatUpdate.AutoToolTip = true;
+		toolStripStatusLabelAstorbDatUpdate.Image = FatcowIcons16px.fatcow_new_16px;
+		toolStripStatusLabelAstorbDatUpdate.IsLink = true;
+		toolStripStatusLabelAstorbDatUpdate.LinkBehavior = LinkBehavior.HoverUnderline;
+		toolStripStatusLabelAstorbDatUpdate.LinkColor = SystemColors.ControlText;
+		toolStripStatusLabelAstorbDatUpdate.Name = "toolStripStatusLabelAstorbDatUpdate";
+		toolStripStatusLabelAstorbDatUpdate.Size = new Size(178, 17);
+		toolStripStatusLabelAstorbDatUpdate.Text = "ASTORB.DAT update available";
+		toolStripStatusLabelAstorbDatUpdate.ToolTipText = "ASTORB.DAT update available";
+		toolStripStatusLabelAstorbDatUpdate.Click += MenuitemDownloadAstorbDat_Click;
+		toolStripStatusLabelAstorbDatUpdate.MouseEnter += Control_Enter;
+		toolStripStatusLabelAstorbDatUpdate.MouseLeave += Control_Leave;
+		// 
+		// toolStripStatusLabelMpcorbDatUpdate
+		// 
+		toolStripStatusLabelMpcorbDatUpdate.AccessibleDescription = "Shows whether an MPCORB.DAT update is available";
+		toolStripStatusLabelMpcorbDatUpdate.AccessibleName = "MPCORB.DAT update available";
+		toolStripStatusLabelMpcorbDatUpdate.AccessibleRole = AccessibleRole.StaticText;
+		toolStripStatusLabelMpcorbDatUpdate.Alignment = ToolStripItemAlignment.Right;
+		toolStripStatusLabelMpcorbDatUpdate.AutoToolTip = true;
+		toolStripStatusLabelMpcorbDatUpdate.Image = FatcowIcons16px.fatcow_new_16px;
+		toolStripStatusLabelMpcorbDatUpdate.IsLink = true;
+		toolStripStatusLabelMpcorbDatUpdate.LinkBehavior = LinkBehavior.HoverUnderline;
+		toolStripStatusLabelMpcorbDatUpdate.LinkColor = SystemColors.ControlText;
+		toolStripStatusLabelMpcorbDatUpdate.Name = "toolStripStatusLabelMpcorbDatUpdate";
+		toolStripStatusLabelMpcorbDatUpdate.Size = new Size(185, 17);
+		toolStripStatusLabelMpcorbDatUpdate.Text = "MPCORB.DAT update available";
+		toolStripStatusLabelMpcorbDatUpdate.ToolTipText = "MPCORB.DAT update available";
+		toolStripStatusLabelMpcorbDatUpdate.Click += MenuitemDownloadMpcorbDat_Click;
+		toolStripStatusLabelMpcorbDatUpdate.MouseEnter += Control_Enter;
+		toolStripStatusLabelMpcorbDatUpdate.MouseLeave += Control_Leave;
 		// 
 		// kryptonNavigatorMain
 		// 
@@ -3843,7 +3815,7 @@ partial class PlanetoidDbForm
 		kryptonNavigatorMain.Pages.AddRange(new Krypton.Navigator.KryptonPage[] { kryptonPageMpcorbDat });
 		kryptonNavigatorMain.SelectedIndex = 0;
 		kryptonNavigatorMain.Size = new Size(852, 314);
-		kryptonNavigatorMain.TabIndex = 2;
+		kryptonNavigatorMain.TabIndex = 0;
 		kryptonNavigatorMain.Text = "kryptonNavigatorMain";
 		kryptonNavigatorMain.ToolTipValues.Description = "Shows the database navigator";
 		kryptonNavigatorMain.ToolTipValues.Heading = "Database navigator";
@@ -4428,11 +4400,6 @@ partial class PlanetoidDbForm
 		backgroundWorkerLoadingDatabase.ProgressChanged += BackgroundWorkerLoadingDatabase_ProgressChanged;
 		backgroundWorkerLoadingDatabase.RunWorkerCompleted += BackgroundWorkerLoadingDatabase_RunWorkerCompleted;
 		// 
-		// timerBlinkForUpdateAvailable
-		// 
-		timerBlinkForUpdateAvailable.Interval = 500;
-		timerBlinkForUpdateAvailable.Tick += TimerBlinkForUpdateAvailable_Tick;
-		// 
 		// timerCheckForNewMpcorbDatFile
 		// 
 		timerCheckForNewMpcorbDatFile.Enabled = true;
@@ -4451,6 +4418,12 @@ partial class PlanetoidDbForm
 		kryptonManager.GlobalPaletteMode = PaletteMode.Global;
 		kryptonManager.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
 		kryptonManager.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+		// 
+		// timerCheckForNewAstorbDatFile
+		// 
+		timerCheckForNewAstorbDatFile.Enabled = true;
+		timerCheckForNewAstorbDatFile.Interval = 1440000;
+		timerCheckForNewAstorbDatFile.Tick += TimerCheckForNewAstorbDatFile_Tick;
 		// 
 		// PlanetoidDbForm
 		// 
@@ -4524,12 +4497,9 @@ partial class PlanetoidDbForm
     private ToolStripMenuItem menuitemOpenWebsiteMPC;
     private ToolStripMenuItem menuitemOpenMPCORBWebsite;
     private ToolStripMenuItem menuitemOptions;
-    private ToolStripProgressBar toolStripProgressBarBackgroundDownload;
-    private ToolStripStatusLabel toolStripStatusLabelBackgroundDownload;
     private BackgroundWorker backgroundWorkerLoadingDatabase;
     private ToolStripStatusLabel labelInformation;
-    private ToolStripStatusLabel toolStripStatusLabelUpdate;
-    private Timer timerBlinkForUpdateAvailable;
+    private ToolStripStatusLabel toolStripStatusLabelMpcorbDatUpdate;
     private KryptonToolStrip kryptonToolStripIcons;
     private ToolStripButton toolStripButtonCheckMpcorbDat;
     private ToolStripButton toolStripButtonDownloadMpcorbDat;
@@ -4565,7 +4535,6 @@ partial class PlanetoidDbForm
     private ToolStripContainer toolStripContainer;
     private ToolStripMenuItem menuitemStyle;
     private Timer timerCheckForNewMpcorbDatFile;
-	private ToolStripStatusLabel toolStripStatusLabelCancelBackgroundDownload;
 	private ToolStripMenuItem menuitemTerminology;
 	private ToolStripButton toolStripButtonTerminology;
 	private ToolStripSplitButton toolStripSplitButtonStepBackward;
@@ -4763,4 +4732,6 @@ partial class PlanetoidDbForm
 	private ToolStripMenuItem toolStripMenuItemShowMpcorbDatUpdateIsAvailable;
 	private ToolStripMenuItem toolStripMenuItemShowAstorbDatUpdateIsAvailable;
 	private ToolStripSeparator toolStripSeparator19;
+	private Timer timerCheckForNewAstorbDatFile;
+	private ToolStripStatusLabel toolStripStatusLabelAstorbDatUpdate;
 }

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -14,7 +14,6 @@ using Planetoid_DB.Properties;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO.Compression;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Reflection;
@@ -34,10 +33,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <summary>NLog logger instance.</summary>
 	/// <remarks>This logger is used throughout the application to log important events and errors.</remarks>
 	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-
-	/// <summary>Cancellation token source used to cancel an ongoing download operation. May be null when no download is active.</summary>
-	/// <remarks>This token is used to cancel the download operation if needed.</remarks>
-	private CancellationTokenSource? cancellationTokenSource;
 
 	/// <summary>Gets the status label to be used for displaying information.</summary>
 	/// <remarks>Derived classes should override this property to provide the specific label.</remarks>
@@ -76,20 +71,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <summary>URI for the ASTORB database.</summary>
 	/// <remarks>This URI is used to access the ASTORB database.</remarks>
 	private readonly Uri uriAstorb = new(uriString: Settings.Default.systemAstorbDatGzUrl);
-
-	/// <summary>Cancellation token source for download operations.</summary>
-	/// <remarks>This token source is used to cancel ongoing download operations.</remarks>
-	private CancellationTokenSource? downloadCancellationTokenSource;
-
-	/// <summary>Shared <see cref="HttpClient"/> used for HTTP requests. Initialized in the constructor. Reuse to avoid socket exhaustion.</summary>
-	/// <remarks>This HttpClient instance is reused for all HTTP requests to improve performance.</remarks>
-	private static readonly HttpClient httpClient = new(handler: new HttpClientHandler
-	{
-		AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-	})
-	{
-		Timeout = TimeSpan.FromMinutes(10)
-	};
 
 	/*
 	private readonly IProgress<int>? downloadProgress;
@@ -1038,8 +1019,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			// Show the downloader form as a modal dialog
 			if (downloaderForm.ShowDialog() == DialogResult.OK)
 			{
-				// Disable the menu item for showing updates is available
+				// Disable the menu item and the status label for showing updates is available
 				toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Enabled = false;
+				toolStripStatusLabelMpcorbDatUpdate.Enabled = false;
 				// Ask the user if they want to restart the application after downloading the database
 				AskForRestartAfterDownloadingDatabase();
 			}
@@ -1067,8 +1049,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			// Show the downloader form as a modal dialog
 			if (downloaderForm.ShowDialog() == DialogResult.OK)
 			{
-				// Disable the menu item for showing updates is available
+				// Disable the menu item and the status label for showing updates is available
 				toolStripMenuItemShowAstorbDatUpdateIsAvailable.Enabled = false;
+				toolStripStatusLabelAstorbDatUpdate.Enabled = false;
 				// Ask the user if they want to restart the application after downloading the database
 				AskForRestartAfterDownloadingDatabase();
 			}
@@ -1821,36 +1804,29 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method is used to handle the shown event of the form.</remarks>
 	private void PlanetoidDBForm_Shown(object sender, EventArgs e)
 	{
-		// Disable the background download label
-		toolStripStatusLabelBackgroundDownload.Enabled = false;
-		// Disable the background download progress bar
-		toolStripProgressBarBackgroundDownload.Enabled = false;
-		// Disable the cancel background download label
-		toolStripStatusLabelCancelBackgroundDownload.Enabled = false;
-		// Hide the background download label
-		toolStripStatusLabelBackgroundDownload.Visible = false;
-		// Hide the background download progress bar
-		toolStripProgressBarBackgroundDownload.Visible = false;
-		// Hide the cancel background download label
-		toolStripStatusLabelCancelBackgroundDownload.Visible = false;
 		// Check if an update is available for the MPCORB database and enable the timer for blinking the update label
 		if (IsMpcorbDatUpdateAvailable())
 		{
 			toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Enabled = true;
-			timerBlinkForUpdateAvailable.Enabled = true;
-			toolStripStatusLabelUpdate.Enabled = true;
+			toolStripStatusLabelMpcorbDatUpdate.Enabled = true;
 		}
-		// Otherwise, disable the timer and hide the update label
+		// Otherwise, disable and hide the update label
 		else
 		{
-			timerBlinkForUpdateAvailable.Enabled = false;
-			toolStripStatusLabelUpdate.Enabled = false;
-			toolStripStatusLabelUpdate.Visible = false;
+			toolStripStatusLabelMpcorbDatUpdate.Enabled = false;
+			toolStripStatusLabelMpcorbDatUpdate.Visible = false;
 		}
 		// Check if an update is available for the ASTORB database and enable the timer for blinking the update label
 		if (IsAstorbDatUpdateAvailable())
 		{
 			toolStripMenuItemShowAstorbDatUpdateIsAvailable.Enabled = true;
+			toolStripStatusLabelAstorbDatUpdate.Enabled = true;
+		}
+		// Otherwise, disable and hide the update label
+		else
+		{
+			toolStripStatusLabelAstorbDatUpdate.Enabled = false;
+			toolStripStatusLabelAstorbDatUpdate.Visible = false;
 		}
 		// Check if the form should stay on top of other windows
 		CheckStayOnTop();
@@ -1943,162 +1919,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 	#endregion
 
-	#region Download and update database
-
-	/// <summary>Handles the progress changed event during the download process. Updates the progress bar and taskbar progress.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="DownloadProgressChangedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to update the progress bar and taskbar progress during the download process.</remarks>
-	private void ProgressChanged(object sender, DownloadProgressChangedEventArgs e)
-	{
-		// Update the progress bar value
-		toolStripProgressBarBackgroundDownload.Value = e.ProgressPercentage;
-		// Set the taskbar progress value
-		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: 0, progressMax: 100);
-	}
-
-	/// <summary>Extracts a GZIP-compressed file to the specified output file.</summary>
-	/// <param name="gzipFilePath">Full path to the source .gz file.</param>
-	/// <param name="outputFilePath">Full path where the decompressed file will be written.</param>
-	/// <remarks>The method streams the compressed input to the output file using <see cref="GZipStream"/>. It throws exceptions (e.g. <see cref="IOException"/>, <see cref="InvalidDataException"/>) to the caller.</remarks>
-	private static void ExtractGzipFile(string gzipFilePath, string outputFilePath)
-	{
-		// Create a new file stream for the gzip file
-		using FileStream originalFileStream = new(path: gzipFilePath, mode: FileMode.Open, access: FileAccess.Read);
-		// Create a new file stream for the output file
-		using FileStream decompressedFileStream = new(path: outputFilePath, mode: FileMode.Create, access: FileAccess.Write);
-		// Create a GZipStream for decompression
-		using GZipStream decompressionStream = new(stream: originalFileStream, mode: CompressionMode.Decompress);
-		// Copy the decompressed data to the output file stream
-		decompressionStream.CopyTo(destination: decompressedFileStream);
-	}
-
-	/// <summary>Handles the completion of the download process. Manages file operations and updates the UI accordingly.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="AsyncCompletedEventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to handle the completion of the download process.</remarks>
-	private async void ToolStripStatusLabelUpdate_Click(object sender, EventArgs e)
-	{
-		// Check if the user wants to download the latest MPCORB.DAT file
-		if (KryptonMessageBox.Show(text: I18nStrings.AskForDownloadingLatestMpcorbDatFile,
-				caption: I18nStrings.AskForDownloadingLatestMpcorbDatFileCaption, buttons: KryptonMessageBoxButtons.YesNo,
-				icon: KryptonMessageBoxIcon.Question) != DialogResult.Yes)
-		{
-			// User chose not to download the file, so we exit the method
-			return;
-		}
-		// Start the download process
-		toolStripStatusLabelUpdate.IsLink = false;
-		toolStripStatusLabelUpdate.Enabled = false;
-		toolStripStatusLabelUpdate.Visible = false;
-		timerBlinkForUpdateAvailable.Enabled = false;
-		toolStripStatusLabelBackgroundDownload.Visible = true;
-		toolStripProgressBarBackgroundDownload.Visible = true;
-		toolStripStatusLabelCancelBackgroundDownload.Visible = true;
-		toolStripStatusLabelBackgroundDownload.Enabled = true;
-		toolStripProgressBarBackgroundDownload.Enabled = true;
-		toolStripStatusLabelCancelBackgroundDownload.Enabled = true;
-		downloadCancellationTokenSource = new CancellationTokenSource();
-		// Create a new HttpClient instance for downloading the file
-		try
-		{
-			// Define the URI for the MPCORB.DAT.gz file
-			// Use HttpClient to download the file asynchronously
-			using (HttpResponseMessage response = await httpClient.GetAsync(requestUri: uriMpcorb, completionOption: HttpCompletionOption.ResponseHeadersRead))
-			{
-				// Ensure the response indicates success
-				_ = response.EnsureSuccessStatusCode();
-				// Get the total number of bytes to download
-				long totalBytes = response.Content.Headers.ContentLength ?? -1L;
-				// Open the content stream for reading
-				using Stream contentStream = await response.Content.ReadAsStreamAsync();
-				// Create a file stream for writing the downloaded file
-				using FileStream fileStream = new(path: Settings.Default.systemFilenameMpcorbTemp, mode: FileMode.Create, access: FileAccess.Write, share: FileShare.None, bufferSize: 8192, useAsync: true);
-				// Buffer for reading data
-				byte[] buffer = new byte[8192];
-				// Variables to track progress
-				long totalRead = 0;
-				int read;
-				// Set the progress bar style based on whether totalBytes is known
-				toolStripProgressBarBackgroundDownload.Style = totalBytes > 0 ? ProgressBarStyle.Continuous : ProgressBarStyle.Marquee;
-				// Read the content stream in chunks and write to the file stream
-				while ((read = await contentStream.ReadAsync(buffer)) > 0)
-				{
-					// Check if the download has been cancelled
-					await fileStream.WriteAsync(buffer: buffer.AsMemory(start: 0, length: read));
-					totalRead += read;
-					// Update progress if totalBytes is known
-					if (totalBytes > 0)
-					{
-						int percent = (int)(totalRead * 100 / totalBytes);
-						// Update the progress bar value
-						toolStripProgressBarBackgroundDownload.Value = Math.Min(percent, 100);
-						// Update the taskbar progress value
-						TaskbarProgress.SetValue(windowHandle: Handle, progressValue: (ulong)Math.Min(percent, 100), progressMax: 100);
-					}
-				}
-			}
-			// Replace the old MPCORB.DAT file with the newly downloaded one
-			File.Delete(path: filenameMpcorb);
-			// Set the progress bar style to Marquee to indicate processing
-			toolStripProgressBarBackgroundDownload.Style = ProgressBarStyle.Marquee;
-			// Create a new CancellationTokenSource for this download
-			cancellationTokenSource = new CancellationTokenSource();
-			// Extract the downloaded GZIP file
-			await Task.Run(action: () =>
-				ExtractGzipFile(gzipFilePath: filenameMpcorbTemp, outputFilePath: Settings.Default.systemFilenameMpcorb),
-				cancellationToken: cancellationTokenSource.Token);
-			// Delete the temporary GZIP file
-			File.Delete(path: filenameMpcorbTemp);
-			// Notify the user that the update was successful
-			AskForRestartAfterDownloadingDatabase();
-		}
-		catch (OperationCanceledException)
-		{
-			// Handle the cancellation of the download process
-			toolStripStatusLabelBackgroundDownload.Enabled = false;
-			toolStripProgressBarBackgroundDownload.Enabled = false;
-			toolStripStatusLabelCancelBackgroundDownload.Enabled = false;
-			toolStripStatusLabelBackgroundDownload.Visible = false;
-			toolStripProgressBarBackgroundDownload.Visible = false;
-			toolStripStatusLabelCancelBackgroundDownload.Visible = false;
-			File.Delete(path: filenameMpcorbTemp);
-			_ = KryptonMessageBox.Show(text: "Download cancelled", caption: "Cancel", buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
-		}
-		catch (Exception ex)
-		{
-			// Handle any errors that occur during the download process
-			ShowErrorMessage(message: ex.Message);
-			toolStripStatusLabelUpdate.IsLink = true;
-			toolStripStatusLabelUpdate.Enabled = true;
-			toolStripStatusLabelUpdate.Visible = true;
-			timerBlinkForUpdateAvailable.Enabled = true;
-			toolStripStatusLabelBackgroundDownload.Visible = false;
-			toolStripProgressBarBackgroundDownload.Visible = false;
-			toolStripStatusLabelCancelBackgroundDownload.Visible = false;
-			toolStripStatusLabelBackgroundDownload.Enabled = false;
-			toolStripProgressBarBackgroundDownload.Enabled = false;
-			toolStripStatusLabelCancelBackgroundDownload.Enabled = false;
-			File.Delete(path: filenameMpcorbTemp);
-		}
-		// Reset the UI elements after the download process
-		toolStripStatusLabelBackgroundDownload.Enabled = false;
-		toolStripProgressBarBackgroundDownload.Enabled = false;
-		toolStripStatusLabelCancelBackgroundDownload.Enabled = false;
-		toolStripStatusLabelBackgroundDownload.Visible = false;
-		toolStripProgressBarBackgroundDownload.Visible = false;
-		toolStripStatusLabelCancelBackgroundDownload.Visible = false;
-		toolStripStatusLabelUpdate.IsLink = false;
-		toolStripStatusLabelUpdate.Enabled = false;
-		toolStripStatusLabelUpdate.Visible = false;
-		timerBlinkForUpdateAvailable.Enabled = false;
-		toolStripProgressBarBackgroundDownload.Value = toolStripProgressBarBackgroundDownload.Minimum;
-		// Reset the taskbar progress
-		TaskbarProgress.SetValue(windowHandle: Handle, progressValue: 0, progressMax: 100);
-	}
-
-	#endregion
-
 	#region Timer event handlers
 
 	/// <summary>Handles the tick event for checking new MPCORB data file. Calls the PlanetoidDBForm_Shown method.</summary>
@@ -2107,11 +1927,11 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method is used to check for a new MPCORB data file.</remarks>
 	private void TimerCheckForNewMpcorbDatFile_Tick(object sender, EventArgs e) => PlanetoidDBForm_Shown(sender: sender, e: e);
 
-	/// <summary>Handles the tick event for blinking the update available status label. Toggles the ForeColor of the toolStripStatusLabelUpdate.</summary>
+	/// <summary>Handles the tick event for checking new ASTORB data file. Calls the PlanetoidDBForm_Shown method.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to blink the update available status label.</remarks>
-	private void TimerBlinkForUpdateAvailable_Tick(object sender, EventArgs e) => toolStripStatusLabelUpdate.ForeColor = toolStripStatusLabelUpdate.ForeColor == SystemColors.HotTrack ? SystemColors.ControlText : SystemColors.HotTrack;
+	/// <remarks>This method is used to check for a new ASTORB data file.</remarks>
+	private void TimerCheckForNewAstorbDatFile_Tick(object sender, EventArgs e) => PlanetoidDBForm_Shown(sender: sender, e: e);
 
 	#endregion
 
@@ -2274,22 +2094,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the terminology form with the specified index.</remarks>
 	private void ToolStripButtonTerminology_Click(object sender, EventArgs e) => OpenTerminology(index: 0);
-
-	/// <summary>Handles the click event for the ToolStripStatusLabelCancelBackgroundDownload. Cancels the background download.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to cancel the background download.</remarks>
-	private void ToolStripStatusLabelCancelBackgroundDownload_Click(object sender, EventArgs e)
-	{
-		// Cancel download
-		toolStripStatusLabelBackgroundDownload.Enabled = false;
-		toolStripProgressBarBackgroundDownload.Enabled = false;
-		toolStripStatusLabelCancelBackgroundDownload.Enabled = false;
-		toolStripStatusLabelBackgroundDownload.Visible = false;
-		toolStripProgressBarBackgroundDownload.Visible = false;
-		toolStripStatusLabelCancelBackgroundDownload.Visible = false;
-		downloadCancellationTokenSource?.Cancel();
-	}
 
 	/// <summary>Handles the click event for the ToolStripMenuItem10. Sets the navigation step to 10 and updates the menu item checked state.</summary>
 	/// <param name="sender">The event source.</param>

--- a/Forms/PlanetoidDBForm.resx
+++ b/Forms/PlanetoidDBForm.resx
@@ -118,16 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="contextMenuNavigationStep.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>743, 54</value>
+    <value>610, 54</value>
   </metadata>
   <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 91</value>
+    <value>1008, 54</value>
   </metadata>
   <metadata name="contextMenuOpenTerminology.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>832, 17</value>
+    <value>848, 17</value>
   </metadata>
   <metadata name="contextMenuTopTenRecords.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>539, 54</value>
+    <value>406, 54</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="menuitemRecordsMeanAnomalyAtTheEpoch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -285,7 +285,7 @@
 </value>
   </data>
   <metadata name="contextMenuDistributions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>949, 54</value>
+    <value>816, 54</value>
   </metadata>
   <data name="menuitemDistributionMeanAnomalyAtTheEpoch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -526,13 +526,13 @@
 </value>
   </data>
   <metadata name="contextMenuFullCopyToClipboardOrbitalElements.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>234, 91</value>
+    <value>17, 91</value>
   </metadata>
   <metadata name="menu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>385, 17</value>
+    <value>612, 17</value>
   </metadata>
   <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>470, 17</value>
+    <value>697, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>99</value>
@@ -6581,24 +6581,24 @@
 </value>
   </data>
   <metadata name="kryptonToolStripIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>244, 17</value>
   </metadata>
   <metadata name="kryptonToolStripNavigation.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>186, 17</value>
+    <value>413, 17</value>
   </metadata>
   <metadata name="backgroundWorkerLoadingDatabase.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>150, 54</value>
-  </metadata>
-  <metadata name="timerBlinkForUpdateAvailable.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>621, 17</value>
-  </metadata>
-  <metadata name="timerCheckForNewMpcorbDatFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1052, 17</value>
-  </metadata>
-  <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 54</value>
   </metadata>
+  <metadata name="timerCheckForNewMpcorbDatFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>337, 91</value>
+  </metadata>
+  <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1075, 17</value>
+  </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>397, 54</value>
+    <value>264, 54</value>
+  </metadata>
+  <metadata name="timerCheckForNewAstorbDatFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
This PR redesigns the status-bar update notification area on the main PlanetoidDB form. The previous in-status-bar background download/progress UI (and its associated HTTP/GZip download logic, blink timer, and cancellation plumbing) is removed and replaced by two simple right-aligned status labels — one each for ASTORB.DAT and MPCORB.DAT — that link to the existing downloader forms. A new periodic timer is added to check for ASTORB.DAT updates, mirroring the existing MPCORB timer.

**Changes:**
- Replace `toolStripStatusLabelUpdate` / background-download progress UI with `toolStripStatusLabelMpcorbDatUpdate` and `toolStripStatusLabelAstorbDatUpdate`, wired to the existing downloader handlers.
- Remove the inline async download implementation (`ToolStripStatusLabelUpdate_Click`, `ExtractGzipFile`, `ProgressChanged`, cancel handler, `httpClient`, `cancellationTokenSource`, blink timer) and the now-unused `System.IO.Compression` import.
- Add `timerCheckForNewAstorbDatFile` (24-minute interval) which re-runs the `Shown` handler to refresh the new ASTORB label, and update `PlanetoidDBForm_Shown` plus the downloader callbacks to manage the new labels.