### PR TITLE
Fixed `KryptonMessageBoxIcon` in `PlanetoidDBForm`

### DIFF
--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -265,7 +265,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		// and the caption "Information"
 		// If the user clicks "Yes", restart the application
 		// If the user clicks "No", do nothing
-		if (KryptonMessageBox.Show(text: I18nStrings.DownloadCompleteAndRestartQuestionText, caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.YesNo, icon: KryptonMessageBoxIcon.Information, defaultButton: KryptonMessageBoxDefaultButton.Button1) == DialogResult.Yes)
+		if (KryptonMessageBox.Show(text: I18nStrings.DownloadCompleteAndRestartQuestionText, caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.YesNo, icon: KryptonMessageBoxIcon.Question, defaultButton: KryptonMessageBoxDefaultButton.Button1) == DialogResult.Yes)
 		{
 			// Restart the application
 			Restart();


### PR DESCRIPTION
Changes the icon of the post-download restart confirmation dialog from `Information` to `Question`, which better reflects that the dialog is prompting the user for a Yes/No decision.

**Changes:**
- Updated `KryptonMessageBoxIcon` from `Information` to `Question` in `AskForRestartAfterDownloadingDatabase`.