### PR TITLE
Renamed objects and event handlers

### DIFF
--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -1873,6 +1873,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecords.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemRecords.AutoToolTip = true;
 		toolStripMenuItemRecords.DropDown = contextMenuTopTenRecords;
+		toolStripMenuItemRecords.Enabled = false;
 		toolStripMenuItemRecords.Image = FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemRecords.Name = "toolStripMenuItemRecords";
 		toolStripMenuItemRecords.ShortcutKeyDisplayString = "Strg+R";
@@ -1890,6 +1891,7 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
 		toolStripSplitButtonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
 		toolStripSplitButtonTopTenRecords.DropDown = contextMenuTopTenRecords;
+		toolStripSplitButtonTopTenRecords.Enabled = false;
 		toolStripSplitButtonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
 		toolStripSplitButtonTopTenRecords.ImageTransparentColor = Color.Magenta;
 		toolStripSplitButtonTopTenRecords.Name = "toolStripSplitButtonTopTenRecords";
@@ -3230,7 +3232,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Name = "toolStripMenuItemNearEarthObjectCoordinationCentre";
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Size = new Size(331, 22);
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Text = "Near-Earth Object Coordination Centre (NEOCC)";
-		toolStripMenuItemNearEarthObjectCoordinationCentre.Click += OpenDataPageEarthObjectCoordinationCentre_Click;
+		toolStripMenuItemNearEarthObjectCoordinationCentre.Click += OpenDataPageNearEarthObjectCoordinationCentre_Click;
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseEnter += Control_Enter;
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseLeave += Control_Leave;
 		// 

--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -49,10 +49,10 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep1000 = new ToolStripMenuItem();
 		toolStripMenuItemNavigateStep10000 = new ToolStripMenuItem();
 		toolStripMenuItemNavigateStep100000 = new ToolStripMenuItem();
-		toolStripMenuItemNavigateSomeDataForward = new ToolStripMenuItem();
 		toolStripSplitButtonStepForward = new ToolStripSplitButton();
 		toolStripSplitButtonStepBackward = new ToolStripSplitButton();
 		toolStripMenuItemNavigateSomeDataBackward = new ToolStripMenuItem();
+		toolStripMenuItemNavigateSomeDataForward = new ToolStripMenuItem();
 		tableLayoutPanelData = new KryptonTableLayoutPanel();
 		labelIndexData = new KryptonLabel();
 		contextMenuCopyToClipboard = new ContextMenuStrip(components);
@@ -158,8 +158,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardComputerName = new ToolStripMenuItem();
 		toolStripMenuItemCopyToClipboardFlags = new ToolStripMenuItem();
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation = new ToolStripMenuItem();
-		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		toolStripMenuItemCopytoClipboard = new ToolStripMenuItem();
+		toolStripDropDownButtonCopyToClipboard = new ToolStripDropDownButton();
 		menuStrip = new MenuStrip();
 		toolStripMenuItemFile = new ToolStripMenuItem();
 		toolStripMenuItemOpenLocalMpcorbDat = new ToolStripMenuItem();
@@ -267,7 +267,7 @@ partial class PlanetoidDbForm
 		toolStripButtonTerminology = new ToolStripButton();
 		toolStripSeparator3 = new ToolStripSeparator();
 		toolStripSeparator5 = new ToolStripSeparator();
-		toolStripButtonCheckMpcorbDat = new ToolStripButton();
+		toolStripButtonCheckMpcorbDatUpdate = new ToolStripButton();
 		toolStripButtonDownloadMpcorbDat = new ToolStripButton();
 		toolStripSeparator1 = new ToolStripSeparator();
 		toolStripButtonAbout = new ToolStripButton();
@@ -326,7 +326,7 @@ partial class PlanetoidDbForm
 		contextMenuNavigationStep.Font = new Font("Segoe UI", 9F);
 		contextMenuNavigationStep.Items.AddRange(new ToolStripItem[] { toolStripMenuItemNavigateStep10, toolStripMenuItemNavigateStep100, toolStripMenuItemNavigateStep1000, toolStripMenuItemNavigateStep10000, toolStripMenuItemNavigateStep100000 });
 		contextMenuNavigationStep.Name = "contextMenu";
-		contextMenuNavigationStep.OwnerItem = toolStripMenuItemNavigateSomeDataBackward;
+		contextMenuNavigationStep.OwnerItem = toolStripMenuItemNavigateSomeDataForward;
 		contextMenuNavigationStep.ShowCheckMargin = true;
 		contextMenuNavigationStep.ShowImageMargin = false;
 		contextMenuNavigationStep.Size = new Size(111, 114);
@@ -347,7 +347,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep10.Size = new Size(110, 22);
 		toolStripMenuItemNavigateStep10.Text = "10";
 		toolStripMenuItemNavigateStep10.ToolTipText = "Jump 10 items backward/forward";
-		toolStripMenuItemNavigateStep10.Click += ToolStripMenuItem10_Click;
+		toolStripMenuItemNavigateStep10.Click += NavigateStep10_Click;
 		toolStripMenuItemNavigateStep10.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateStep10.MouseLeave += Control_Leave;
 		// 
@@ -363,7 +363,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep100.Size = new Size(110, 22);
 		toolStripMenuItemNavigateStep100.Text = "100";
 		toolStripMenuItemNavigateStep100.ToolTipText = "Jump 100 items backward/forward";
-		toolStripMenuItemNavigateStep100.Click += ToolStripMenuItem100_Click;
+		toolStripMenuItemNavigateStep100.Click += NavigateStep100_Click;
 		toolStripMenuItemNavigateStep100.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateStep100.MouseLeave += Control_Leave;
 		// 
@@ -377,7 +377,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep1000.Size = new Size(110, 22);
 		toolStripMenuItemNavigateStep1000.Text = "1000";
 		toolStripMenuItemNavigateStep1000.ToolTipText = "Jump 1000 items backward/forward";
-		toolStripMenuItemNavigateStep1000.Click += ToolStripMenuItem1000_Click;
+		toolStripMenuItemNavigateStep1000.Click += NavigateStep1000_Click;
 		toolStripMenuItemNavigateStep1000.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateStep1000.MouseLeave += Control_Leave;
 		// 
@@ -391,7 +391,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep10000.Size = new Size(110, 22);
 		toolStripMenuItemNavigateStep10000.Text = "10000";
 		toolStripMenuItemNavigateStep10000.ToolTipText = "Jump 10000 items backward/forward";
-		toolStripMenuItemNavigateStep10000.Click += ToolStripMenuItem10000_Click;
+		toolStripMenuItemNavigateStep10000.Click += NavigateStep10000_Click;
 		toolStripMenuItemNavigateStep10000.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateStep10000.MouseLeave += Control_Leave;
 		// 
@@ -405,25 +405,9 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateStep100000.Size = new Size(110, 22);
 		toolStripMenuItemNavigateStep100000.Text = "100000";
 		toolStripMenuItemNavigateStep100000.ToolTipText = "Jump 100000 items backward/forward";
-		toolStripMenuItemNavigateStep100000.Click += ToolStripMenuItem100000_Click;
+		toolStripMenuItemNavigateStep100000.Click += NavigateStep100000_Click;
 		toolStripMenuItemNavigateStep100000.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateStep100000.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemNavigateSomeDataForward
-		// 
-		toolStripMenuItemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
-		toolStripMenuItemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
-		toolStripMenuItemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemNavigateSomeDataForward.AutoToolTip = true;
-		toolStripMenuItemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
-		toolStripMenuItemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
-		toolStripMenuItemNavigateSomeDataForward.Name = "toolStripMenuItemNavigateSomeDataForward";
-		toolStripMenuItemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
-		toolStripMenuItemNavigateSomeDataForward.Size = new Size(275, 22);
-		toolStripMenuItemNavigateSomeDataForward.Text = "Navigate some data &forward";
-		toolStripMenuItemNavigateSomeDataForward.Click += ToolStripMenuItemNavigateSomeDataForward_Click;
-		toolStripMenuItemNavigateSomeDataForward.MouseEnter += Control_Enter;
-		toolStripMenuItemNavigateSomeDataForward.MouseLeave += Control_Leave;
 		// 
 		// toolStripSplitButtonStepForward
 		// 
@@ -437,7 +421,7 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonStepForward.Name = "toolStripSplitButtonStepForward";
 		toolStripSplitButtonStepForward.Size = new Size(32, 22);
 		toolStripSplitButtonStepForward.Text = "Navigate some data forward";
-		toolStripSplitButtonStepForward.ButtonClick += ToolStripButtonStepForward_Click;
+		toolStripSplitButtonStepForward.ButtonClick += NavigateSomeDataForward_Click;
 		toolStripSplitButtonStepForward.MouseEnter += Control_Enter;
 		toolStripSplitButtonStepForward.MouseLeave += Control_Leave;
 		// 
@@ -453,7 +437,7 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonStepBackward.Name = "toolStripSplitButtonStepBackward";
 		toolStripSplitButtonStepBackward.Size = new Size(32, 22);
 		toolStripSplitButtonStepBackward.Text = "Navigate some data backward";
-		toolStripSplitButtonStepBackward.ButtonClick += ToolStripButtonStepBackward_Click;
+		toolStripSplitButtonStepBackward.ButtonClick += NavigateSomeDataBackward_Click;
 		toolStripSplitButtonStepBackward.MouseEnter += Control_Enter;
 		toolStripSplitButtonStepBackward.MouseLeave += Control_Leave;
 		// 
@@ -469,9 +453,25 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateSomeDataBackward.ShortcutKeys = Keys.Control | Keys.D2;
 		toolStripMenuItemNavigateSomeDataBackward.Size = new Size(275, 22);
 		toolStripMenuItemNavigateSomeDataBackward.Text = "Navigate some data back&ward";
-		toolStripMenuItemNavigateSomeDataBackward.Click += ToolStripMenuItemNavigateSomeDataBackward_Click;
+		toolStripMenuItemNavigateSomeDataBackward.Click += NavigateSomeDataBackward_Click;
 		toolStripMenuItemNavigateSomeDataBackward.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateSomeDataBackward.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemNavigateSomeDataForward
+		// 
+		toolStripMenuItemNavigateSomeDataForward.AccessibleDescription = "Navigates some data forward";
+		toolStripMenuItemNavigateSomeDataForward.AccessibleName = "Navigates some data forward";
+		toolStripMenuItemNavigateSomeDataForward.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemNavigateSomeDataForward.AutoToolTip = true;
+		toolStripMenuItemNavigateSomeDataForward.DropDown = contextMenuNavigationStep;
+		toolStripMenuItemNavigateSomeDataForward.Image = FatcowIcons16px.fatcow_control_fastforward_blue_16px;
+		toolStripMenuItemNavigateSomeDataForward.Name = "toolStripMenuItemNavigateSomeDataForward";
+		toolStripMenuItemNavigateSomeDataForward.ShortcutKeys = Keys.Control | Keys.D5;
+		toolStripMenuItemNavigateSomeDataForward.Size = new Size(275, 22);
+		toolStripMenuItemNavigateSomeDataForward.Text = "Navigate some data &forward";
+		toolStripMenuItemNavigateSomeDataForward.Click += NavigateSomeDataForward_Click;
+		toolStripMenuItemNavigateSomeDataForward.MouseEnter += Control_Enter;
+		toolStripMenuItemNavigateSomeDataForward.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanelData
 		// 
@@ -1596,7 +1596,7 @@ partial class PlanetoidDbForm
 		contextMenuTopTenRecords.Items.AddRange(new ToolStripItem[] { toolStripMenuItemRecordsSortDirection, toolStripSeparator12, toolStripMenuItemRecordsMeanAnomalyAtTheEpoch, toolStripMenuItemRecordsArgumentOfThePerihelion, toolStripMenuItemRecordsLongitudeOfTheAscendingNode, toolStripMenuItemRecordsInclination, toolStripMenuItemRecordsOrbitalEccentricity, toolStripMenuItemRecordsMeanDailyMotion, toolStripMenuItemRecordsSemiMajorAxis, toolStripMenuItemRecordsAbsoluteMagnitude, toolStripMenuItemRecordsSlopeParameter, toolStripMenuItemRecordsNumberOfOppositions, toolStripMenuItemRecordsNumberOfObservations, toolStripMenuItemRecordsObservationSpan, toolStripMenuItemRecordsRmsResidual, toolStripMenuItemRecordsComputername, toolStripMenuItemRecordsDateOfTheLastObservation });
 		contextMenuTopTenRecords.Name = "contextMenuTopTenRecords";
 		contextMenuTopTenRecords.OwnerItem = toolStripSplitButtonTopTenRecords;
-		contextMenuTopTenRecords.Size = new Size(250, 384);
+		contextMenuTopTenRecords.Size = new Size(250, 362);
 		contextMenuTopTenRecords.TabStop = true;
 		contextMenuTopTenRecords.Text = "Top ten records";
 		contextMenuTopTenRecords.Enter += Control_Enter;
@@ -1666,7 +1666,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.Name = "toolStripMenuItemRecordsMeanAnomalyAtTheEpoch";
 		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.Size = new Size(249, 22);
 		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.Text = "Mean anomaly at the epoch";
-		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.Click += ToolStripMenuItemRecordsMeanAnomalyAtTheEpoch_Click;
+		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.Click += RecordsMeanAnomalyAtTheEpoch_Click;
 		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
 		// 
@@ -1680,7 +1680,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsArgumentOfThePerihelion.Name = "toolStripMenuItemRecordsArgumentOfThePerihelion";
 		toolStripMenuItemRecordsArgumentOfThePerihelion.Size = new Size(249, 22);
 		toolStripMenuItemRecordsArgumentOfThePerihelion.Text = "Argument of perihelion";
-		toolStripMenuItemRecordsArgumentOfThePerihelion.Click += ToolStripMenuItemRecordsArgumentOfThePerihelion_Click;
+		toolStripMenuItemRecordsArgumentOfThePerihelion.Click += RecordsArgumentOfThePerihelion_Click;
 		toolStripMenuItemRecordsArgumentOfThePerihelion.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsArgumentOfThePerihelion.MouseLeave += Control_Leave;
 		// 
@@ -1694,7 +1694,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.Name = "toolStripMenuItemRecordsLongitudeOfTheAscendingNode";
 		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.Size = new Size(249, 22);
 		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.Text = "Longitude of the ascending node";
-		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.Click += ToolStripMenuItemRecordsLongitudeOfTheAscendingNode_Click;
+		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.Click += RecordsLongitudeOfTheAscendingNode_Click;
 		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsLongitudeOfTheAscendingNode.MouseLeave += Control_Leave;
 		// 
@@ -1708,7 +1708,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsInclination.Name = "toolStripMenuItemRecordsInclination";
 		toolStripMenuItemRecordsInclination.Size = new Size(249, 22);
 		toolStripMenuItemRecordsInclination.Text = "Inclination to the ecliptic";
-		toolStripMenuItemRecordsInclination.Click += ToolStripMenuItemRecordsInclination_Click;
+		toolStripMenuItemRecordsInclination.Click += RecordsInclination_Click;
 		toolStripMenuItemRecordsInclination.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsInclination.MouseLeave += Control_Leave;
 		// 
@@ -1722,7 +1722,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsOrbitalEccentricity.Name = "toolStripMenuItemRecordsOrbitalEccentricity";
 		toolStripMenuItemRecordsOrbitalEccentricity.Size = new Size(249, 22);
 		toolStripMenuItemRecordsOrbitalEccentricity.Text = "Orbital eccentricity";
-		toolStripMenuItemRecordsOrbitalEccentricity.Click += ToolStripMenuItemRecordsOrbitalEccentricity_Click;
+		toolStripMenuItemRecordsOrbitalEccentricity.Click += RecordsOrbitalEccentricity_Click;
 		toolStripMenuItemRecordsOrbitalEccentricity.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsOrbitalEccentricity.MouseLeave += Control_Leave;
 		// 
@@ -1736,7 +1736,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsMeanDailyMotion.Name = "toolStripMenuItemRecordsMeanDailyMotion";
 		toolStripMenuItemRecordsMeanDailyMotion.Size = new Size(249, 22);
 		toolStripMenuItemRecordsMeanDailyMotion.Text = "Mean daily motion";
-		toolStripMenuItemRecordsMeanDailyMotion.Click += ToolStripMenuItemRecordsMeanDailyMotion_Click;
+		toolStripMenuItemRecordsMeanDailyMotion.Click += RecordsMeanDailyMotion_Click;
 		toolStripMenuItemRecordsMeanDailyMotion.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsMeanDailyMotion.MouseLeave += Control_Leave;
 		// 
@@ -1750,7 +1750,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsSemiMajorAxis.Name = "toolStripMenuItemRecordsSemiMajorAxis";
 		toolStripMenuItemRecordsSemiMajorAxis.Size = new Size(249, 22);
 		toolStripMenuItemRecordsSemiMajorAxis.Text = "Semi-major axis";
-		toolStripMenuItemRecordsSemiMajorAxis.Click += ToolStripMenuItemRecordsSemiMajorAxis_Click;
+		toolStripMenuItemRecordsSemiMajorAxis.Click += RecordsSemiMajorAxis_Click;
 		toolStripMenuItemRecordsSemiMajorAxis.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsSemiMajorAxis.MouseLeave += Control_Leave;
 		// 
@@ -1764,7 +1764,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsAbsoluteMagnitude.Name = "toolStripMenuItemRecordsAbsoluteMagnitude";
 		toolStripMenuItemRecordsAbsoluteMagnitude.Size = new Size(249, 22);
 		toolStripMenuItemRecordsAbsoluteMagnitude.Text = "Absolute magnitude";
-		toolStripMenuItemRecordsAbsoluteMagnitude.Click += ToolStripMenuItemRecordsAbsoluteMagnitude_Click;
+		toolStripMenuItemRecordsAbsoluteMagnitude.Click += RecordsAbsoluteMagnitude_Click;
 		toolStripMenuItemRecordsAbsoluteMagnitude.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsAbsoluteMagnitude.MouseLeave += Control_Leave;
 		// 
@@ -1778,7 +1778,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsSlopeParameter.Name = "toolStripMenuItemRecordsSlopeParameter";
 		toolStripMenuItemRecordsSlopeParameter.Size = new Size(249, 22);
 		toolStripMenuItemRecordsSlopeParameter.Text = "Slope parameter";
-		toolStripMenuItemRecordsSlopeParameter.Click += ToolStripMenuItemRecordsSlopeParameter_Click;
+		toolStripMenuItemRecordsSlopeParameter.Click += RecordsSlopeParameter_Click;
 		toolStripMenuItemRecordsSlopeParameter.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsSlopeParameter.MouseLeave += Control_Leave;
 		// 
@@ -1792,7 +1792,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsNumberOfOppositions.Name = "toolStripMenuItemRecordsNumberOfOppositions";
 		toolStripMenuItemRecordsNumberOfOppositions.Size = new Size(249, 22);
 		toolStripMenuItemRecordsNumberOfOppositions.Text = "Number of oppositions";
-		toolStripMenuItemRecordsNumberOfOppositions.Click += ToolStripMenuItemRecordsNumberOfOppositions_Click;
+		toolStripMenuItemRecordsNumberOfOppositions.Click += RecordsNumberOfOppositions_Click;
 		toolStripMenuItemRecordsNumberOfOppositions.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsNumberOfOppositions.MouseLeave += Control_Leave;
 		// 
@@ -1806,7 +1806,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsNumberOfObservations.Name = "toolStripMenuItemRecordsNumberOfObservations";
 		toolStripMenuItemRecordsNumberOfObservations.Size = new Size(249, 22);
 		toolStripMenuItemRecordsNumberOfObservations.Text = "Number of observations";
-		toolStripMenuItemRecordsNumberOfObservations.Click += ToolStripMenuItemRecordsNumberOfObservations_Click;
+		toolStripMenuItemRecordsNumberOfObservations.Click += RecordsNumberOfObservations_Click;
 		toolStripMenuItemRecordsNumberOfObservations.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsNumberOfObservations.MouseLeave += Control_Leave;
 		// 
@@ -1820,7 +1820,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsObservationSpan.Name = "toolStripMenuItemRecordsObservationSpan";
 		toolStripMenuItemRecordsObservationSpan.Size = new Size(249, 22);
 		toolStripMenuItemRecordsObservationSpan.Text = "Observation span";
-		toolStripMenuItemRecordsObservationSpan.Click += ToolStripMenuItemRecordsObservationSpan_Click;
+		toolStripMenuItemRecordsObservationSpan.Click += RecordsObservationSpan_Click;
 		toolStripMenuItemRecordsObservationSpan.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsObservationSpan.MouseLeave += Control_Leave;
 		// 
@@ -1834,7 +1834,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsRmsResidual.Name = "toolStripMenuItemRecordsRmsResidual";
 		toolStripMenuItemRecordsRmsResidual.Size = new Size(249, 22);
 		toolStripMenuItemRecordsRmsResidual.Text = "r.m.s. residual";
-		toolStripMenuItemRecordsRmsResidual.Click += ToolStripMenuItemRecordsRmsResidual_Click;
+		toolStripMenuItemRecordsRmsResidual.Click += RecordsRmsResidual_Click;
 		toolStripMenuItemRecordsRmsResidual.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsRmsResidual.MouseLeave += Control_Leave;
 		// 
@@ -1848,7 +1848,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsComputername.Name = "toolStripMenuItemRecordsComputername";
 		toolStripMenuItemRecordsComputername.Size = new Size(249, 22);
 		toolStripMenuItemRecordsComputername.Text = "Computer name";
-		toolStripMenuItemRecordsComputername.Click += ToolStripMenuItemRecordsComputerName_Click;
+		toolStripMenuItemRecordsComputername.Click += RecordsComputerName_Click;
 		toolStripMenuItemRecordsComputername.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsComputername.MouseLeave += Control_Leave;
 		// 
@@ -1862,7 +1862,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecordsDateOfTheLastObservation.Name = "toolStripMenuItemRecordsDateOfTheLastObservation";
 		toolStripMenuItemRecordsDateOfTheLastObservation.Size = new Size(249, 22);
 		toolStripMenuItemRecordsDateOfTheLastObservation.Text = "Date of the last observation";
-		toolStripMenuItemRecordsDateOfTheLastObservation.Click += ToolStripMenuItemRecordsDateOfTheLastObservation_Click;
+		toolStripMenuItemRecordsDateOfTheLastObservation.Click += RecordsDateOfTheLastObservation_Click;
 		toolStripMenuItemRecordsDateOfTheLastObservation.MouseEnter += Control_Enter;
 		toolStripMenuItemRecordsDateOfTheLastObservation.MouseLeave += Control_Leave;
 		// 
@@ -1873,14 +1873,13 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRecords.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemRecords.AutoToolTip = true;
 		toolStripMenuItemRecords.DropDown = contextMenuTopTenRecords;
-		toolStripMenuItemRecords.Enabled = false;
 		toolStripMenuItemRecords.Image = FatcowIcons16px.fatcow_page_white_text_16px;
 		toolStripMenuItemRecords.Name = "toolStripMenuItemRecords";
 		toolStripMenuItemRecords.ShortcutKeyDisplayString = "Strg+R";
 		toolStripMenuItemRecords.ShortcutKeys = Keys.Control | Keys.R;
 		toolStripMenuItemRecords.Size = new Size(227, 22);
 		toolStripMenuItemRecords.Text = "Top ten &records";
-		toolStripMenuItemRecords.Click += ToolStripMenuItemRecordsTopTen_Click;
+		toolStripMenuItemRecords.Click += Records_Click;
 		toolStripMenuItemRecords.MouseEnter += Control_Enter;
 		toolStripMenuItemRecords.MouseLeave += Control_Leave;
 		// 
@@ -1891,13 +1890,12 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonTopTenRecords.AccessibleRole = AccessibleRole.SplitButton;
 		toolStripSplitButtonTopTenRecords.DisplayStyle = ToolStripItemDisplayStyle.Image;
 		toolStripSplitButtonTopTenRecords.DropDown = contextMenuTopTenRecords;
-		toolStripSplitButtonTopTenRecords.Enabled = false;
 		toolStripSplitButtonTopTenRecords.Image = FatcowIcons16px.fatcow_text_list_numbers_16px;
 		toolStripSplitButtonTopTenRecords.ImageTransparentColor = Color.Magenta;
 		toolStripSplitButtonTopTenRecords.Name = "toolStripSplitButtonTopTenRecords";
 		toolStripSplitButtonTopTenRecords.Size = new Size(32, 22);
 		toolStripSplitButtonTopTenRecords.Text = "Top ten records";
-		toolStripSplitButtonTopTenRecords.ButtonClick += ToolStripSplitButtonTopTenRecords_ButtonClick;
+		toolStripSplitButtonTopTenRecords.ButtonClick += Records_Click;
 		toolStripSplitButtonTopTenRecords.MouseEnter += Control_Enter;
 		toolStripSplitButtonTopTenRecords.MouseLeave += Control_Leave;
 		// 
@@ -1910,6 +1908,7 @@ partial class PlanetoidDbForm
 		contextMenuDistributions.Font = new Font("Segoe UI", 9F);
 		contextMenuDistributions.Items.AddRange(new ToolStripItem[] { toolStripMenuItemDistributionMeanAnomalyAtTheEpoch, toolStripMenuItemDistributionArgumentOfThePerihelion, toolStripMenuItemDistributionLongitudeOfTheAscendingNode, toolStripMenuItemDistributionInclination, toolStripMenuItemDistributionOrbitalEccentricity, toolStripMenuItemDistributionMeanDailyMotion, toolStripMenuItemDistributionSemiMajorAxis, toolStripMenuItemDistributionAbsoluteMagnitude, toolStripMenuItemDistributionSlopeParameter, toolStripMenuItemDistributionNumberOfOppositions, toolStripMenuItemDistributionNumberOfObservations, toolStripMenuItemDistributionObservationSpan, toolStripMenuItemDistributionRmsResidual, toolStripMenuItemDistributionComputerName });
 		contextMenuDistributions.Name = "contextMenuDistributions";
+		contextMenuDistributions.OwnerItem = toolStripMenuItemDistribution;
 		contextMenuDistributions.Size = new Size(250, 312);
 		contextMenuDistributions.TabStop = true;
 		contextMenuDistributions.Text = "Distributions";
@@ -1928,7 +1927,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.Name = "toolStripMenuItemDistributionMeanAnomalyAtTheEpoch";
 		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.Size = new Size(249, 22);
 		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.Text = "Mean anomaly at the epoch";
-		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.Click += ToolStripMenuItemDistributionMeanAnomalyAtTheEpoch_Click;
+		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.Click += DistributionMeanAnomalyAtTheEpoch_Click;
 		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
 		// 
@@ -1942,7 +1941,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionArgumentOfThePerihelion.Name = "toolStripMenuItemDistributionArgumentOfThePerihelion";
 		toolStripMenuItemDistributionArgumentOfThePerihelion.Size = new Size(249, 22);
 		toolStripMenuItemDistributionArgumentOfThePerihelion.Text = "Argument of the perihelion";
-		toolStripMenuItemDistributionArgumentOfThePerihelion.Click += ToolStripMenuItemDistributionArgumentOfThePerihelion_Click;
+		toolStripMenuItemDistributionArgumentOfThePerihelion.Click += DistributionArgumentOfThePerihelion_Click;
 		toolStripMenuItemDistributionArgumentOfThePerihelion.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionArgumentOfThePerihelion.MouseLeave += Control_Leave;
 		// 
@@ -1956,7 +1955,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.Name = "toolStripMenuItemDistributionLongitudeOfTheAscendingNode";
 		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.Size = new Size(249, 22);
 		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.Text = "Longitude of the ascending node";
-		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.Click += ToolStripMenuItemDistributionLongitudeOfTheAscendingNode_Click;
+		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.Click += DistributionLongitudeOfTheAscendingNode_Click;
 		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionLongitudeOfTheAscendingNode.MouseLeave += Control_Leave;
 		// 
@@ -1970,7 +1969,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionInclination.Name = "toolStripMenuItemDistributionInclination";
 		toolStripMenuItemDistributionInclination.Size = new Size(249, 22);
 		toolStripMenuItemDistributionInclination.Text = "Inclination to the ecliptic";
-		toolStripMenuItemDistributionInclination.Click += ToolStripMenuItemDistributionInclination_Click;
+		toolStripMenuItemDistributionInclination.Click += DistributionInclination_Click;
 		toolStripMenuItemDistributionInclination.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionInclination.MouseLeave += Control_Leave;
 		// 
@@ -1984,7 +1983,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionOrbitalEccentricity.Name = "toolStripMenuItemDistributionOrbitalEccentricity";
 		toolStripMenuItemDistributionOrbitalEccentricity.Size = new Size(249, 22);
 		toolStripMenuItemDistributionOrbitalEccentricity.Text = "Orbital eccentricity";
-		toolStripMenuItemDistributionOrbitalEccentricity.Click += ToolStripMenuItemDistributionOrbitalEccentricity_Click;
+		toolStripMenuItemDistributionOrbitalEccentricity.Click += DistributionOrbitalEccentricity_Click;
 		toolStripMenuItemDistributionOrbitalEccentricity.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionOrbitalEccentricity.MouseLeave += Control_Leave;
 		// 
@@ -1998,7 +1997,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionMeanDailyMotion.Name = "toolStripMenuItemDistributionMeanDailyMotion";
 		toolStripMenuItemDistributionMeanDailyMotion.Size = new Size(249, 22);
 		toolStripMenuItemDistributionMeanDailyMotion.Text = "Mean daily motion";
-		toolStripMenuItemDistributionMeanDailyMotion.Click += ToolStripMenuItemDistributionMeanDailyMotion_Click;
+		toolStripMenuItemDistributionMeanDailyMotion.Click += DistributionMeanDailyMotion_Click;
 		toolStripMenuItemDistributionMeanDailyMotion.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionMeanDailyMotion.MouseLeave += Control_Leave;
 		// 
@@ -2012,7 +2011,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionSemiMajorAxis.Name = "toolStripMenuItemDistributionSemiMajorAxis";
 		toolStripMenuItemDistributionSemiMajorAxis.Size = new Size(249, 22);
 		toolStripMenuItemDistributionSemiMajorAxis.Text = "Semi-major axis";
-		toolStripMenuItemDistributionSemiMajorAxis.Click += ToolStripMenuItemDistributionSemiMajorAxis_Click;
+		toolStripMenuItemDistributionSemiMajorAxis.Click += DistributionSemiMajorAxis_Click;
 		toolStripMenuItemDistributionSemiMajorAxis.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionSemiMajorAxis.MouseLeave += Control_Leave;
 		// 
@@ -2026,7 +2025,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionAbsoluteMagnitude.Name = "toolStripMenuItemDistributionAbsoluteMagnitude";
 		toolStripMenuItemDistributionAbsoluteMagnitude.Size = new Size(249, 22);
 		toolStripMenuItemDistributionAbsoluteMagnitude.Text = "Absolute magnitude";
-		toolStripMenuItemDistributionAbsoluteMagnitude.Click += ToolStripMenuItemDistributionAbsoluteMagnitude_Click;
+		toolStripMenuItemDistributionAbsoluteMagnitude.Click += DistributionAbsoluteMagnitude_Click;
 		toolStripMenuItemDistributionAbsoluteMagnitude.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionAbsoluteMagnitude.MouseLeave += Control_Leave;
 		// 
@@ -2040,7 +2039,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionSlopeParameter.Name = "toolStripMenuItemDistributionSlopeParameter";
 		toolStripMenuItemDistributionSlopeParameter.Size = new Size(249, 22);
 		toolStripMenuItemDistributionSlopeParameter.Text = "Slope parameter";
-		toolStripMenuItemDistributionSlopeParameter.Click += ToolStripMenuItemDistributionSlopeParameter_Click;
+		toolStripMenuItemDistributionSlopeParameter.Click += DistributionSlopeParameter_Click;
 		toolStripMenuItemDistributionSlopeParameter.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionSlopeParameter.MouseLeave += Control_Leave;
 		// 
@@ -2054,7 +2053,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionNumberOfOppositions.Name = "toolStripMenuItemDistributionNumberOfOppositions";
 		toolStripMenuItemDistributionNumberOfOppositions.Size = new Size(249, 22);
 		toolStripMenuItemDistributionNumberOfOppositions.Text = "Number of oppositions";
-		toolStripMenuItemDistributionNumberOfOppositions.Click += ToolStripMenuItemDistributionNumberOfOppositions_Click;
+		toolStripMenuItemDistributionNumberOfOppositions.Click += DistributionNumberOfOppositions_Click;
 		toolStripMenuItemDistributionNumberOfOppositions.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionNumberOfOppositions.MouseLeave += Control_Leave;
 		// 
@@ -2068,7 +2067,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionNumberOfObservations.Name = "toolStripMenuItemDistributionNumberOfObservations";
 		toolStripMenuItemDistributionNumberOfObservations.Size = new Size(249, 22);
 		toolStripMenuItemDistributionNumberOfObservations.Text = "Number of observations";
-		toolStripMenuItemDistributionNumberOfObservations.Click += ToolStripMenuItemDistributionNumberOfObservations_Click;
+		toolStripMenuItemDistributionNumberOfObservations.Click += DistributionNumberOfObservations_Click;
 		toolStripMenuItemDistributionNumberOfObservations.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionNumberOfObservations.MouseLeave += Control_Leave;
 		// 
@@ -2082,7 +2081,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionObservationSpan.Name = "toolStripMenuItemDistributionObservationSpan";
 		toolStripMenuItemDistributionObservationSpan.Size = new Size(249, 22);
 		toolStripMenuItemDistributionObservationSpan.Text = "Observation span";
-		toolStripMenuItemDistributionObservationSpan.Click += ToolStripMenuItemDistributionObservationSpan_Click;
+		toolStripMenuItemDistributionObservationSpan.Click += DistributionObservationSpan_Click;
 		toolStripMenuItemDistributionObservationSpan.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionObservationSpan.MouseLeave += Control_Leave;
 		// 
@@ -2096,7 +2095,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionRmsResidual.Name = "toolStripMenuItemDistributionRmsResidual";
 		toolStripMenuItemDistributionRmsResidual.Size = new Size(249, 22);
 		toolStripMenuItemDistributionRmsResidual.Text = "r.m.s. residual";
-		toolStripMenuItemDistributionRmsResidual.Click += ToolStripMenuItemDistributionRmsResidual_Click;
+		toolStripMenuItemDistributionRmsResidual.Click += DistributionRmsResidual_Click;
 		toolStripMenuItemDistributionRmsResidual.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionRmsResidual.MouseLeave += Control_Leave;
 		// 
@@ -2110,7 +2109,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistributionComputerName.Name = "toolStripMenuItemDistributionComputerName";
 		toolStripMenuItemDistributionComputerName.Size = new Size(249, 22);
 		toolStripMenuItemDistributionComputerName.Text = "Computer name";
-		toolStripMenuItemDistributionComputerName.Click += ToolStripMenuItemDistributionComputerName_Click;
+		toolStripMenuItemDistributionComputerName.Click += DistributionComputerName_Click;
 		toolStripMenuItemDistributionComputerName.MouseEnter += Control_Enter;
 		toolStripMenuItemDistributionComputerName.MouseLeave += Control_Leave;
 		// 
@@ -2127,7 +2126,7 @@ partial class PlanetoidDbForm
 		toolStripSplitButtonDistribution.Name = "toolStripSplitButtonDistribution";
 		toolStripSplitButtonDistribution.Size = new Size(32, 22);
 		toolStripSplitButtonDistribution.Text = "Distributions";
-		toolStripSplitButtonDistribution.ButtonClick += ToolStripSplitButtonDistribution_ButtonClick;
+		toolStripSplitButtonDistribution.ButtonClick += Distributions_Click;
 		toolStripSplitButtonDistribution.MouseEnter += Control_Enter;
 		toolStripSplitButtonDistribution.MouseLeave += Control_Leave;
 		// 
@@ -2144,7 +2143,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDistribution.ShortcutKeys = Keys.Control | Keys.D;
 		toolStripMenuItemDistribution.Size = new Size(227, 22);
 		toolStripMenuItemDistribution.Text = "&Distributions";
-		toolStripMenuItemDistribution.Click += ToolStripMenuItemDistribution_Click;
+		toolStripMenuItemDistribution.Click += Distributions_Click;
 		toolStripMenuItemDistribution.MouseEnter += Control_Enter;
 		toolStripMenuItemDistribution.MouseLeave += Control_Leave;
 		// 
@@ -2157,7 +2156,7 @@ partial class PlanetoidDbForm
 		contextMenuFullCopyToClipboardOrbitalElements.Font = new Font("Segoe UI", 9F);
 		contextMenuFullCopyToClipboardOrbitalElements.Items.AddRange(new ToolStripItem[] { toolStripMenuItemCopyToClipboardIndexNumber, toolStripMenuItemCopyToClipboardReadableDesignation, toolStripMenuItemCopyToClipboardEpoch, toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch, toolStripMenuItemCopyToClipboardArgumentOfThePerihelion, toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode, toolStripMenuItemCopyToClipboardInclinationToTheEcliptic, toolStripMenuItemToClipboardOrbitalEccentricity, toolStripMenuItemCopyToClipboardMeanDailyMotion, toolStripMenuItemCopyToClipboardSemiMajorAxis, toolStripMenuItemCopyToClipboardAbsoluteMagnitude, toolStripMenuItemCopyToClipboardSlopeParameter, toolStripMenuItemCopyToClipboardReference, toolStripMenuItemCopyToClipboardNumberOfOppositions, toolStripMenuItemCopyToClipboardNumberOfObservations, toolStripMenuItemCopyToClipboardObservationSpan, toolStripMenuItemCopyToClipboardRmsResidual, toolStripMenuItemCopyToClipboardComputerName, toolStripMenuItemCopyToClipboardFlags, toolStripMenuItemCopyToClipboardDateOfTheLastObservation });
 		contextMenuFullCopyToClipboardOrbitalElements.Name = "Context menu of copying to clipboard of orbital elements";
-		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripMenuItemCopytoClipboard;
+		contextMenuFullCopyToClipboardOrbitalElements.OwnerItem = toolStripDropDownButtonCopyToClipboard;
 		contextMenuFullCopyToClipboardOrbitalElements.Size = new Size(309, 444);
 		contextMenuFullCopyToClipboardOrbitalElements.TabStop = true;
 		contextMenuFullCopyToClipboardOrbitalElements.Text = "Copy to clipboard";
@@ -2176,7 +2175,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardIndexNumber.Name = "toolStripMenuItemCopyToClipboardIndexNumber";
 		toolStripMenuItemCopyToClipboardIndexNumber.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardIndexNumber.Text = "Index No.";
-		toolStripMenuItemCopyToClipboardIndexNumber.Click += ToolStripMenuIndexNumberCopyToClipboard_Click;
+		toolStripMenuItemCopyToClipboardIndexNumber.Click += CopyToClipboardIndexNumber_Click;
 		toolStripMenuItemCopyToClipboardIndexNumber.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardIndexNumber.MouseLeave += Control_Leave;
 		// 
@@ -2190,7 +2189,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardReadableDesignation.Name = "toolStripMenuItemCopyToClipboardReadableDesignation";
 		toolStripMenuItemCopyToClipboardReadableDesignation.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardReadableDesignation.Text = "Readable designation";
-		toolStripMenuItemCopyToClipboardReadableDesignation.Click += ToolStripMenuItemCopyToClipboardReadableDesignation_Click;
+		toolStripMenuItemCopyToClipboardReadableDesignation.Click += CopyToClipboardReadableDesignation_Click;
 		toolStripMenuItemCopyToClipboardReadableDesignation.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardReadableDesignation.MouseLeave += Control_Leave;
 		// 
@@ -2204,7 +2203,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardEpoch.Name = "toolStripMenuItemCopyToClipboardEpoch";
 		toolStripMenuItemCopyToClipboardEpoch.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardEpoch.Text = "Epoch (in packed form, .0 TT)";
-		toolStripMenuItemCopyToClipboardEpoch.Click += ToolStripMenuItemCopyToClipboardEpoch_Click;
+		toolStripMenuItemCopyToClipboardEpoch.Click += CopyToClipboardEpoch_Click;
 		toolStripMenuItemCopyToClipboardEpoch.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardEpoch.MouseLeave += Control_Leave;
 		// 
@@ -2218,7 +2217,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.Name = "toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch";
 		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.Text = "Mean anomaly at the epoch (°)";
-		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.Click += ToolStripMenuItemCopyToClipboardMeanAnomaly_Click;
+		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.Click += CopyToClipboardMeanAnomaly_Click;
 		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
 		// 
@@ -2232,7 +2231,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.Name = "toolStripMenuItemCopyToClipboardArgumentOfThePerihelion";
 		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.Text = "Argument of perihelion, J2000.0 (°)";
-		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.Click += ToolStripMenuItemCopyToClipboardArgumentOfThePerihelion_Click;
+		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.Click += CopyToClipboardArgumentOfThePerihelion_Click;
 		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardArgumentOfThePerihelion.MouseLeave += Control_Leave;
 		// 
@@ -2246,7 +2245,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.Name = "toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode";
 		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.Text = "Longitude of the ascending node, J2000.0 (°)";
-		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.Click += ToolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode_Click;
+		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.Click += CopyToClipboardLongitudeOfTheAscendingNode_Click;
 		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode.MouseLeave += Control_Leave;
 		// 
@@ -2260,7 +2259,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.Name = "toolStripMenuItemCopyToClipboardInclinationToTheEcliptic";
 		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.Text = "Inclination to the ecliptic, J2000.0 (°)";
-		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.Click += ToolStripMenuItemCopyToClipboardInclinationToTheEcliptic_Click;
+		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.Click += CopyToClipboardInclinationToTheEcliptic_Click;
 		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardInclinationToTheEcliptic.MouseLeave += Control_Leave;
 		// 
@@ -2274,7 +2273,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemToClipboardOrbitalEccentricity.Name = "toolStripMenuItemToClipboardOrbitalEccentricity";
 		toolStripMenuItemToClipboardOrbitalEccentricity.Size = new Size(308, 22);
 		toolStripMenuItemToClipboardOrbitalEccentricity.Text = "Orbital eccentricity";
-		toolStripMenuItemToClipboardOrbitalEccentricity.Click += ToolStripMenuItemCopyToClipboardOrbitalEccentricity_Click;
+		toolStripMenuItemToClipboardOrbitalEccentricity.Click += CopyToClipboardOrbitalEccentricity_Click;
 		toolStripMenuItemToClipboardOrbitalEccentricity.MouseEnter += Control_Enter;
 		toolStripMenuItemToClipboardOrbitalEccentricity.MouseLeave += Control_Leave;
 		// 
@@ -2288,7 +2287,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardMeanDailyMotion.Name = "toolStripMenuItemCopyToClipboardMeanDailyMotion";
 		toolStripMenuItemCopyToClipboardMeanDailyMotion.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardMeanDailyMotion.Text = "Mean daily motion (°/day)";
-		toolStripMenuItemCopyToClipboardMeanDailyMotion.Click += ToolStripMenuItemCopyToClipboardMeanDailyMotion_Click;
+		toolStripMenuItemCopyToClipboardMeanDailyMotion.Click += CopyToClipboardMeanDailyMotion_Click;
 		toolStripMenuItemCopyToClipboardMeanDailyMotion.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardMeanDailyMotion.MouseLeave += Control_Leave;
 		// 
@@ -2302,7 +2301,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardSemiMajorAxis.Name = "toolStripMenuItemCopyToClipboardSemiMajorAxis";
 		toolStripMenuItemCopyToClipboardSemiMajorAxis.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardSemiMajorAxis.Text = "Semi-major axis (AU)";
-		toolStripMenuItemCopyToClipboardSemiMajorAxis.Click += ToolStripMenuItemCopyToClipboardSemiMajorAxis_Click;
+		toolStripMenuItemCopyToClipboardSemiMajorAxis.Click += CopyToClipboardSemiMajorAxis_Click;
 		toolStripMenuItemCopyToClipboardSemiMajorAxis.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardSemiMajorAxis.MouseLeave += Control_Leave;
 		// 
@@ -2316,7 +2315,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.Name = "toolStripMenuItemCopyToClipboardAbsoluteMagnitude";
 		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.Text = "Absolute magnitude, H";
-		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.Click += ToolStripMenuItemCopyToClipboardAbsoluteMagnitude_Click;
+		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.Click += CopyToClipboardAbsoluteMagnitude_Click;
 		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardAbsoluteMagnitude.MouseLeave += Control_Leave;
 		// 
@@ -2330,7 +2329,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardSlopeParameter.Name = "toolStripMenuItemCopyToClipboardSlopeParameter";
 		toolStripMenuItemCopyToClipboardSlopeParameter.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardSlopeParameter.Text = "Slope parameter, G";
-		toolStripMenuItemCopyToClipboardSlopeParameter.Click += ToolStripMenuItemCopyToClipboardSlopeParameter_Click;
+		toolStripMenuItemCopyToClipboardSlopeParameter.Click += CopyToClipboardSlopeParameter_Click;
 		toolStripMenuItemCopyToClipboardSlopeParameter.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardSlopeParameter.MouseLeave += Control_Leave;
 		// 
@@ -2344,7 +2343,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardReference.Name = "toolStripMenuItemCopyToClipboardReference";
 		toolStripMenuItemCopyToClipboardReference.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardReference.Text = "Reference";
-		toolStripMenuItemCopyToClipboardReference.Click += ToolStripMenuItemCopyToClipboardReference_Click;
+		toolStripMenuItemCopyToClipboardReference.Click += CopyToClipboardReference_Click;
 		toolStripMenuItemCopyToClipboardReference.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardReference.MouseLeave += Control_Leave;
 		// 
@@ -2358,7 +2357,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardNumberOfOppositions.Name = "toolStripMenuItemCopyToClipboardNumberOfOppositions";
 		toolStripMenuItemCopyToClipboardNumberOfOppositions.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardNumberOfOppositions.Text = "Number of oppositions";
-		toolStripMenuItemCopyToClipboardNumberOfOppositions.Click += ToolStripMenuItemCopyToClipboardNumberOfOppositions_Click;
+		toolStripMenuItemCopyToClipboardNumberOfOppositions.Click += CopyToClipboardNumberOfOppositions_Click;
 		toolStripMenuItemCopyToClipboardNumberOfOppositions.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardNumberOfOppositions.MouseLeave += Control_Leave;
 		// 
@@ -2372,7 +2371,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardNumberOfObservations.Name = "toolStripMenuItemCopyToClipboardNumberOfObservations";
 		toolStripMenuItemCopyToClipboardNumberOfObservations.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardNumberOfObservations.Text = "Number of observations";
-		toolStripMenuItemCopyToClipboardNumberOfObservations.Click += ToolStripMenuItemCopyToClipboardNumberOfObservations_Click;
+		toolStripMenuItemCopyToClipboardNumberOfObservations.Click += CopyToClipboardNumberOfObservations_Click;
 		toolStripMenuItemCopyToClipboardNumberOfObservations.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardNumberOfObservations.MouseLeave += Control_Leave;
 		// 
@@ -2386,7 +2385,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardObservationSpan.Name = "toolStripMenuItemCopyToClipboardObservationSpan";
 		toolStripMenuItemCopyToClipboardObservationSpan.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardObservationSpan.Text = "Observation span";
-		toolStripMenuItemCopyToClipboardObservationSpan.Click += ToolStripMenuItemCopyToClipboardObservationSpan_Click;
+		toolStripMenuItemCopyToClipboardObservationSpan.Click += CopyToClipboardObservationSpan_Click;
 		toolStripMenuItemCopyToClipboardObservationSpan.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardObservationSpan.MouseLeave += Control_Leave;
 		// 
@@ -2400,7 +2399,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardRmsResidual.Name = "toolStripMenuItemCopyToClipboardRmsResidual";
 		toolStripMenuItemCopyToClipboardRmsResidual.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardRmsResidual.Text = "r.m.s. residual (\")";
-		toolStripMenuItemCopyToClipboardRmsResidual.Click += ToolStripMenuItemCopyToClipboardRmsResidual_Click;
+		toolStripMenuItemCopyToClipboardRmsResidual.Click += CopyToClipboardRmsResidual_Click;
 		toolStripMenuItemCopyToClipboardRmsResidual.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardRmsResidual.MouseLeave += Control_Leave;
 		// 
@@ -2414,7 +2413,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardComputerName.Name = "toolStripMenuItemCopyToClipboardComputerName";
 		toolStripMenuItemCopyToClipboardComputerName.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardComputerName.Text = "Computer name";
-		toolStripMenuItemCopyToClipboardComputerName.Click += ToolStripMenuItemCopyToClipboardComputerName_Click;
+		toolStripMenuItemCopyToClipboardComputerName.Click += CopyToClipboardComputerName_Click;
 		toolStripMenuItemCopyToClipboardComputerName.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardComputerName.MouseLeave += Control_Leave;
 		// 
@@ -2428,7 +2427,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardFlags.Name = "toolStripMenuItemCopyToClipboardFlags";
 		toolStripMenuItemCopyToClipboardFlags.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardFlags.Text = "4-hexdigit flags";
-		toolStripMenuItemCopyToClipboardFlags.Click += ToolStripMenuItemCopyToClipboardFlags_Click;
+		toolStripMenuItemCopyToClipboardFlags.Click += CopyToClipboardFlags_Click;
 		toolStripMenuItemCopyToClipboardFlags.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardFlags.MouseLeave += Control_Leave;
 		// 
@@ -2442,24 +2441,9 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.Name = "toolStripMenuItemCopyToClipboardDateOfTheLastObservation";
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.Size = new Size(308, 22);
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.Text = "Date of last observation";
-		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.Click += ToolStripMenuItemCopyToClipboardDateOfLastObservation_Click;
+		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.Click += CopyToClipboardDateOfLastObservation_Click;
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.MouseEnter += Control_Enter;
 		toolStripMenuItemCopyToClipboardDateOfTheLastObservation.MouseLeave += Control_Leave;
-		// 
-		// toolStripDropDownButtonCopyToClipboard
-		// 
-		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
-		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
-		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
-		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
-		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
-		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
-		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
-		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
-		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemCopytoClipboard
 		// 
@@ -2475,6 +2459,21 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCopytoClipboard.Text = "&Copy";
 		toolStripMenuItemCopytoClipboard.MouseEnter += Control_Enter;
 		toolStripMenuItemCopytoClipboard.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonCopyToClipboard
+		// 
+		toolStripDropDownButtonCopyToClipboard.AccessibleDescription = "Copies to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleName = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.AccessibleRole = AccessibleRole.DropList;
+		toolStripDropDownButtonCopyToClipboard.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripDropDownButtonCopyToClipboard.DropDown = contextMenuFullCopyToClipboardOrbitalElements;
+		toolStripDropDownButtonCopyToClipboard.Image = FatcowIcons16px.fatcow_page_white_copy_16px;
+		toolStripDropDownButtonCopyToClipboard.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonCopyToClipboard.Name = "toolStripDropDownButtonCopyToClipboard";
+		toolStripDropDownButtonCopyToClipboard.Size = new Size(29, 22);
+		toolStripDropDownButtonCopyToClipboard.Text = "Copy to clipboard";
+		toolStripDropDownButtonCopyToClipboard.MouseEnter += Control_Enter;
+		toolStripDropDownButtonCopyToClipboard.MouseLeave += Control_Leave;
 		// 
 		// menuStrip
 		// 
@@ -2525,7 +2524,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenLocalMpcorbDat.Name = "toolStripMenuItemOpenLocalMpcorbDat";
 		toolStripMenuItemOpenLocalMpcorbDat.Size = new Size(207, 22);
 		toolStripMenuItemOpenLocalMpcorbDat.Text = "&Open local MPCORB.DAT";
-		toolStripMenuItemOpenLocalMpcorbDat.Click += ToolStripMenuItemOpenLocalMpcorbDat_Click;
+		toolStripMenuItemOpenLocalMpcorbDat.Click += OpenLocalMpcorbDat_Click;
 		toolStripMenuItemOpenLocalMpcorbDat.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenLocalMpcorbDat.MouseLeave += Control_Leave;
 		// 
@@ -2539,7 +2538,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemExportDataEntry.Name = "toolStripMenuItemExportDataEntry";
 		toolStripMenuItemExportDataEntry.Size = new Size(207, 22);
 		toolStripMenuItemExportDataEntry.Text = "&Export data entry";
-		toolStripMenuItemExportDataEntry.Click += ToolStripButtonExport_Click;
+		toolStripMenuItemExportDataEntry.Click += Export_Click;
 		toolStripMenuItemExportDataEntry.MouseEnter += Control_Enter;
 		toolStripMenuItemExportDataEntry.MouseLeave += Control_Leave;
 		// 
@@ -2553,7 +2552,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemPrint.Name = "toolStripMenuItemPrint";
 		toolStripMenuItemPrint.Size = new Size(207, 22);
 		toolStripMenuItemPrint.Text = "&Print data sheet";
-		toolStripMenuItemPrint.Click += ToolStripMenuItemPrint_Click;
+		toolStripMenuItemPrint.Click += PrintDataSheet_Click;
 		toolStripMenuItemPrint.MouseEnter += Control_Enter;
 		toolStripMenuItemPrint.MouseLeave += Control_Leave;
 		// 
@@ -2577,7 +2576,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemArchive.Name = "toolStripMenuItemArchive";
 		toolStripMenuItemArchive.Size = new Size(207, 22);
 		toolStripMenuItemArchive.Text = "&Archive";
-		toolStripMenuItemArchive.Click += ToolStripMenuItemArchive_Click;
+		toolStripMenuItemArchive.Click += Archive_Click;
 		toolStripMenuItemArchive.MouseEnter += Control_Enter;
 		toolStripMenuItemArchive.MouseLeave += Control_Leave;
 		// 
@@ -2591,7 +2590,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCompareDatabases.Name = "toolStripMenuItemCompareDatabases";
 		toolStripMenuItemCompareDatabases.Size = new Size(207, 22);
 		toolStripMenuItemCompareDatabases.Text = "&Compare databases";
-		toolStripMenuItemCompareDatabases.Click += ToolStripMenuItemCompareDatabases_Click;
+		toolStripMenuItemCompareDatabases.Click += CompareDatabases_Click;
 		toolStripMenuItemCompareDatabases.MouseEnter += Control_Enter;
 		toolStripMenuItemCompareDatabases.MouseLeave += Control_Leave;
 		// 
@@ -2616,7 +2615,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRestart.ShortcutKeys = Keys.Alt | Keys.F3;
 		toolStripMenuItemRestart.Size = new Size(207, 22);
 		toolStripMenuItemRestart.Text = "&Restart";
-		toolStripMenuItemRestart.Click += ToolStripMenuItemRestart_Click;
+		toolStripMenuItemRestart.Click += Restart_Click;
 		toolStripMenuItemRestart.MouseEnter += Control_Enter;
 		toolStripMenuItemRestart.MouseLeave += Control_Leave;
 		// 
@@ -2632,7 +2631,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemExit.ShortcutKeys = Keys.Alt | Keys.F4;
 		toolStripMenuItemExit.Size = new Size(207, 22);
 		toolStripMenuItemExit.Text = "E&xit";
-		toolStripMenuItemExit.Click += ToolStripMenuItemExit_Click;
+		toolStripMenuItemExit.Click += Exit_Click;
 		toolStripMenuItemExit.MouseEnter += Control_Enter;
 		toolStripMenuItemExit.MouseLeave += Control_Leave;
 		// 
@@ -2661,7 +2660,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemSearch.ShortcutKeys = Keys.Control | Keys.S;
 		toolStripMenuItemSearch.Size = new Size(151, 22);
 		toolStripMenuItemSearch.Text = "&Search";
-		toolStripMenuItemSearch.Click += ToolStripMenuItemSearch_Click;
+		toolStripMenuItemSearch.Click += Search_Click;
 		toolStripMenuItemSearch.MouseEnter += Control_Enter;
 		toolStripMenuItemSearch.MouseLeave += Control_Leave;
 		// 
@@ -2689,7 +2688,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemRandomMinorPlanet.ShortcutKeys = Keys.Control | Keys.R;
 		toolStripMenuItemRandomMinorPlanet.Size = new Size(275, 22);
 		toolStripMenuItemRandomMinorPlanet.Text = "&Random minor planet";
-		toolStripMenuItemRandomMinorPlanet.Click += ToolStripMenuItemRandomMinorPlanet_Click;
+		toolStripMenuItemRandomMinorPlanet.Click += LoadRandomMinorPlanet_Click;
 		toolStripMenuItemRandomMinorPlanet.MouseEnter += Control_Enter;
 		toolStripMenuItemRandomMinorPlanet.MouseLeave += Control_Leave;
 		// 
@@ -2714,7 +2713,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateToTheBeginning.ShortcutKeys = Keys.Control | Keys.D1;
 		toolStripMenuItemNavigateToTheBeginning.Size = new Size(275, 22);
 		toolStripMenuItemNavigateToTheBeginning.Text = "Navigate to the &beginning";
-		toolStripMenuItemNavigateToTheBeginning.Click += ToolStripMenuItemNavigateToTheBegin_Click;
+		toolStripMenuItemNavigateToTheBeginning.Click += NavigateToTheBegin_Click;
 		toolStripMenuItemNavigateToTheBeginning.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateToTheBeginning.MouseLeave += Control_Leave;
 		// 
@@ -2729,7 +2728,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateToThePreviousData.ShortcutKeys = Keys.Control | Keys.D3;
 		toolStripMenuItemNavigateToThePreviousData.Size = new Size(275, 22);
 		toolStripMenuItemNavigateToThePreviousData.Text = "Navigate to the &previous";
-		toolStripMenuItemNavigateToThePreviousData.Click += ToolStripMenuItemNavigateToThePreviousData_Click;
+		toolStripMenuItemNavigateToThePreviousData.Click += NavigateToThePreviousData_Click;
 		toolStripMenuItemNavigateToThePreviousData.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateToThePreviousData.MouseLeave += Control_Leave;
 		// 
@@ -2744,7 +2743,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateToTheNextData.ShortcutKeys = Keys.Control | Keys.D4;
 		toolStripMenuItemNavigateToTheNextData.Size = new Size(275, 22);
 		toolStripMenuItemNavigateToTheNextData.Text = "Navigate to the &next";
-		toolStripMenuItemNavigateToTheNextData.Click += ToolStripMenuItemNavigateToTheNextData_Click;
+		toolStripMenuItemNavigateToTheNextData.Click += NavigateToTheNextData_Click;
 		toolStripMenuItemNavigateToTheNextData.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateToTheNextData.MouseLeave += Control_Leave;
 		// 
@@ -2759,7 +2758,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNavigateToTheEnd.ShortcutKeys = Keys.Control | Keys.D6;
 		toolStripMenuItemNavigateToTheEnd.Size = new Size(275, 22);
 		toolStripMenuItemNavigateToTheEnd.Text = "Navigate to the &end";
-		toolStripMenuItemNavigateToTheEnd.Click += ToolStripMenuItemNavigateToTheEnd_Click;
+		toolStripMenuItemNavigateToTheEnd.Click += NavigateToTheEnd_Click;
 		toolStripMenuItemNavigateToTheEnd.MouseEnter += Control_Enter;
 		toolStripMenuItemNavigateToTheEnd.MouseLeave += Control_Leave;
 		// 
@@ -2783,7 +2782,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemListReadableDesignations.Name = "toolStripMenuItemListReadableDesignations";
 		toolStripMenuItemListReadableDesignations.Size = new Size(275, 22);
 		toolStripMenuItemListReadableDesignations.Text = "&List readable designations";
-		toolStripMenuItemListReadableDesignations.Click += ToolStripMenuItemListReadableDesignations_Click;
+		toolStripMenuItemListReadableDesignations.Click += ListReadableDesignations_Click;
 		toolStripMenuItemListReadableDesignations.MouseEnter += Control_Enter;
 		toolStripMenuItemListReadableDesignations.MouseLeave += Control_Leave;
 		// 
@@ -2810,7 +2809,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDerivedOrbitElements.Name = "toolStripMenuItemDerivedOrbitElements";
 		toolStripMenuItemDerivedOrbitElements.Size = new Size(227, 22);
 		toolStripMenuItemDerivedOrbitElements.Text = "Derived &orbital elements";
-		toolStripMenuItemDerivedOrbitElements.Click += ToolStripMenuItemDerivedOrbitElements_Click;
+		toolStripMenuItemDerivedOrbitElements.Click += DerivedOrbitElements_Click;
 		toolStripMenuItemDerivedOrbitElements.MouseEnter += Control_Enter;
 		toolStripMenuItemDerivedOrbitElements.MouseLeave += Control_Leave;
 		// 
@@ -2825,7 +2824,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemFilter.Name = "toolStripMenuItemFilter";
 		toolStripMenuItemFilter.Size = new Size(227, 22);
 		toolStripMenuItemFilter.Text = "&Filter";
-		toolStripMenuItemFilter.Click += ToolStripMenuItemFilter_Click;
+		toolStripMenuItemFilter.Click += Filter_Click;
 		toolStripMenuItemFilter.MouseEnter += Control_Enter;
 		toolStripMenuItemFilter.MouseLeave += Control_Leave;
 		// 
@@ -2870,7 +2869,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDatabaseInformation.ShortcutKeys = Keys.Control | Keys.I;
 		toolStripMenuItemDatabaseInformation.Size = new Size(227, 22);
 		toolStripMenuItemDatabaseInformation.Text = "Database &information";
-		toolStripMenuItemDatabaseInformation.Click += ToolStripMenuItemDatabaseInformation_Click;
+		toolStripMenuItemDatabaseInformation.Click += DatabaseInformation_Click;
 		toolStripMenuItemDatabaseInformation.MouseEnter += Control_Enter;
 		toolStripMenuItemDatabaseInformation.MouseLeave += Control_Leave;
 		// 
@@ -2885,7 +2884,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTableMode.ShortcutKeys = Keys.Control | Keys.M;
 		toolStripMenuItemTableMode.Size = new Size(227, 22);
 		toolStripMenuItemTableMode.Text = "&Table mode";
-		toolStripMenuItemTableMode.Click += ToolStripMenuItemTableMode_Click;
+		toolStripMenuItemTableMode.Click += TableMode_Click;
 		toolStripMenuItemTableMode.MouseEnter += Control_Enter;
 		toolStripMenuItemTableMode.MouseLeave += Control_Leave;
 		// 
@@ -2900,7 +2899,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTerminology.ShortcutKeys = Keys.Control | Keys.L;
 		toolStripMenuItemTerminology.Size = new Size(227, 22);
 		toolStripMenuItemTerminology.Text = "Terminolog&y";
-		toolStripMenuItemTerminology.Click += ToolStripMenuItemTerminology_Click;
+		toolStripMenuItemTerminology.Click += Terminology_Click;
 		toolStripMenuItemTerminology.MouseEnter += Control_Enter;
 		toolStripMenuItemTerminology.MouseLeave += Control_Leave;
 		// 
@@ -2924,7 +2923,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOrbitElementsGrouping.Name = "toolStripMenuItemOrbitElementsGrouping";
 		toolStripMenuItemOrbitElementsGrouping.Size = new Size(227, 22);
 		toolStripMenuItemOrbitElementsGrouping.Text = "Orbit &elements grouping";
-		toolStripMenuItemOrbitElementsGrouping.Click += ToolStripMenuItemOrbitElementsGrouping_Click;
+		toolStripMenuItemOrbitElementsGrouping.Click += OrbitElementsGrouping_Click;
 		toolStripMenuItemOrbitElementsGrouping.MouseEnter += Control_Enter;
 		toolStripMenuItemOrbitElementsGrouping.MouseLeave += Control_Leave;
 		// 
@@ -2939,7 +2938,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAsteroidFamiliesDetection.Size = new Size(227, 22);
 		toolStripMenuItemAsteroidFamiliesDetection.Text = "Asteroid &families detection";
 		toolStripMenuItemAsteroidFamiliesDetection.ToolTipText = "Asteroid families detection";
-		toolStripMenuItemAsteroidFamiliesDetection.Click += ToolStripMenuItemAsteroidFamiliesDetection_Click;
+		toolStripMenuItemAsteroidFamiliesDetection.Click += AsteroidFamiliesDetection_Click;
 		toolStripMenuItemAsteroidFamiliesDetection.MouseEnter += Control_Enter;
 		toolStripMenuItemAsteroidFamiliesDetection.MouseLeave += Control_Leave;
 		// 
@@ -2977,7 +2976,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemMoidsOfOneMinorPlanet.Size = new Size(241, 22);
 		toolStripMenuItemMoidsOfOneMinorPlanet.Text = "&MOIDs of one minor planet";
 		toolStripMenuItemMoidsOfOneMinorPlanet.ToolTipText = "Shows the Minimum Orbit Intersection Distances (MOIDs) of a minor planet";
-		toolStripMenuItemMoidsOfOneMinorPlanet.Click += ToolStripMenuItemMoids_Click;
+		toolStripMenuItemMoidsOfOneMinorPlanet.Click += Moids_Click;
 		toolStripMenuItemMoidsOfOneMinorPlanet.MouseEnter += Control_Enter;
 		toolStripMenuItemMoidsOfOneMinorPlanet.MouseLeave += Control_Leave;
 		// 
@@ -2991,7 +2990,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemMoidsOfAllMinorPlanets.Name = "toolStripMenuItemMoidsOfAllMinorPlanets";
 		toolStripMenuItemMoidsOfAllMinorPlanets.Size = new Size(241, 22);
 		toolStripMenuItemMoidsOfAllMinorPlanets.Text = "MOIDs of all minor planets";
-		toolStripMenuItemMoidsOfAllMinorPlanets.Click += ToolStripMenuItemMoidsOfAllMinorPlanets_Click;
+		toolStripMenuItemMoidsOfAllMinorPlanets.Click += MoidsOfAllMinorPlanets_Click;
 		toolStripMenuItemMoidsOfAllMinorPlanets.MouseEnter += Control_Enter;
 		toolStripMenuItemMoidsOfAllMinorPlanets.MouseLeave += Control_Leave;
 		// 
@@ -3005,7 +3004,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemMoidsRelativeToMinorPlanets.Name = "toolStripMenuItemMoidsRelativeToMinorPlanets";
 		toolStripMenuItemMoidsRelativeToMinorPlanets.Size = new Size(241, 22);
 		toolStripMenuItemMoidsRelativeToMinorPlanets.Text = "MOIDs relative to minor planets";
-		toolStripMenuItemMoidsRelativeToMinorPlanets.Click += ToolStripMenuItemMoidsRelativeToMinorPlanets_Click;
+		toolStripMenuItemMoidsRelativeToMinorPlanets.Click += MoidsRelativeToMinorPlanets_Click;
 		toolStripMenuItemMoidsRelativeToMinorPlanets.MouseEnter += Control_Enter;
 		toolStripMenuItemMoidsRelativeToMinorPlanets.MouseLeave += Control_Leave;
 		// 
@@ -3031,7 +3030,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTisserandParameterOfOneMinorPlanet.Name = "toolStripMenuItemTisserandParameterOfOneMinorPlanet";
 		toolStripMenuItemTisserandParameterOfOneMinorPlanet.Size = new Size(288, 22);
 		toolStripMenuItemTisserandParameterOfOneMinorPlanet.Text = "Tisserand parameter of one minor planet";
-		toolStripMenuItemTisserandParameterOfOneMinorPlanet.Click += ToolStripMenuItemTisserandParameters_Click;
+		toolStripMenuItemTisserandParameterOfOneMinorPlanet.Click += TisserandParameters_Click;
 		toolStripMenuItemTisserandParameterOfOneMinorPlanet.MouseEnter += Control_Enter;
 		toolStripMenuItemTisserandParameterOfOneMinorPlanet.MouseLeave += Control_Leave;
 		// 
@@ -3044,7 +3043,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTisserandParameterOfAllMinorPlanets.Name = "toolStripMenuItemTisserandParameterOfAllMinorPlanets";
 		toolStripMenuItemTisserandParameterOfAllMinorPlanets.Size = new Size(288, 22);
 		toolStripMenuItemTisserandParameterOfAllMinorPlanets.Text = "Tisserand parameter of all minor planets";
-		toolStripMenuItemTisserandParameterOfAllMinorPlanets.Click += ToolStripMenuItemTisserandParametersOfAllMinorPlanets_Click;
+		toolStripMenuItemTisserandParameterOfAllMinorPlanets.Click += TisserandParametersOfAllMinorPlanets_Click;
 		toolStripMenuItemTisserandParameterOfAllMinorPlanets.MouseEnter += Control_Enter;
 		toolStripMenuItemTisserandParameterOfAllMinorPlanets.MouseLeave += Control_Leave;
 		// 
@@ -3071,7 +3070,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.Name = "toolStripMenuItemOrbitalResonancesOfOneMinorPlanet";
 		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.Size = new Size(280, 22);
 		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.Text = "Orbital resonan&ces of one minor planet";
-		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.Click += ToolStripMenuItemOrbitalResonances_Click;
+		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.Click += OrbitalResonances_Click;
 		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.MouseEnter += Control_Enter;
 		toolStripMenuItemOrbitalResonancesOfOneMinorPlanet.MouseLeave += Control_Leave;
 		// 
@@ -3085,7 +3084,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.Name = "toolStripMenuItemOrbitalResonancesOfAllMinorPlanets";
 		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.Size = new Size(280, 22);
 		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.Text = "Orbital resonances of &all minor planets";
-		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.Click += ToolStripMenuitemOrbitalResonancesOfAllMinorPlanets_Click;
+		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.Click += OrbitalResonancesOfAllMinorPlanets_Click;
 		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.MouseEnter += Control_Enter;
 		toolStripMenuItemOrbitalResonancesOfAllMinorPlanets.MouseLeave += Control_Leave;
 		// 
@@ -3113,7 +3112,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemObservationLogs.Size = new Size(259, 22);
 		toolStripMenuItemObservationLogs.Text = "&Observation logs";
 		toolStripMenuItemObservationLogs.ToolTipText = "Shows the observations of the minor planet";
-		toolStripMenuItemObservationLogs.Click += ToolStripMenuItemObservations_Click;
+		toolStripMenuItemObservationLogs.Click += Observations_Click;
 		toolStripMenuItemObservationLogs.MouseEnter += Control_Enter;
 		toolStripMenuItemObservationLogs.MouseLeave += Control_Leave;
 		// 
@@ -3127,7 +3126,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemBulkObservationsDataDownloader.Name = "toolStripMenuItemBulkObservationsDataDownloader";
 		toolStripMenuItemBulkObservationsDataDownloader.Size = new Size(259, 22);
 		toolStripMenuItemBulkObservationsDataDownloader.Text = "&Bulk observations data downloader";
-		toolStripMenuItemBulkObservationsDataDownloader.Click += ToolStripMenuItemBulkObservationDataDownloader_Click;
+		toolStripMenuItemBulkObservationsDataDownloader.Click += BulkObservationDataDownloader_Click;
 		toolStripMenuItemBulkObservationsDataDownloader.MouseEnter += Control_Enter;
 		toolStripMenuItemBulkObservationsDataDownloader.MouseLeave += Control_Leave;
 		// 
@@ -3140,7 +3139,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemObservatoryCodes.Name = "toolStripMenuItemObservatoryCodes";
 		toolStripMenuItemObservatoryCodes.Size = new Size(259, 22);
 		toolStripMenuItemObservatoryCodes.Text = "Observatory codes";
-		toolStripMenuItemObservatoryCodes.Click += ToolStripMenuItemObservatoryCodes_Click;
+		toolStripMenuItemObservatoryCodes.Click += ObservatoryCodes_Click;
 		toolStripMenuItemObservatoryCodes.MouseEnter += Control_Enter;
 		toolStripMenuItemObservatoryCodes.MouseLeave += Control_Leave;
 		// 
@@ -3161,7 +3160,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemMpcDatabase.Name = "toolStripMenuItemMpcDatabase";
 		toolStripMenuItemMpcDatabase.Size = new Size(331, 22);
 		toolStripMenuItemMpcDatabase.Text = "MPC database";
-		toolStripMenuItemMpcDatabase.Click += ToolStripMenuItemMpcDatabase_Click;
+		toolStripMenuItemMpcDatabase.Click += OpenDataPageMpcDatabase_Click;
 		toolStripMenuItemMpcDatabase.MouseEnter += Control_Enter;
 		toolStripMenuItemMpcDatabase.MouseLeave += Control_Leave;
 		// 
@@ -3175,7 +3174,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemJplSmallBodyDatabase.Name = "toolStripMenuItemJplSmallBodyDatabase";
 		toolStripMenuItemJplSmallBodyDatabase.Size = new Size(331, 22);
 		toolStripMenuItemJplSmallBodyDatabase.Text = "JPL Small-Body Database";
-		toolStripMenuItemJplSmallBodyDatabase.Click += ToolStripMenuItemJplSmallBodyDatabase_Click;
+		toolStripMenuItemJplSmallBodyDatabase.Click += OpenDataPageJplSmallBodyDatabase_Click;
 		toolStripMenuItemJplSmallBodyDatabase.MouseEnter += Control_Enter;
 		toolStripMenuItemJplSmallBodyDatabase.MouseLeave += Control_Leave;
 		// 
@@ -3189,7 +3188,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLowellMinorPlanetServices.Name = "toolStripMenuItemLowellMinorPlanetServices";
 		toolStripMenuItemLowellMinorPlanetServices.Size = new Size(331, 22);
 		toolStripMenuItemLowellMinorPlanetServices.Text = "Lowell Minor Planet Services";
-		toolStripMenuItemLowellMinorPlanetServices.Click += ToolStripMenuItemLowellMinorPlanetServices_Click;
+		toolStripMenuItemLowellMinorPlanetServices.Click += OpenDataPageLowellMinorPlanetServices_Click;
 		toolStripMenuItemLowellMinorPlanetServices.MouseEnter += Control_Enter;
 		toolStripMenuItemLowellMinorPlanetServices.MouseLeave += Control_Leave;
 		// 
@@ -3203,7 +3202,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAsteroidsDynamicSite.Name = "toolStripMenuItemAsteroidsDynamicSite";
 		toolStripMenuItemAsteroidsDynamicSite.Size = new Size(331, 22);
 		toolStripMenuItemAsteroidsDynamicSite.Text = "Asteroids Dynamic Site (AstDyS-2)";
-		toolStripMenuItemAsteroidsDynamicSite.Click += ToolStripMenuItemAsteroidsDynamicSite_Click;
+		toolStripMenuItemAsteroidsDynamicSite.Click += OpenDataPageAsteroidsDynamicSite_Click;
 		toolStripMenuItemAsteroidsDynamicSite.MouseEnter += Control_Enter;
 		toolStripMenuItemAsteroidsDynamicSite.MouseLeave += Control_Leave;
 		// 
@@ -3217,7 +3216,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNearEarthObjectsDynamicSite.Name = "toolStripMenuItemNearEarthObjectsDynamicSite";
 		toolStripMenuItemNearEarthObjectsDynamicSite.Size = new Size(331, 22);
 		toolStripMenuItemNearEarthObjectsDynamicSite.Text = "Near Earth Objects Dynamic Site (NEODyS-2)";
-		toolStripMenuItemNearEarthObjectsDynamicSite.Click += ToolStripMenuItemNearEarthObjectsDynamicSite_Click;
+		toolStripMenuItemNearEarthObjectsDynamicSite.Click += OpenDataPageNearEarthObjectsDynamicSite_Click;
 		toolStripMenuItemNearEarthObjectsDynamicSite.MouseEnter += Control_Enter;
 		toolStripMenuItemNearEarthObjectsDynamicSite.MouseLeave += Control_Leave;
 		// 
@@ -3231,7 +3230,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Name = "toolStripMenuItemNearEarthObjectCoordinationCentre";
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Size = new Size(331, 22);
 		toolStripMenuItemNearEarthObjectCoordinationCentre.Text = "Near-Earth Object Coordination Centre (NEOCC)";
-		toolStripMenuItemNearEarthObjectCoordinationCentre.Click += ToolStripMenuItemNearEarthObjectCoordinationCentre_Click;
+		toolStripMenuItemNearEarthObjectCoordinationCentre.Click += OpenDataPageEarthObjectCoordinationCentre_Click;
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseEnter += Control_Enter;
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseLeave += Control_Leave;
 		// 
@@ -3255,7 +3254,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenAllDataPages.Name = "toolStripMenuItemOpenAllDataPages";
 		toolStripMenuItemOpenAllDataPages.Size = new Size(331, 22);
 		toolStripMenuItemOpenAllDataPages.Text = "Open all data pages";
-		toolStripMenuItemOpenAllDataPages.Click += ToolStripMenuItemOpenAllDataPages_Click;
+		toolStripMenuItemOpenAllDataPages.Click += OpenAllDataPages_Click;
 		toolStripMenuItemOpenAllDataPages.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenAllDataPages.MouseLeave += Control_Leave;
 		// 
@@ -3283,7 +3282,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Name = "toolStripMenuItemShowMpcorbDatUpdateIsAvailable";
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Size = new Size(236, 22);
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Text = "MPCORB.DAT update available";
-		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Click += ToolStripMenuItemDownloadMpcorbDat_Click;
+		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.Click += DownloadMpcorbDat_Click;
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.MouseEnter += Control_Enter;
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable.MouseLeave += Control_Leave;
 		// 
@@ -3298,7 +3297,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.Name = "toolStripMenuItemShowAstorbDatUpdateIsAvailable";
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.Size = new Size(236, 22);
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.Text = "ASTORB.DAT update available";
-		toolStripMenuItemShowAstorbDatUpdateIsAvailable.Click += ToolStripMenuItemDownloadAstorbDat_Click;
+		toolStripMenuItemShowAstorbDatUpdateIsAvailable.Click += DownloadAstorbDat_Click;
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.MouseEnter += Control_Enter;
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.MouseLeave += Control_Leave;
 		// 
@@ -3322,7 +3321,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCheckMpcorbDatUpdate.Name = "toolStripMenuItemCheckMpcorbDatUpdate";
 		toolStripMenuItemCheckMpcorbDatUpdate.Size = new Size(236, 22);
 		toolStripMenuItemCheckMpcorbDatUpdate.Text = "&Check MPCORB.DAT";
-		toolStripMenuItemCheckMpcorbDatUpdate.Click += ToolStripMenuItemCheckMpcorbDat_Click;
+		toolStripMenuItemCheckMpcorbDatUpdate.Click += CheckMpcorbDatUpdate_Click;
 		toolStripMenuItemCheckMpcorbDatUpdate.MouseEnter += Control_Enter;
 		toolStripMenuItemCheckMpcorbDatUpdate.MouseLeave += Control_Leave;
 		// 
@@ -3336,7 +3335,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDownloadMpcorbDat.Name = "toolStripMenuItemDownloadMpcorbDat";
 		toolStripMenuItemDownloadMpcorbDat.Size = new Size(236, 22);
 		toolStripMenuItemDownloadMpcorbDat.Text = "&Download MPCORB.DAT";
-		toolStripMenuItemDownloadMpcorbDat.Click += ToolStripMenuItemDownloadMpcorbDat_Click;
+		toolStripMenuItemDownloadMpcorbDat.Click += DownloadMpcorbDat_Click;
 		toolStripMenuItemDownloadMpcorbDat.MouseEnter += Control_Enter;
 		toolStripMenuItemDownloadMpcorbDat.MouseLeave += Control_Leave;
 		// 
@@ -3360,7 +3359,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemCheckAstorbDatUpdate.Name = "toolStripMenuItemCheckAstorbDatUpdate";
 		toolStripMenuItemCheckAstorbDatUpdate.Size = new Size(236, 22);
 		toolStripMenuItemCheckAstorbDatUpdate.Text = "Check ASTORB.DAT";
-		toolStripMenuItemCheckAstorbDatUpdate.Click += ToolStripMenuItemCheckAstorbDat_Click;
+		toolStripMenuItemCheckAstorbDatUpdate.Click += CheckAstorbDatUpdate_Click;
 		toolStripMenuItemCheckAstorbDatUpdate.MouseEnter += Control_Enter;
 		toolStripMenuItemCheckAstorbDatUpdate.MouseLeave += Control_Leave;
 		// 
@@ -3374,7 +3373,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDownloadAstorbDat.Name = "toolStripMenuItemDownloadAstorbDat";
 		toolStripMenuItemDownloadAstorbDat.Size = new Size(236, 22);
 		toolStripMenuItemDownloadAstorbDat.Text = "Download ASTORB.DAT";
-		toolStripMenuItemDownloadAstorbDat.Click += ToolStripMenuItemDownloadAstorbDat_Click;
+		toolStripMenuItemDownloadAstorbDat.Click += DownloadAstorbDat_Click;
 		toolStripMenuItemDownloadAstorbDat.MouseEnter += Control_Enter;
 		toolStripMenuItemDownloadAstorbDat.MouseLeave += Control_Leave;
 		// 
@@ -3403,7 +3402,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemSettings.Name = "toolStripMenuItemSettings";
 		toolStripMenuItemSettings.Size = new Size(264, 22);
 		toolStripMenuItemSettings.Text = "&Settings";
-		toolStripMenuItemSettings.Click += ToolStripMenuItemSettings_Click;
+		toolStripMenuItemSettings.Click += Settings_Click;
 		toolStripMenuItemSettings.MouseEnter += Control_Enter;
 		toolStripMenuItemSettings.MouseLeave += Control_Leave;
 		// 
@@ -3433,7 +3432,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemIconsetFatcow.Name = "toolStripMenuItemIconsetFatcow";
 		toolStripMenuItemIconsetFatcow.Size = new Size(143, 22);
 		toolStripMenuItemIconsetFatcow.Text = "Fatcow icons";
-		toolStripMenuItemIconsetFatcow.Click += ToolStripMenuItemIconSetFatcow_Click;
+		toolStripMenuItemIconsetFatcow.Click += IconSetFatcow_Click;
 		toolStripMenuItemIconsetFatcow.MouseEnter += Control_Enter;
 		toolStripMenuItemIconsetFatcow.MouseLeave += Control_Leave;
 		// 
@@ -3450,7 +3449,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemIconsetSilk.Name = "toolStripMenuItemIconsetSilk";
 		toolStripMenuItemIconsetSilk.Size = new Size(143, 22);
 		toolStripMenuItemIconsetSilk.Text = "Silk icons";
-		toolStripMenuItemIconsetSilk.Click += ToolStripMenuItemIconSetSilk_Click;
+		toolStripMenuItemIconsetSilk.Click += IconSetSilk_Click;
 		toolStripMenuItemIconsetSilk.MouseEnter += Control_Enter;
 		toolStripMenuItemIconsetSilk.MouseLeave += Control_Leave;
 		// 
@@ -3465,7 +3464,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemIconsetFugue.Name = "toolStripMenuItemIconsetFugue";
 		toolStripMenuItemIconsetFugue.Size = new Size(143, 22);
 		toolStripMenuItemIconsetFugue.Text = "Fugue icons";
-		toolStripMenuItemIconsetFugue.Click += ToolStripMenuItemIconSetFugue_Click;
+		toolStripMenuItemIconsetFugue.Click += IconSetFugue_Click;
 		toolStripMenuItemIconsetFugue.MouseEnter += Control_Enter;
 		toolStripMenuItemIconsetFugue.MouseLeave += Control_Leave;
 		// 
@@ -3489,7 +3488,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionStayOnTop.Name = "toolStripMenuItemOptionStayOnTop";
 		toolStripMenuItemOptionStayOnTop.Size = new Size(264, 22);
 		toolStripMenuItemOptionStayOnTop.Text = "Stay always on &top";
-		toolStripMenuItemOptionStayOnTop.Click += ToolStripMenuItemStayOnTop_Click;
+		toolStripMenuItemOptionStayOnTop.Click += StayOnTop_Click;
 		toolStripMenuItemOptionStayOnTop.MouseEnter += Control_Enter;
 		toolStripMenuItemOptionStayOnTop.MouseLeave += Control_Leave;
 		// 
@@ -3506,7 +3505,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Name = "toolStripMenuItemOptionEnabledCopyingByDoubleClicking";
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Size = new Size(264, 22);
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Text = "Enabled &copying by double-clicking";
-		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Click += ToolStripMenuItemEnableCopyingByDoubleClicking_Click;
+		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Click += EnableCopyingByDoubleClicking_Click;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.MouseEnter += Control_Enter;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.MouseLeave += Control_Leave;
 		// 
@@ -3523,7 +3522,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionEnableLinkingToTerminology.Name = "toolStripMenuItemOptionEnableLinkingToTerminology";
 		toolStripMenuItemOptionEnableLinkingToTerminology.Size = new Size(264, 22);
 		toolStripMenuItemOptionEnableLinkingToTerminology.Text = "Enable linking to terminolog&y";
-		toolStripMenuItemOptionEnableLinkingToTerminology.Click += ToolStripMenuItemEnableLinkingToTerminology_Click;
+		toolStripMenuItemOptionEnableLinkingToTerminology.Click += EnableLinkingToTerminology_Click;
 		toolStripMenuItemOptionEnableLinkingToTerminology.MouseEnter += Control_Enter;
 		toolStripMenuItemOptionEnableLinkingToTerminology.MouseLeave += Control_Leave;
 		// 
@@ -3552,7 +3551,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAbout.Size = new Size(236, 22);
 		toolStripMenuItemAbout.Text = "&About";
 		toolStripMenuItemAbout.ToolTipText = "More information about the application";
-		toolStripMenuItemAbout.Click += ToolStripMenuItemAbout_Click;
+		toolStripMenuItemAbout.Click += About_Click;
 		toolStripMenuItemAbout.MouseEnter += Control_Enter;
 		toolStripMenuItemAbout.MouseLeave += Control_Leave;
 		// 
@@ -3566,7 +3565,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLicense.Name = "toolStripMenuItemLicense";
 		toolStripMenuItemLicense.Size = new Size(236, 22);
 		toolStripMenuItemLicense.Text = "License";
-		toolStripMenuItemLicense.Click += ToolStripMenuItemLicense_Click;
+		toolStripMenuItemLicense.Click += License_Click;
 		toolStripMenuItemLicense.MouseEnter += Control_Enter;
 		toolStripMenuItemLicense.MouseLeave += Control_Leave;
 		// 
@@ -3591,7 +3590,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenWebsitePDB.Size = new Size(236, 22);
 		toolStripMenuItemOpenWebsitePDB.Text = "Open Planetoid-DB homepage";
 		toolStripMenuItemOpenWebsitePDB.ToolTipText = "Opens the Planetoid-DB homepage";
-		toolStripMenuItemOpenWebsitePDB.Click += ToolStripMenuItemOpenWebsitePDB_Click;
+		toolStripMenuItemOpenWebsitePDB.Click += OpenWebsitePDB_Click;
 		toolStripMenuItemOpenWebsitePDB.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenWebsitePDB.MouseLeave += Control_Leave;
 		// 
@@ -3606,7 +3605,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenWebsiteMPC.Size = new Size(236, 22);
 		toolStripMenuItemOpenWebsiteMPC.Text = "Open MPC homepage";
 		toolStripMenuItemOpenWebsiteMPC.ToolTipText = "Opens the MPC homepage";
-		toolStripMenuItemOpenWebsiteMPC.Click += ToolStripMenuItemOpenWebsiteMPC_Click;
+		toolStripMenuItemOpenWebsiteMPC.Click += OpenWebsiteMPC_Click;
 		toolStripMenuItemOpenWebsiteMPC.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenWebsiteMPC.MouseLeave += Control_Leave;
 		// 
@@ -3621,7 +3620,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenMPCORBWebsite.Size = new Size(236, 22);
 		toolStripMenuItemOpenMPCORBWebsite.Text = "Open MPCORB website";
 		toolStripMenuItemOpenMPCORBWebsite.ToolTipText = "Opens the MPCORB website";
-		toolStripMenuItemOpenMPCORBWebsite.Click += ToolStripMenuItemOpenMPCORBWebsite_Click;
+		toolStripMenuItemOpenMPCORBWebsite.Click += OpenMpcorbDatWebsite_Click;
 		toolStripMenuItemOpenMPCORBWebsite.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenMPCORBWebsite.MouseLeave += Control_Leave;
 		// 
@@ -3636,7 +3635,7 @@ partial class PlanetoidDbForm
 		toolStripButtonObservations.Name = "toolStripButtonObservations";
 		toolStripButtonObservations.Size = new Size(23, 22);
 		toolStripButtonObservations.Text = "Observations";
-		toolStripButtonObservations.Click += ToolStripButtonObservations_Click;
+		toolStripButtonObservations.Click += Observations_Click;
 		toolStripButtonObservations.MouseEnter += Control_Enter;
 		toolStripButtonObservations.MouseLeave += Control_Leave;
 		// 
@@ -3751,7 +3750,7 @@ partial class PlanetoidDbForm
 		toolStripStatusLabelAstorbDatUpdate.Size = new Size(178, 17);
 		toolStripStatusLabelAstorbDatUpdate.Text = "ASTORB.DAT update available";
 		toolStripStatusLabelAstorbDatUpdate.ToolTipText = "ASTORB.DAT update available";
-		toolStripStatusLabelAstorbDatUpdate.Click += ToolStripMenuItemDownloadAstorbDat_Click;
+		toolStripStatusLabelAstorbDatUpdate.Click += DownloadAstorbDat_Click;
 		toolStripStatusLabelAstorbDatUpdate.MouseEnter += Control_Enter;
 		toolStripStatusLabelAstorbDatUpdate.MouseLeave += Control_Leave;
 		// 
@@ -3770,7 +3769,7 @@ partial class PlanetoidDbForm
 		toolStripStatusLabelMpcorbDatUpdate.Size = new Size(185, 17);
 		toolStripStatusLabelMpcorbDatUpdate.Text = "MPCORB.DAT update available";
 		toolStripStatusLabelMpcorbDatUpdate.ToolTipText = "MPCORB.DAT update available";
-		toolStripStatusLabelMpcorbDatUpdate.Click += ToolStripMenuItemDownloadMpcorbDat_Click;
+		toolStripStatusLabelMpcorbDatUpdate.Click += DownloadMpcorbDat_Click;
 		toolStripStatusLabelMpcorbDatUpdate.MouseEnter += Control_Enter;
 		toolStripStatusLabelMpcorbDatUpdate.MouseLeave += Control_Leave;
 		// 
@@ -3865,7 +3864,7 @@ partial class PlanetoidDbForm
 		kryptonToolStripIcons.AllowItemReorder = true;
 		kryptonToolStripIcons.Dock = DockStyle.None;
 		kryptonToolStripIcons.Font = new Font("Segoe UI", 9F);
-		kryptonToolStripIcons.Items.AddRange(new ToolStripItem[] { toolStripButtonOpenLocalMpcorbDat, toolStripButtonExport, toolStripButtonPrint, toolStripSeparator14, toolStripButtonArchive, toolStripButtonCompareDatabases, toolStripSeparator15, toolStripDropDownButtonCopyToClipboard, toolStripButtonSearch, toolStripSeparator4, toolStripButtonDatabaseInformation, toolStripButtonTableMode, toolStripButtonTerminology, toolStripSeparator3, toolStripSplitButtonTopTenRecords, toolStripSplitButtonDistribution, toolStripSeparator5, toolStripButtonCheckMpcorbDat, toolStripButtonDownloadMpcorbDat, toolStripSeparator1, toolStripButtonAbout, toolStripButtonLicense, toolStripButtonOpenWebsitePDB });
+		kryptonToolStripIcons.Items.AddRange(new ToolStripItem[] { toolStripButtonOpenLocalMpcorbDat, toolStripButtonExport, toolStripButtonPrint, toolStripSeparator14, toolStripButtonArchive, toolStripButtonCompareDatabases, toolStripSeparator15, toolStripDropDownButtonCopyToClipboard, toolStripButtonSearch, toolStripSeparator4, toolStripButtonDatabaseInformation, toolStripButtonTableMode, toolStripButtonTerminology, toolStripSeparator3, toolStripSplitButtonTopTenRecords, toolStripSplitButtonDistribution, toolStripSeparator5, toolStripButtonCheckMpcorbDatUpdate, toolStripButtonDownloadMpcorbDat, toolStripSeparator1, toolStripButtonAbout, toolStripButtonLicense, toolStripButtonOpenWebsitePDB });
 		kryptonToolStripIcons.LayoutStyle = ToolStripLayoutStyle.HorizontalStackWithOverflow;
 		kryptonToolStripIcons.Location = new Point(0, 24);
 		kryptonToolStripIcons.Name = "kryptonToolStripIcons";
@@ -3890,7 +3889,7 @@ partial class PlanetoidDbForm
 		toolStripButtonOpenLocalMpcorbDat.Name = "toolStripButtonOpenLocalMpcorbDat";
 		toolStripButtonOpenLocalMpcorbDat.Size = new Size(23, 22);
 		toolStripButtonOpenLocalMpcorbDat.Text = "Open local MPCORB.DAT";
-		toolStripButtonOpenLocalMpcorbDat.Click += ToolStripButtonOpenLocalMpcorbDat_Click;
+		toolStripButtonOpenLocalMpcorbDat.Click += OpenLocalMpcorbDat_Click;
 		toolStripButtonOpenLocalMpcorbDat.MouseEnter += Control_Enter;
 		toolStripButtonOpenLocalMpcorbDat.MouseLeave += Control_Leave;
 		// 
@@ -3905,7 +3904,7 @@ partial class PlanetoidDbForm
 		toolStripButtonExport.Name = "toolStripButtonExport";
 		toolStripButtonExport.Size = new Size(23, 22);
 		toolStripButtonExport.Text = "Export";
-		toolStripButtonExport.Click += ToolStripButtonExport_Click;
+		toolStripButtonExport.Click += Export_Click;
 		toolStripButtonExport.MouseEnter += Control_Enter;
 		toolStripButtonExport.MouseLeave += Control_Leave;
 		// 
@@ -3920,7 +3919,7 @@ partial class PlanetoidDbForm
 		toolStripButtonPrint.Name = "toolStripButtonPrint";
 		toolStripButtonPrint.Size = new Size(23, 22);
 		toolStripButtonPrint.Text = "Print";
-		toolStripButtonPrint.Click += ToolStripButtonPrint_Click;
+		toolStripButtonPrint.Click += PrintDataSheet_Click;
 		toolStripButtonPrint.MouseEnter += Control_Enter;
 		toolStripButtonPrint.MouseLeave += Control_Leave;
 		// 
@@ -3945,7 +3944,7 @@ partial class PlanetoidDbForm
 		toolStripButtonArchive.Name = "toolStripButtonArchive";
 		toolStripButtonArchive.Size = new Size(23, 22);
 		toolStripButtonArchive.Text = "&Archive";
-		toolStripButtonArchive.Click += ToolStripButtonArchive_Click;
+		toolStripButtonArchive.Click += Archive_Click;
 		toolStripButtonArchive.MouseEnter += Control_Enter;
 		toolStripButtonArchive.MouseLeave += Control_Leave;
 		// 
@@ -3960,7 +3959,7 @@ partial class PlanetoidDbForm
 		toolStripButtonCompareDatabases.Name = "toolStripButtonCompareDatabases";
 		toolStripButtonCompareDatabases.Size = new Size(23, 22);
 		toolStripButtonCompareDatabases.Text = "&Compare databases";
-		toolStripButtonCompareDatabases.Click += ToolStripButtonCompareDatabases_Click;
+		toolStripButtonCompareDatabases.Click += CompareDatabases_Click;
 		toolStripButtonCompareDatabases.MouseEnter += Control_Enter;
 		toolStripButtonCompareDatabases.MouseLeave += Control_Leave;
 		// 
@@ -3985,7 +3984,7 @@ partial class PlanetoidDbForm
 		toolStripButtonSearch.Name = "toolStripButtonSearch";
 		toolStripButtonSearch.Size = new Size(23, 22);
 		toolStripButtonSearch.Text = "Search";
-		toolStripButtonSearch.Click += ToolStripMenuItemSearch_Click;
+		toolStripButtonSearch.Click += Search_Click;
 		toolStripButtonSearch.MouseEnter += Control_Enter;
 		toolStripButtonSearch.MouseLeave += Control_Leave;
 		// 
@@ -4010,7 +4009,7 @@ partial class PlanetoidDbForm
 		toolStripButtonDatabaseInformation.Name = "toolStripButtonDatabaseInformation";
 		toolStripButtonDatabaseInformation.Size = new Size(23, 22);
 		toolStripButtonDatabaseInformation.Text = "Database information";
-		toolStripButtonDatabaseInformation.Click += ToolStripButtonDatabaseInformation_Click;
+		toolStripButtonDatabaseInformation.Click += DatabaseInformation_Click;
 		toolStripButtonDatabaseInformation.MouseEnter += Control_Enter;
 		toolStripButtonDatabaseInformation.MouseLeave += Control_Leave;
 		// 
@@ -4025,7 +4024,7 @@ partial class PlanetoidDbForm
 		toolStripButtonTableMode.Name = "toolStripButtonTableMode";
 		toolStripButtonTableMode.Size = new Size(23, 22);
 		toolStripButtonTableMode.Text = "Table mode";
-		toolStripButtonTableMode.Click += ToolStripButtonTableMode_Click;
+		toolStripButtonTableMode.Click += TableMode_Click;
 		toolStripButtonTableMode.MouseEnter += Control_Enter;
 		toolStripButtonTableMode.MouseLeave += Control_Leave;
 		// 
@@ -4040,7 +4039,7 @@ partial class PlanetoidDbForm
 		toolStripButtonTerminology.Name = "toolStripButtonTerminology";
 		toolStripButtonTerminology.Size = new Size(23, 22);
 		toolStripButtonTerminology.Text = "Terminology";
-		toolStripButtonTerminology.Click += ToolStripButtonTerminology_Click;
+		toolStripButtonTerminology.Click += Terminology_Click;
 		toolStripButtonTerminology.MouseEnter += Control_Enter;
 		toolStripButtonTerminology.MouseLeave += Control_Leave;
 		// 
@@ -4064,20 +4063,20 @@ partial class PlanetoidDbForm
 		toolStripSeparator5.MouseEnter += Control_Enter;
 		toolStripSeparator5.MouseLeave += Control_Leave;
 		// 
-		// toolStripButtonCheckMpcorbDat
+		// toolStripButtonCheckMpcorbDatUpdate
 		// 
-		toolStripButtonCheckMpcorbDat.AccessibleDescription = "Checks for updates of the database MPCORB.DAT";
-		toolStripButtonCheckMpcorbDat.AccessibleName = "Check MPCORB.DAT";
-		toolStripButtonCheckMpcorbDat.AccessibleRole = AccessibleRole.PushButton;
-		toolStripButtonCheckMpcorbDat.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripButtonCheckMpcorbDat.Image = FatcowIcons16px.fatcow_database_lightning_16px;
-		toolStripButtonCheckMpcorbDat.ImageTransparentColor = Color.Magenta;
-		toolStripButtonCheckMpcorbDat.Name = "toolStripButtonCheckMpcorbDat";
-		toolStripButtonCheckMpcorbDat.Size = new Size(23, 22);
-		toolStripButtonCheckMpcorbDat.Text = "Check MPCORB.DAT";
-		toolStripButtonCheckMpcorbDat.Click += ToolStripButtonCheckMpcorbDat_Click;
-		toolStripButtonCheckMpcorbDat.MouseEnter += Control_Enter;
-		toolStripButtonCheckMpcorbDat.MouseLeave += Control_Leave;
+		toolStripButtonCheckMpcorbDatUpdate.AccessibleDescription = "Checks for updates of the database MPCORB.DAT";
+		toolStripButtonCheckMpcorbDatUpdate.AccessibleName = "Check MPCORB.DAT update";
+		toolStripButtonCheckMpcorbDatUpdate.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonCheckMpcorbDatUpdate.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripButtonCheckMpcorbDatUpdate.Image = FatcowIcons16px.fatcow_database_lightning_16px;
+		toolStripButtonCheckMpcorbDatUpdate.ImageTransparentColor = Color.Magenta;
+		toolStripButtonCheckMpcorbDatUpdate.Name = "toolStripButtonCheckMpcorbDatUpdate";
+		toolStripButtonCheckMpcorbDatUpdate.Size = new Size(23, 22);
+		toolStripButtonCheckMpcorbDatUpdate.Text = "Check MPCORB.DAT update";
+		toolStripButtonCheckMpcorbDatUpdate.Click += CheckMpcorbDatUpdate_Click;
+		toolStripButtonCheckMpcorbDatUpdate.MouseEnter += Control_Enter;
+		toolStripButtonCheckMpcorbDatUpdate.MouseLeave += Control_Leave;
 		// 
 		// toolStripButtonDownloadMpcorbDat
 		// 
@@ -4090,7 +4089,7 @@ partial class PlanetoidDbForm
 		toolStripButtonDownloadMpcorbDat.Name = "toolStripButtonDownloadMpcorbDat";
 		toolStripButtonDownloadMpcorbDat.Size = new Size(23, 22);
 		toolStripButtonDownloadMpcorbDat.Text = "Download MPCORB.DAT";
-		toolStripButtonDownloadMpcorbDat.Click += ToolStripButtonDownloadMpcorbDat_Click;
+		toolStripButtonDownloadMpcorbDat.Click += DownloadMpcorbDat_Click;
 		toolStripButtonDownloadMpcorbDat.MouseEnter += Control_Enter;
 		toolStripButtonDownloadMpcorbDat.MouseLeave += Control_Leave;
 		// 
@@ -4115,7 +4114,7 @@ partial class PlanetoidDbForm
 		toolStripButtonAbout.Name = "toolStripButtonAbout";
 		toolStripButtonAbout.Size = new Size(23, 22);
 		toolStripButtonAbout.Text = "About";
-		toolStripButtonAbout.Click += ToolStripButtonAbout_Click;
+		toolStripButtonAbout.Click += About_Click;
 		toolStripButtonAbout.MouseEnter += Control_Enter;
 		toolStripButtonAbout.MouseLeave += Control_Leave;
 		// 
@@ -4130,7 +4129,7 @@ partial class PlanetoidDbForm
 		toolStripButtonLicense.Name = "toolStripButtonLicense";
 		toolStripButtonLicense.Size = new Size(23, 22);
 		toolStripButtonLicense.Text = "License";
-		toolStripButtonLicense.Click += ToolStripButtonLicense_Click;
+		toolStripButtonLicense.Click += License_Click;
 		toolStripButtonLicense.MouseEnter += Control_Enter;
 		toolStripButtonLicense.MouseLeave += Control_Leave;
 		// 
@@ -4145,7 +4144,7 @@ partial class PlanetoidDbForm
 		toolStripButtonOpenWebsitePDB.Name = "toolStripButtonOpenWebsitePDB";
 		toolStripButtonOpenWebsitePDB.Size = new Size(23, 22);
 		toolStripButtonOpenWebsitePDB.Text = "Open Planetoid-DB homepage";
-		toolStripButtonOpenWebsitePDB.Click += ToolStripButtonOpenWebsitePDB_Click;
+		toolStripButtonOpenWebsitePDB.Click += OpenWebsitePDB_Click;
 		toolStripButtonOpenWebsitePDB.MouseEnter += Control_Enter;
 		toolStripButtonOpenWebsitePDB.MouseLeave += Control_Leave;
 		// 
@@ -4182,7 +4181,7 @@ partial class PlanetoidDbForm
 		toolStripButtonLoadRandomMinorPlanet.Name = "toolStripButtonLoadRandomMinorPlanet";
 		toolStripButtonLoadRandomMinorPlanet.Size = new Size(23, 22);
 		toolStripButtonLoadRandomMinorPlanet.Text = "Random minor planet";
-		toolStripButtonLoadRandomMinorPlanet.Click += ToolStripButtonLoadRandomMinorPlanet_Click;
+		toolStripButtonLoadRandomMinorPlanet.Click += LoadRandomMinorPlanet_Click;
 		toolStripButtonLoadRandomMinorPlanet.MouseEnter += Control_Enter;
 		toolStripButtonLoadRandomMinorPlanet.MouseLeave += Control_Leave;
 		// 
@@ -4207,7 +4206,7 @@ partial class PlanetoidDbForm
 		toolStripButtonStepToBegin.Name = "toolStripButtonStepToBegin";
 		toolStripButtonStepToBegin.Size = new Size(23, 22);
 		toolStripButtonStepToBegin.Text = "Begin of the data";
-		toolStripButtonStepToBegin.Click += ToolStripButtonStepToBegin_Click;
+		toolStripButtonStepToBegin.Click += NavigateToTheBegin_Click;
 		toolStripButtonStepToBegin.MouseEnter += Control_Enter;
 		toolStripButtonStepToBegin.MouseLeave += Control_Leave;
 		// 
@@ -4222,7 +4221,7 @@ partial class PlanetoidDbForm
 		toolStripButtonStepBackwardOne.Name = "toolStripButtonStepBackwardOne";
 		toolStripButtonStepBackwardOne.Size = new Size(23, 22);
 		toolStripButtonStepBackwardOne.Text = "Navigate to the previous data";
-		toolStripButtonStepBackwardOne.Click += ToolStripButtonStepBackwardOne_Click;
+		toolStripButtonStepBackwardOne.Click += NavigateToThePreviousData_Click;
 		toolStripButtonStepBackwardOne.MouseEnter += Control_Enter;
 		toolStripButtonStepBackwardOne.MouseLeave += Control_Leave;
 		// 
@@ -4237,7 +4236,7 @@ partial class PlanetoidDbForm
 		toolStripButtonStepForwardOne.Name = "toolStripButtonStepForwardOne";
 		toolStripButtonStepForwardOne.Size = new Size(23, 22);
 		toolStripButtonStepForwardOne.Text = "Navigate to the next data";
-		toolStripButtonStepForwardOne.Click += ToolStripButtonStepForwardOne_Click;
+		toolStripButtonStepForwardOne.Click += NavigateToTheNextData_Click;
 		toolStripButtonStepForwardOne.MouseEnter += Control_Enter;
 		toolStripButtonStepForwardOne.MouseLeave += Control_Leave;
 		// 
@@ -4252,7 +4251,7 @@ partial class PlanetoidDbForm
 		toolStripButtonStepToEnd.Name = "toolStripButtonStepToEnd";
 		toolStripButtonStepToEnd.Size = new Size(23, 22);
 		toolStripButtonStepToEnd.Text = "End of the data";
-		toolStripButtonStepToEnd.Click += ToolStripButtonStepToEnd_Click;
+		toolStripButtonStepToEnd.Click += NavigateToTheEnd_Click;
 		toolStripButtonStepToEnd.MouseEnter += Control_Enter;
 		toolStripButtonStepToEnd.MouseLeave += Control_Leave;
 		// 
@@ -4316,7 +4315,7 @@ partial class PlanetoidDbForm
 		toolStripTextBoxGotoIndex.TextBoxTextAlign = HorizontalAlignment.Center;
 		toolStripTextBoxGotoIndex.Enter += Control_Enter;
 		toolStripTextBoxGotoIndex.Leave += Control_Leave;
-		toolStripTextBoxGotoIndex.KeyPress += ToolStripTextBoxGotoIndex_KeyPress;
+		toolStripTextBoxGotoIndex.KeyPress += GotoIndex_KeyPress;
 		toolStripTextBoxGotoIndex.MouseEnter += Control_Enter;
 		toolStripTextBoxGotoIndex.MouseLeave += Control_Leave;
 		// 
@@ -4331,7 +4330,7 @@ partial class PlanetoidDbForm
 		toolStripButtonGoToIndex.Name = "toolStripButtonGoToIndex";
 		toolStripButtonGoToIndex.Size = new Size(23, 22);
 		toolStripButtonGoToIndex.Text = "Go to index";
-		toolStripButtonGoToIndex.Click += ToolStripButtonGoToIndex_Click;
+		toolStripButtonGoToIndex.Click += GoToIndex_Click;
 		toolStripButtonGoToIndex.MouseEnter += Control_Enter;
 		toolStripButtonGoToIndex.MouseLeave += Control_Leave;
 		// 
@@ -4346,7 +4345,7 @@ partial class PlanetoidDbForm
 		toolStripButtonListReadableDesignations.Name = "toolStripButtonListReadableDesignations";
 		toolStripButtonListReadableDesignations.Size = new Size(23, 22);
 		toolStripButtonListReadableDesignations.Text = "List readable designations";
-		toolStripButtonListReadableDesignations.Click += ToolStripButtonListReadableDesignations_Click;
+		toolStripButtonListReadableDesignations.Click += ListReadableDesignations_Click;
 		toolStripButtonListReadableDesignations.MouseEnter += Control_Enter;
 		toolStripButtonListReadableDesignations.MouseLeave += Control_Leave;
 		// 
@@ -4371,7 +4370,7 @@ partial class PlanetoidDbForm
 		toolStripButtonDerivedOrbitElements.Name = "toolStripButtonDerivedOrbitElements";
 		toolStripButtonDerivedOrbitElements.Size = new Size(23, 22);
 		toolStripButtonDerivedOrbitElements.Text = "Derived orbit elements";
-		toolStripButtonDerivedOrbitElements.Click += ToolStripButtonDerivedOrbitElements_Click;
+		toolStripButtonDerivedOrbitElements.Click += DerivedOrbitElements_Click;
 		toolStripButtonDerivedOrbitElements.MouseEnter += Control_Enter;
 		toolStripButtonDerivedOrbitElements.MouseLeave += Control_Leave;
 		// 
@@ -4387,7 +4386,7 @@ partial class PlanetoidDbForm
 		toolStripButtonFilter.Name = "toolStripButtonFilter";
 		toolStripButtonFilter.Size = new Size(23, 22);
 		toolStripButtonFilter.Text = "Filter";
-		toolStripButtonFilter.Click += ToolStripButtonFilter_Click;
+		toolStripButtonFilter.Click += Filter_Click;
 		toolStripButtonFilter.MouseEnter += Control_Enter;
 		toolStripButtonFilter.MouseLeave += Control_Leave;
 		// 
@@ -4518,7 +4517,7 @@ partial class PlanetoidDbForm
     private ToolStripStatusLabel labelInformation;
     private ToolStripStatusLabel toolStripStatusLabelMpcorbDatUpdate;
     private KryptonToolStrip kryptonToolStripIcons;
-    private ToolStripButton toolStripButtonCheckMpcorbDat;
+    private ToolStripButton toolStripButtonCheckMpcorbDatUpdate;
     private ToolStripButton toolStripButtonDownloadMpcorbDat;
     private ToolStripButton toolStripButtonAbout;
     private ToolStripSeparator toolStripSeparator1;

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -957,7 +957,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 	/// <summary>Shows the MPCORB data check form.</summary>
 	/// <remarks>This method is used to check the MPCORB data for updates.</remarks>
-	private async void ShowMpcorbDatCheck()
+	private async void ShowMpcorbDatUpdateCheck()
 	{
 		// Check if the network is available before proceeding with the download
 		if (!NetworkInterface.GetIsNetworkAvailable())
@@ -979,7 +979,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 	/// <summary>Shows the ASTORB data check form.</summary>
 	/// <remarks>This method is used to check the ASTORB data for updates.</remarks>
-	private void ShowAstorbDatCheck()
+	private void ShowAstorbDatUpdateCheck()
 	{
 		// Check if the network is available before proceeding with the download
 		if (!NetworkInterface.GetIsNetworkAvailable())
@@ -1957,7 +1957,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="KeyPressEventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to ensure only numeric input is allowed in the ToolStripTextBoxGotoIndex.</remarks>
-	private void ToolStripTextBoxGotoIndex_KeyPress(object sender, KeyPressEventArgs e)
+	private void GotoIndex_KeyPress(object sender, KeyPressEventArgs e)
 	{
 		// Check if the pressed key is a control character or a digit
 		if (!char.IsControl(c: e.KeyChar) && !char.IsDigit(c: e.KeyChar))
@@ -1969,7 +1969,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		if (e.KeyChar == Convert.ToChar(value: Keys.Return, provider: CultureInfo.CurrentCulture))
 		{
 			// If the Enter key is pressed, trigger the click event for the ToolStripButtonGoToIndex
-			ToolStripButtonGoToIndex_Click(sender: null, e: null);
+			GoToIndex_Click(sender: null, e: null);
 		}
 	}
 
@@ -2001,55 +2001,13 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the archive.</remarks>
-	private void ToolStripMenuItemArchive_Click(object sender, EventArgs e) => ShowArchive();
-
-	/// <summary>Handles the click event for the ToolStripButtonArchive. Opens the archive.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the archive.</remarks>
-	private void ToolStripButtonArchive_Click(object sender, EventArgs e) => ShowArchive();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepToBegin. Navigates to the beginning of the data.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to navigate to the beginning of the data.</remarks>
-	private void ToolStripButtonStepToBegin_Click(object sender, EventArgs e) => NavigateToTheBeginOfTheData();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepBackward. Navigates backward by a specified step in the data.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to navigate backward by a specified step in the data.</remarks>
-	private void ToolStripButtonStepBackward_Click(object sender, EventArgs e) => NavigateSomeDataBackward();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepBackwardOne. Navigates to the previous data entry.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	///	<remarks>This method is used to navigate to the previous data entry.</remarks>
-	private void ToolStripButtonStepBackwardOne_Click(object sender, EventArgs e) => NavigateToThePreviousData();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepForwardOne. Navigates to the next data entry.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to navigate to the next data entry.</remarks>
-	private void ToolStripButtonStepForwardOne_Click(object sender, EventArgs e) => NavigateToTheNextData();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepForward. Navigates forward by a specified step in the data.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to navigate forward by a specified step in the data.</remarks>
-	private void ToolStripButtonStepForward_Click(object sender, EventArgs e) => NavigateSomeDataForward();
-
-	/// <summary>Handles the click event for the ToolStripButtonStepToEnd. Navigates to the end of the data.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	///	<remarks>This method is used to navigate to the end of the data.</remarks>
-	private void ToolStripButtonStepToEnd_Click(object sender, EventArgs e) => NavigateToTheEndOfTheData();
+	private void Archive_Click(object sender, EventArgs e) => ShowArchive();
 
 	/// <summary>Handles the click event for the ToolStripButtonGoToIndex. Navigates to the specified index in the data.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripButtonGoToIndex_Click(object? sender, EventArgs? e)
+	private void GoToIndex_Click(object? sender, EventArgs? e)
 	{
 		int pos = 0;
 		// Try to parse the index from the ToolStripTextBoxGotoIndex
@@ -2064,7 +2022,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			// Log the error message
 			logger.Error(message: ex.Message);
 			// Show an error message box with the exception message
-			ShowErrorMessage(message: $"{nameof(ToolStripButtonGoToIndex_Click)}  {ex.Message}");
+			ShowErrorMessage(message: $"{nameof(GoToIndex_Click)}  {ex.Message}");
 		}
 		// If the parsed index is out of range, show an error message
 		// Otherwise, navigate to the specified index
@@ -2083,23 +2041,17 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 	}
 
-	/// <summary>Handles the click event for the ToolStripMenuItemTerminology. Opens the terminology form with the specified index.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to open the terminology form with the specified index.</remarks>
-	private void ToolStripMenuItemTerminology_Click(object sender, EventArgs e) => OpenTerminology(index: 0);
-
 	/// <summary>Handles the click event for the ToolStripButtonTerminology. Opens the terminology form with the specified index.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the terminology form with the specified index.</remarks>
-	private void ToolStripButtonTerminology_Click(object sender, EventArgs e) => OpenTerminology(index: 0);
+	private void Terminology_Click(object sender, EventArgs e) => OpenTerminology(index: 0);
 
 	/// <summary>Handles the click event for the ToolStripMenuItem10. Sets the navigation step to 10 and updates the menu item checked state.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripMenuItem10_Click(object sender, EventArgs e)
+	private void NavigateStep10_Click(object sender, EventArgs e)
 	{
 		// Set the step position to 10
 		stepPosition = 10;
@@ -2113,7 +2065,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripMenuItem100_Click(object sender, EventArgs e)
+	private void NavigateStep100_Click(object sender, EventArgs e)
 	{
 		// Set the step position to 100
 		stepPosition = 100;
@@ -2127,7 +2079,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripMenuItem1000_Click(object sender, EventArgs e)
+	private void NavigateStep1000_Click(object sender, EventArgs e)
 	{
 		// Set the step position to 1000
 		stepPosition = 1000;
@@ -2141,7 +2093,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripMenuItem10000_Click(object sender, EventArgs e)
+	private void NavigateStep10000_Click(object sender, EventArgs e)
 	{
 		// Set the step position to 10000
 		stepPosition = 10000;
@@ -2155,7 +2107,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to a specific index in the data.</remarks>
-	private void ToolStripMenuItem100000_Click(object sender, EventArgs e)
+	private void NavigateStep100000_Click(object sender, EventArgs e)
 	{
 		// Set the step position to 100000
 		stepPosition = 100000;
@@ -2169,453 +2121,381 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to close the application.</remarks>
-	private void ToolStripMenuItemExit_Click(object sender, EventArgs e) => Close();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemAbout. Shows the application information form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the application information form.</remarks>
-	private void ToolStripMenuItemAbout_Click(object sender, EventArgs e) => ShowAppInfo();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemLicense. Shows the license form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the license form.</remarks>
-	private void ToolStripMenuItemLicense_Click(object sender, EventArgs e) => ShowLicense();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemOpenWebsitePDB. Opens the Planetoid Database website.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to open the Planetoid Database website.</remarks>
-	private void ToolStripMenuItemOpenWebsitePDB_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemHomepage);
+	private void Exit_Click(object sender, EventArgs e) => Close();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemOpenWebsiteMPC. Opens the Minor Planet Center website.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the Minor Planet Center website.</remarks>
-	private void ToolStripMenuItemOpenWebsiteMPC_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemWebsiteMpc);
+	private void OpenWebsiteMPC_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemWebsiteMpc);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemOpenMPCORBWebsite. Opens the MPCORB website.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the MPCORB website.</remarks>
-	private void ToolStripMenuItemOpenMPCORBWebsite_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemWebsiteMpcorb);
+	private void OpenMpcorbDatWebsite_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemWebsiteMpcorb);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemDownloadMpcorbDat. Shows the downloader form for the MPCORB database.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the downloader form for the MPCORB database.</remarks>
-	private void ToolStripMenuItemDownloadMpcorbDat_Click(object sender, EventArgs e) => ShowMpcorbDatDownloader();
+	private void DownloadMpcorbDat_Click(object sender, EventArgs e) => ShowMpcorbDatDownloader();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemDownloadAstorbDat. Shows the downloader form for the ASTORB database.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the downloader form for the ASTORB database.</remarks>
-	private void ToolStripMenuItemDownloadAstorbDat_Click(object sender, EventArgs e) => ShowAstorbDatDownloader();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemCheckMpcorbDat. Shows the MPCORB data check form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	///	<remarks>This method is used to show the MPCORB data check form.</remarks>
-	private void ToolStripMenuItemCheckMpcorbDat_Click(object sender, EventArgs e) => ShowMpcorbDatCheck();
+	private void DownloadAstorbDat_Click(object sender, EventArgs e) => ShowAstorbDatDownloader();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCheckAstorbDat. Shows the ASTORB data check form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the ASTORB data check form.</remarks>
-	private void ToolStripMenuItemCheckAstorbDat_Click(object sender, EventArgs e) => ShowAstorbDatCheck();
+	private void CheckAstorbDatUpdate_Click(object sender, EventArgs e) => ShowAstorbDatUpdateCheck();
 
 	/// <summary>Handles the click event for the ToolStripButtonCheckMpcorbDat. Shows the MPCORB data check form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>
 	///	This method is used to show the MPCORB data check form.</remarks>
-	private void ToolStripButtonCheckMpcorbDat_Click(object sender, EventArgs e) => ShowMpcorbDatCheck();
-
-	/// <summary>Handles the click event for the ToolStripButtonDownloadMpcorbDat. Shows the downloader form for the MPCORB database.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the downloader form for the MPCORB database.</remarks>
-	private void ToolStripButtonDownloadMpcorbDat_Click(object sender, EventArgs e) => ShowMpcorbDatDownloader();
+	private void CheckMpcorbDatUpdate_Click(object sender, EventArgs e) => ShowMpcorbDatUpdateCheck();
 
 	/// <summary>Handles the click event for the ToolStripButtonAbout. Shows the application information form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the application information form.</remarks>
-	private void ToolStripButtonAbout_Click(object sender, EventArgs e) => ShowAppInfo();
+	private void About_Click(object sender, EventArgs e) => ShowAppInfo();
 
 	/// <summary>Handles the click event for the ToolStripButtonOpenWebsitePDB. Opens the Planetoid Database website.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the Planetoid Database website.</remarks>
-	private void ToolStripButtonOpenWebsitePDB_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemHomepage);
+	private void OpenWebsitePDB_Click(object sender, EventArgs e) => OpenWebsite(fileName: Settings.Default.systemHomepage);
 
-	/// <summary>Handles the click event for the ToolStripButtonTableMode. Opens the table mode form.</summary>
+	/// <summary>Handles the click event for the TableMode button. Opens the table mode form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to open the table mode form.</remarks>
-	private void ToolStripButtonTableMode_Click(object sender, EventArgs e) => OpenTableMode();
+	private void TableMode_Click(object sender, EventArgs e) => OpenTableMode();
 
-	/// <summary>Handles the click event for the ToolStripMenuItemTableMode. Opens the table mode form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to open the table mode form.</remarks>
-	private void ToolStripMenuItemTableMode_Click(object sender, EventArgs e) => OpenTableMode();
-
-	/// <summary>Handles the click event for the ToolStripButtonDatabaseInformation. Shows the database information form.</summary>
+	/// <summary>Handles the click event for the DatabaseInformation_Click. Shows the database information form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>
 	///	This method is used to show the database information form.</remarks>
-	private void ToolStripButtonDatabaseInformation_Click(object sender, EventArgs e) => ShowDatabaseInformation();
-
-	/// <summary>Handles the click event for the ToolStripButtonPrint. Shows the print data sheet form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the print data sheet form.</remarks>
-	private void ToolStripButtonPrint_Click(object sender, EventArgs e) => PrintDataSheet();
+	private void DatabaseInformation_Click(object sender, EventArgs e) => ShowDatabaseInformation();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemPrint. Shows the print data sheet form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the print data sheet form.</remarks>
-	private void ToolStripMenuItemPrint_Click(object sender, EventArgs e) => PrintDataSheet();
+	private void PrintDataSheet_Click(object sender, EventArgs e) => PrintDataSheet();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemSearch. Shows the search form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the search form.</remarks>
-	private void ToolStripMenuItemSearch_Click(object sender, EventArgs e) => ShowSearch();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemDatabaseInformation. Shows the database information form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the database information form.</remarks>
-	private void ToolStripMenuItemDatabaseInformation_Click(object sender, EventArgs e) => ShowDatabaseInformation();
+	private void Search_Click(object sender, EventArgs e) => ShowSearch();
 
 	/// <summary>Handles the click event for the ToolStripButtonLoadRandomMinorPlanet. Loads a random minor planet from the database.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to load a random minor planet from the database.</remarks>
-	private void ToolStripButtonLoadRandomMinorPlanet_Click(object sender, EventArgs e) => LoadRandomMinorPlanet();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemRandomMinorPlanet. Loads a random minor planet from the database.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to load a random minor planet from the database.</remarks>
-	private void ToolStripMenuItemRandomMinorPlanet_Click(object sender, EventArgs e) => LoadRandomMinorPlanet();
+	private void LoadRandomMinorPlanet_Click(object sender, EventArgs e) => LoadRandomMinorPlanet();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateToTheBegin. Navigates to the beginning of the data.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to the beginning of the data.</remarks>
-	private void ToolStripMenuItemNavigateToTheBegin_Click(object sender, EventArgs e) => NavigateToTheBeginOfTheData();
+	private void NavigateToTheBegin_Click(object sender, EventArgs e) => NavigateToTheBeginOfTheData();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateSomeDataBackward. Navigates backward by a specified step in the data.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate backward by a specified step in the data.</remarks>
-	private void ToolStripMenuItemNavigateSomeDataBackward_Click(object sender, EventArgs e) => NavigateSomeDataBackward();
+	private void NavigateSomeDataBackward_Click(object sender, EventArgs e) => NavigateSomeDataBackward();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateToThePreviousData. Navigates to the previous data entry.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to the previous data entry.</remarks>
-	private void ToolStripMenuItemNavigateToThePreviousData_Click(object sender, EventArgs e) => NavigateToThePreviousData();
+	private void NavigateToThePreviousData_Click(object sender, EventArgs e) => NavigateToThePreviousData();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateToTheNextData. Navigates to the next data entry.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to the next data entry.</remarks>
-	private void ToolStripMenuItemNavigateToTheNextData_Click(object sender, EventArgs e) => NavigateToTheNextData();
+	private void NavigateToTheNextData_Click(object sender, EventArgs e) => NavigateToTheNextData();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateSomeDataForward. Navigates forward by a specified step in the data.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate forward by a specified step in the data.</remarks>
-	private void ToolStripMenuItemNavigateSomeDataForward_Click(object sender, EventArgs e) => NavigateSomeDataForward();
+	private void NavigateSomeDataForward_Click(object sender, EventArgs e) => NavigateSomeDataForward();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemNavigateToTheEnd. Navigates to the end of the data.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to navigate to the end of the data.</remarks>
-	private void ToolStripMenuItemNavigateToTheEnd_Click(object sender, EventArgs e) => NavigateToTheEndOfTheData();
+	private void NavigateToTheEnd_Click(object sender, EventArgs e) => NavigateToTheEndOfTheData();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemSettings. Shows the settings form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the settings form.</remarks>
-	private void ToolStripMenuItemSettings_Click(object sender, EventArgs e) => ShowSettings();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemFilter. Shows the filter form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the filter form.</remarks>
-	private void ToolStripMenuItemFilter_Click(object sender, EventArgs e) => ShowFilter();
+	private void Settings_Click(object sender, EventArgs e) => ShowSettings();
 
 	/// <summary>Handles the click event for the ToolStripButtonFilter. Shows the filter form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the filter form.</remarks>
-	private void ToolStripButtonFilter_Click(object sender, EventArgs e) => ShowFilter();
+	private void Filter_Click(object sender, EventArgs e) => ShowFilter();
 
 	/// <summary>Handles the click event for the ToolStripButtonDerivedOrbitElements. Shows the derived orbit elements form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the derived orbit elements form.</remarks>
-	private void ToolStripButtonDerivedOrbitElements_Click(object sender, EventArgs e) => ShowDerivedOrbitElements();
+	private void DerivedOrbitElements_Click(object sender, EventArgs e) => ShowDerivedOrbitElements();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRestart. Restarts the application.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to restart the application.</remarks>
-	private void ToolStripMenuItemRestart_Click(object sender, EventArgs e) => Restart();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemDerivedtiveOrbitElements. Shows the derived orbit elements form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the derived orbit elements form.</remarks>
-	private void ToolStripMenuItemDerivedOrbitElements_Click(object sender, EventArgs e) => ShowDerivedOrbitElements();
+	private void Restart_Click(object sender, EventArgs e) => Restart();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemStayOnTop. Checks if the form should stay on top of other windows.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to check if the form should stay on top of other windows.</remarks>
-	private void ToolStripMenuItemStayOnTop_Click(object sender, EventArgs e) => CheckStayOnTop();
+	private void StayOnTop_Click(object sender, EventArgs e) => CheckStayOnTop();
 
 	/// <summary>Handles the click event for the ToolStripMenuIndexNumberCopyToClipboard_Click. Copies the index number to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the index number to the clipboard.</remarks>
-	private void ToolStripMenuIndexNumberCopyToClipboard_Click(object sender, EventArgs e) => CopyToClipboard(text: labelIndexData.Text);
+	private void CopyToClipboardIndexNumber_Click(object sender, EventArgs e) => CopyToClipboard(text: labelIndexData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardReadableDesignation. Copies the readable designation to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the readable designation to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardReadableDesignation_Click(object sender, EventArgs e) => CopyToClipboard(text: labelReadableDesignationData.Text);
+	private void CopyToClipboardReadableDesignation_Click(object sender, EventArgs e) => CopyToClipboard(text: labelReadableDesignationData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardEpoch. Copies the epoch to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the epoch to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardEpoch_Click(object sender, EventArgs e) => CopyToClipboard(text: labelEpochData.Text);
+	private void CopyToClipboardEpoch_Click(object sender, EventArgs e) => CopyToClipboard(text: labelEpochData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardMeanAnomaly. Copies the mean anomaly to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the mean anomaly to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardMeanAnomaly_Click(object sender, EventArgs e) => CopyToClipboard(text: labelMeanAnomalyAtTheEpochData.Text);
+	private void CopyToClipboardMeanAnomaly_Click(object sender, EventArgs e) => CopyToClipboard(text: labelMeanAnomalyAtTheEpochData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardArgumentOfThePerihelion. Copies the argument of perihelion to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the argument of perihelion to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardArgumentOfThePerihelion_Click(object sender, EventArgs e) => CopyToClipboard(text: labelArgumentOfThePerihelionData.Text);
+	private void CopyToClipboardArgumentOfThePerihelion_Click(object sender, EventArgs e) => CopyToClipboard(text: labelArgumentOfThePerihelionData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode. Copies the longitude of the ascending node to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the longitude of the ascending node to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardLongitudeOfTheAscendingNode_Click(object sender, EventArgs e) => CopyToClipboard(text: labelLongitudeOfTheAscendingNodeData.Text);
+	private void CopyToClipboardLongitudeOfTheAscendingNode_Click(object sender, EventArgs e) => CopyToClipboard(text: labelLongitudeOfTheAscendingNodeData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardInclinationToTheEcliptic. Copies the inclination to the ecliptic data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the inclination to the ecliptic data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardInclinationToTheEcliptic_Click(object sender, EventArgs e) => CopyToClipboard(text: labelInclinationToTheEclipticData.Text);
+	private void CopyToClipboardInclinationToTheEcliptic_Click(object sender, EventArgs e) => CopyToClipboard(text: labelInclinationToTheEclipticData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardOrbitalEccentricity. Copies the orbital eccentricity data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the orbital eccentricity data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardOrbitalEccentricity_Click(object sender, EventArgs e) => CopyToClipboard(text: labelOrbitalEccentricityData.Text);
+	private void CopyToClipboardOrbitalEccentricity_Click(object sender, EventArgs e) => CopyToClipboard(text: labelOrbitalEccentricityData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardMeanDailyMotion. Copies the mean daily motion data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the mean daily motion data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardMeanDailyMotion_Click(object sender, EventArgs e) => CopyToClipboard(text: labelMeanDailyMotionData.Text);
+	private void CopyToClipboardMeanDailyMotion_Click(object sender, EventArgs e) => CopyToClipboard(text: labelMeanDailyMotionData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardSemiMajorAxis. Copies the semi-major axis data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the semi-major axis data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardSemiMajorAxis_Click(object sender, EventArgs e) => CopyToClipboard(text: labelSemiMajorAxisData.Text);
+	private void CopyToClipboardSemiMajorAxis_Click(object sender, EventArgs e) => CopyToClipboard(text: labelSemiMajorAxisData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardAbsoluteMagnitude. Copies the absolute magnitude data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the absolute magnitude data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardAbsoluteMagnitude_Click(object sender, EventArgs e) => CopyToClipboard(text: labelAbsoluteMagnitudeData.Text);
+	private void CopyToClipboardAbsoluteMagnitude_Click(object sender, EventArgs e) => CopyToClipboard(text: labelAbsoluteMagnitudeData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardSlopeParameter. Copies the slope parameter data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the slope parameter data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardSlopeParameter_Click(object sender, EventArgs e) => CopyToClipboard(text: labelSlopeParameterData.Text);
+	private void CopyToClipboardSlopeParameter_Click(object sender, EventArgs e) => CopyToClipboard(text: labelSlopeParameterData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardReference. Copies the reference data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the reference data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardReference_Click(object sender, EventArgs e) => CopyToClipboard(text: labelReferenceData.Text);
+	private void CopyToClipboardReference_Click(object sender, EventArgs e) => CopyToClipboard(text: labelReferenceData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardNumberOfOppositions. Copies the number of oppositions data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the number of oppositions data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardNumberOfOppositions_Click(object sender, EventArgs e) => CopyToClipboard(text: labelNumberOfOppositionsData.Text);
+	private void CopyToClipboardNumberOfOppositions_Click(object sender, EventArgs e) => CopyToClipboard(text: labelNumberOfOppositionsData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardNumberOfObservations. Copies the number of observations data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the number of observations data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardNumberOfObservations_Click(object sender, EventArgs e) => CopyToClipboard(text: labelNumberOfObservationsData.Text);
+	private void CopyToClipboardNumberOfObservations_Click(object sender, EventArgs e) => CopyToClipboard(text: labelNumberOfObservationsData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardObservationSpan. Copies the observation span data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the observation span data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardObservationSpan_Click(object sender, EventArgs e) => CopyToClipboard(text: labelObservationSpanData.Text);
+	private void CopyToClipboardObservationSpan_Click(object sender, EventArgs e) => CopyToClipboard(text: labelObservationSpanData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardRmsResidual. Copies the RMS residual data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the RMS residual data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardRmsResidual_Click(object sender, EventArgs e) => CopyToClipboard(text: labelRmsResidualData.Text);
+	private void CopyToClipboardRmsResidual_Click(object sender, EventArgs e) => CopyToClipboard(text: labelRmsResidualData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardComputerName. Copies the computer name data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the computer name data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardComputerName_Click(object sender, EventArgs e) => CopyToClipboard(text: labelComputerNameData.Text);
+	private void CopyToClipboardComputerName_Click(object sender, EventArgs e) => CopyToClipboard(text: labelComputerNameData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardDateOfLastObservation. Copies the date of last observation data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the date of last observation data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardDateOfLastObservation_Click(object sender, EventArgs e) => CopyToClipboard(text: labelDateLastObservationData.Text);
+	private void CopyToClipboardDateOfLastObservation_Click(object sender, EventArgs e) => CopyToClipboard(text: labelDateLastObservationData.Text);
 
 	/// <summary>Handles the click event for the ToolStripMenuItemCopyToClipboardFlags. Copies the flags data to the clipboard.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to copy the flags data to the clipboard.</remarks>
-	private void ToolStripMenuItemCopyToClipboardFlags_Click(object sender, EventArgs e) => CopyToClipboard(text: labelFlagsData.Text);
+	private void CopyToClipboardFlags_Click(object sender, EventArgs e) => CopyToClipboard(text: labelFlagsData.Text);
 
 	/// <summary>Handles the click event for the ToolStripButtonExport. Exports the data sheet.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to export the data sheet.</remarks>
-	private void ToolStripButtonExport_Click(object sender, EventArgs e) => ExportDataSheet();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemRecordsTopTen. Shows the records selection form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the records selection form.</remarks>
-	private void ToolStripMenuItemRecordsTopTen_Click(object sender, EventArgs e) => ShowRecordsSelection();
+	private void Export_Click(object sender, EventArgs e) => ExportDataSheet();
 
 	/// <summary>Handles the button click event for the ToolStripSplitButtonTopTenRecords. Shows the records selection form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records selection form.</remarks>
-	private void ToolStripSplitButtonTopTenRecords_ButtonClick(object sender, EventArgs e) => ShowRecordsSelection();
+	private void Records_Click(object sender, EventArgs e) => ShowRecordsSelection();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsMeanAnomalyAtTheEpoch. Shows the main records form for mean anomaly at the epoch.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for mean anomaly at the epoch.</remarks>
-	private void ToolStripMenuItemRecordsMeanAnomalyAtTheEpoch_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsMeanAnomalyAtTheEpoch_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsArgumentOfThePerihelion. Shows the main records form for argument of perihelion.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for argument of perihelion.</remarks>
-	private void ToolStripMenuItemRecordsArgumentOfThePerihelion_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsArgumentOfThePerihelion_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsLongitudeOfTheAscendingNode. Shows the main records form for the longitude of the ascending node.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for the longitude of the ascending node.</remarks>
-	private void ToolStripMenuItemRecordsLongitudeOfTheAscendingNode_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsLongitudeOfTheAscendingNode_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsInclination. Shows the main records form for inclination.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for inclination.</remarks>
-	private void ToolStripMenuItemRecordsInclination_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsInclination_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsOrbitalEccentricity. Shows the main records form for orbital eccentricity.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for orbital eccentricity.</remarks>
-	private void ToolStripMenuItemRecordsOrbitalEccentricity_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsOrbitalEccentricity_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsMeanDailyMotion. Shows the main records form for mean daily motion.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for mean daily motion.</remarks>
-	private void ToolStripMenuItemRecordsMeanDailyMotion_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsMeanDailyMotion_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsSemiMajorAxis. Shows the main records form for semi-major axis.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for semi-major axis.</remarks>
-	private void ToolStripMenuItemRecordsSemiMajorAxis_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsSemiMajorAxis_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsAbsoluteMagnitude. Shows the main records form for absolute magnitude.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for absolute magnitude.</remarks>
-	private void ToolStripMenuItemRecordsAbsoluteMagnitude_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsAbsoluteMagnitude_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsSlopeParameter. Shows the main records form for slope parameter.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for slope parameter.</remarks>
-	private void ToolStripMenuItemRecordsSlopeParameter_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsSlopeParameter_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsNumberOfOppositions. Shows the main records form for number of oppositions.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for number of oppositions.</remarks>
-	private void ToolStripMenuItemRecordsNumberOfOppositions_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsNumberOfOppositions_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsNumberOfObservations. Shows the main records form for number of observations.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for number of observations.</remarks>
-	private void ToolStripMenuItemRecordsNumberOfObservations_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsNumberOfObservations_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsObservationSpan. Shows the main records form for observation span.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for observation span.</remarks>
-	private void ToolStripMenuItemRecordsObservationSpan_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsObservationSpan_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsRmsResidual. Shows the main records form for RMS residual.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for RMS residual.</remarks>
-	private void ToolStripMenuItemRecordsRmsResidual_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsRmsResidual_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsComputerName. Shows the main records form for computer name.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for computer name.</remarks>
-	private void ToolStripMenuItemRecordsComputerName_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsComputerName_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemRecordsDateOfTheLastObservation. Shows the main records form for date of the last observation.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the records main form for date of the last observation.</remarks>
-	private void ToolStripMenuItemRecordsDateOfTheLastObservation_Click(object sender, EventArgs e) => ShowRecordsMain();
+	private void RecordsDateOfTheLastObservation_Click(object sender, EventArgs e) => ShowRecordsMain();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemDistributionMeanAnomalyAtTheEpoch. Shows the distribution form for mean anomaly at the epoch.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for mean anomaly at the epoch.</remarks>
-	private void ToolStripMenuItemDistributionMeanAnomalyAtTheEpoch_Click(object sender, EventArgs e)
+	private void DistributionMeanAnomalyAtTheEpoch_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2625,7 +2505,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for argument of perihelion.</remarks>
-	private void ToolStripMenuItemDistributionArgumentOfThePerihelion_Click(object sender, EventArgs e)
+	private void DistributionArgumentOfThePerihelion_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2635,7 +2515,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for longitude of the ascending node.</remarks>
-	private void ToolStripMenuItemDistributionLongitudeOfTheAscendingNode_Click(object sender, EventArgs e)
+	private void DistributionLongitudeOfTheAscendingNode_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2645,7 +2525,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for inclination.</remarks>
-	private void ToolStripMenuItemDistributionInclination_Click(object sender, EventArgs e)
+	private void DistributionInclination_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2655,7 +2535,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for orbital eccentricity.</remarks>
-	private void ToolStripMenuItemDistributionOrbitalEccentricity_Click(object sender, EventArgs e)
+	private void DistributionOrbitalEccentricity_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2665,7 +2545,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for mean daily motion.</remarks>
-	private void ToolStripMenuItemDistributionMeanDailyMotion_Click(object sender, EventArgs e)
+	private void DistributionMeanDailyMotion_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2675,7 +2555,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for semi-major axis.</remarks>
-	private void ToolStripMenuItemDistributionSemiMajorAxis_Click(object sender, EventArgs e)
+	private void DistributionSemiMajorAxis_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2685,7 +2565,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for absolute magnitude.</remarks>
-	private void ToolStripMenuItemDistributionAbsoluteMagnitude_Click(object sender, EventArgs e)
+	private void DistributionAbsoluteMagnitude_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2695,7 +2575,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for slope parameter.</remarks>
-	private void ToolStripMenuItemDistributionSlopeParameter_Click(object sender, EventArgs e)
+	private void DistributionSlopeParameter_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2705,7 +2585,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for number of oppositions.</remarks>
-	private void ToolStripMenuItemDistributionNumberOfOppositions_Click(object sender, EventArgs e)
+	private void DistributionNumberOfOppositions_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2715,7 +2595,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for number of observations.</remarks>
-	private void ToolStripMenuItemDistributionNumberOfObservations_Click(object sender, EventArgs e)
+	private void DistributionNumberOfObservations_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2725,7 +2605,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for observation span.</remarks>
-	private void ToolStripMenuItemDistributionObservationSpan_Click(object sender, EventArgs e)
+	private void DistributionObservationSpan_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2735,7 +2615,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for RMS residual.</remarks>
-	private void ToolStripMenuItemDistributionRmsResidual_Click(object sender, EventArgs e)
+	private void DistributionRmsResidual_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2745,7 +2625,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for computer name.</remarks>
-	private void ToolStripMenuItemDistributionComputerName_Click(object sender, EventArgs e)
+	private void DistributionComputerName_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
@@ -2755,141 +2635,107 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>This method is used to show the distribution form for the selected parameter.</remarks>
-	private void ToolStripSplitButtonDistribution_ButtonClick(object sender, EventArgs e)
+	private void Distributions_Click(object sender, EventArgs e)
 	{
 		// TODO: Not implemented yet
 		ShowErrorMessage(message: "Not implemented yet");
 	}
-
-	/// <summary>Handles the click event for the ToolStripMenuItemDistribution. Shows the distribution form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the distribution form for the selected parameter.</remarks>
-	private void ToolStripMenuItemDistribution_Click(object sender, EventArgs e)
-	{
-		// TODO: Not implemented yet
-		ShowErrorMessage(message: "Not implemented yet");
-	}
-
-	/// <summary>Handles the click event for the ToolStripButtonListReadableDesignations. Lists readable designations.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the distribution form for the selected parameter.</remarks>
-	private void ToolStripButtonListReadableDesignations_Click(object sender, EventArgs e) => ListReadableDesignations();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemListReadableDesignations. Lists readable designations.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the distribution form for the selected parameter.</remarks>
-	private void ToolStripMenuItemListReadableDesignations_Click(object sender, EventArgs e) => ListReadableDesignations();
+	private void ListReadableDesignations_Click(object sender, EventArgs e) => ListReadableDesignations();
 
 	/// <summary>Handles the click event for the ToolStripButtonLicense. Opens the license.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the license.</remarks>
-	private void ToolStripButtonLicense_Click(object sender, EventArgs e) => ShowLicense();
+	private void License_Click(object sender, EventArgs e) => ShowLicense();
 
 	/// <summary>Handles the click event for the Compare Databases menu item and initiates the process to compare database archives.</summary>
 	/// <remarks>This method is intended to be used as an event handler for a menu item click event. It delegates the comparison operation to the ShowCompareArchives method.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemCompareDatabases_Click(object sender, EventArgs e) => ShowCompareArchives();
-
-	/// <summary>Handles the Click event of the Compare Databases button to initiate the comparison of database archives.	</summary>
-	/// <remarks>This method displays the interface for comparing selected database archives. It is intended to be used as an event handler for the Compare Databases button in the application's toolbar.</remarks>
-	/// <param name="sender">The source of the event, typically the Compare Databases button.</param>
-	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripButtonCompareDatabases_Click(object sender, EventArgs e) => ShowCompareArchives();
+	private void CompareDatabases_Click(object sender, EventArgs e) => ShowCompareArchives();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemOrbitalResonances. Shows the orbital resonances form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the orbital resonances form.</remarks>
-	private void ToolStripMenuItemOrbitalResonances_Click(object sender, EventArgs e) => ShowOrbitalResonances();
-
-	/// <summary>Handles the click event for the ToolStripMenuItemObservations. Shows the observations form.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the observations form.</remarks>
-	private void ToolStripMenuItemObservations_Click(object sender, EventArgs e) => ShowObservations();
+	private void OrbitalResonances_Click(object sender, EventArgs e) => ShowOrbitalResonances();
 
 	/// <summary>Handles the Click event of the ToolStripButtonObservations. Shows the observations form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the observations form.</remarks>
-	private void ToolStripButtonObservations_Click(object sender, EventArgs e) => ShowObservations();
+	private void Observations_Click(object sender, EventArgs e) => ShowObservations();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemOrbitElementsGrouping. Shows the orbit elements grouping form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the orbit elements grouping form.</remarks>
-	private void ToolStripMenuItemOrbitElementsGrouping_Click(object sender, EventArgs e) => ShowOrbitElementsGrouping();
+	private void OrbitElementsGrouping_Click(object sender, EventArgs e) => ShowOrbitElementsGrouping();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemAsteroidFamiliesDetection. Shows the asteroid families form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the asteroid families form.</remarks>
-	private void ToolStripMenuItemAsteroidFamiliesDetection_Click(object sender, EventArgs e) => ShowAsteroidFamiliesDetection();
+	private void AsteroidFamiliesDetection_Click(object sender, EventArgs e) => ShowAsteroidFamiliesDetection();
 
 	/// <summary>Handles the click event for the MenuitemOrbitalResonancesOfAllMinorPlanets. Shows the orbital resonances of all minor planets form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the orbital resonances of all minor planets form.</remarks>
-	private void ToolStripMenuitemOrbitalResonancesOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowOrbitalResonancesOfAllMinorPlanets();
+	private void OrbitalResonancesOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowOrbitalResonancesOfAllMinorPlanets();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemMoids. Shows the MOIDs form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the MOIDs form for the currently selected minor planet.</remarks>
-	private void ToolStripMenuItemMoids_Click(object sender, EventArgs e) => ShowMoids();
+	private void Moids_Click(object sender, EventArgs e) => ShowMoids();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemMoidsOfAllMinorPlanets. Shows the MOIDs of all minor planets form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the MOIDs of all minor planets form.</remarks>
-	private void ToolStripMenuItemMoidsOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowMoidsOfAllMinorPlanets();
+	private void MoidsOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowMoidsOfAllMinorPlanets();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemTisserandParameters. Shows the Tisserand parameters form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the Tisserand parameters form for the currently selected minor planet.</remarks>
-	private void ToolStripMenuItemTisserandParameters_Click(object sender, EventArgs e) => ShowTisserandParameters();
+	private void TisserandParameters_Click(object sender, EventArgs e) => ShowTisserandParameters();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemTisserandParametersOfAllMinorPlanets. Shows the Tisserand parameters of all minor planets form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the Tisserand parameters of all minor planets form.</remarks>
-	private void ToolStripMenuItemTisserandParametersOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowTisserandParametersOfAllMinorPlanets();
+	private void TisserandParametersOfAllMinorPlanets_Click(object sender, EventArgs e) => ShowTisserandParametersOfAllMinorPlanets();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemBulkObservationDataDownloader_Click. Shows the bulk observations data downloader form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to show the bulk observations data downloader form.</remarks>
-	private void ToolStripMenuItemBulkObservationDataDownloader_Click(object sender, EventArgs e) => ShowBulkObservationDataDownloader();
+	private void BulkObservationDataDownloader_Click(object sender, EventArgs e) => ShowBulkObservationDataDownloader();
 
 	/// <summary>Handles the click event for the ToolStripMenuItemMoidsRelativeToMinorPlanets. Shows the MOIDs relative to minor planets form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method opens the form for calculating the MOID between two user-selected minor planets.</remarks>
-	private void ToolStripMenuItemMoidsRelativeToMinorPlanets_Click(object sender, EventArgs e) => ShowMoidsRelativeToMinorPlanets();
-
-	/// <summary>Handles the click event for opening a local MPCORB.DAT file. Opens a file dialog to select a local MPCORB.DAT file, and if a valid file is selected, restarts the application with the selected file path as a command-line argument.</summary>
-	/// <param name="sender">The event source.</param>
-	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method allows the user to select a custom local MPCORB.DAT file instead of using the default one.</remarks>
-	private void ToolStripMenuItemOpenLocalMpcorbDat_Click(object sender, EventArgs e) => OpenLocalMpcorbDat();
+	private void MoidsRelativeToMinorPlanets_Click(object sender, EventArgs e) => ShowMoidsRelativeToMinorPlanets();
 
 	/// <summary>Handles the click event for the toolbar button that opens a local MPCORB.DAT file. Opens a file dialog to select a local MPCORB.DAT file, and if a valid file is selected, restarts the application with the selected file path as a command-line argument.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method allows the user to select a custom local MPCORB.DAT file instead of using the default one.</remarks>
-	private void ToolStripButtonOpenLocalMpcorbDat_Click(object sender, EventArgs e) => OpenLocalMpcorbDat();
+	private void OpenLocalMpcorbDat_Click(object sender, EventArgs e) => OpenLocalMpcorbDat();
 
 	/// <summary>Handles the Click event for the MPC Database menu item and opens the Minor Planet Center database page for the selected object.</summary>
 	/// <remarks>This method constructs a URL to the Minor Planet Center database using the current object's identifier and opens it in the default web browser.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemMpcDatabase_Click(object sender, EventArgs e)
+	private void OpenDataPageMpcDatabase_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://www.minorplanetcenter.net/db_search/show_object?utf8=%E2%9C%93&object_id=" + labelIndexData.Text;
 		OpenWebsite(fileName: dataPageUrl);
@@ -2899,7 +2745,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This event handler constructs a URL to the JPL Small-Body Database using the current value of the index label and opens it in the user's default web browser.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemJplSmallBodyDatabase_Click(object sender, EventArgs e)
+	private void OpenDataPageJplSmallBodyDatabase_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=" + labelIndexData.Text + "&view=OPDA";
 		OpenWebsite(fileName: dataPageUrl);
@@ -2909,7 +2755,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This event handler constructs a URL for the Lowell Observatory's asteroid search page based on the current designation and opens it in the default web browser.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemLowellMinorPlanetServices_Click(object sender, EventArgs e)
+	private void OpenDataPageLowellMinorPlanetServices_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://asteroid.lowell.edu/gui/search/" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
 		OpenWebsite(fileName: dataPageUrl);
@@ -2919,7 +2765,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This event handler constructs a URL for the selected asteroid using its readable designation and opens the associated data page in the default web browser.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemAsteroidsDynamicSite_Click(object sender, EventArgs e)
+	private void OpenDataPageAsteroidsDynamicSite_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://newton.spacedys.com/astdys/index.php?pc=1.1.0&n=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
 		OpenWebsite(fileName: dataPageUrl);
@@ -2929,7 +2775,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method constructs a URL for the Near-Earth Objects dynamic site using the current designation and opens it in the default web browser.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemNearEarthObjectsDynamicSite_Click(object sender, EventArgs e)
+	private void OpenDataPageNearEarthObjectsDynamicSite_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://newton.spacedys.com/neodys/index.php?pc=1.1.0&n=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
 		OpenWebsite(fileName: dataPageUrl);
@@ -2939,7 +2785,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This event handler constructs a URL to the ESA Near-Earth Object Coordination Centre based on the current designation and opens it in the default web browser. Use this handler to provide quick access to detailed asteroid information from the application.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemNearEarthObjectCoordinationCentre_Click(object sender, EventArgs e)
+	private void OpenDataPageEarthObjectCoordinationCentre_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://neo.ssa.esa.int/search-for-asteroids?tab=summary&des=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
 		OpenWebsite(fileName: dataPageUrl);
@@ -2950,14 +2796,14 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method constructs URLs for multiple astronomical data sources using the current object's identifiers and opens each page in the default web browser. The method is intended to provide quick access to external resources for further information about the selected object.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void ToolStripMenuItemOpenAllDataPages_Click(object sender, EventArgs e)
+	private void OpenAllDataPages_Click(object sender, EventArgs e)
 	{
-		ToolStripMenuItemMpcDatabase_Click(sender: sender, e: e);
-		ToolStripMenuItemJplSmallBodyDatabase_Click(sender: sender, e: e);
-		ToolStripMenuItemLowellMinorPlanetServices_Click(sender: sender, e: e);
-		ToolStripMenuItemAsteroidsDynamicSite_Click(sender: sender, e: e);
-		ToolStripMenuItemNearEarthObjectsDynamicSite_Click(sender: sender, e: e);
-		ToolStripMenuItemNearEarthObjectCoordinationCentre_Click(sender: sender, e: e);
+		OpenDataPageMpcDatabase_Click(sender: sender, e: e);
+		OpenDataPageJplSmallBodyDatabase_Click(sender: sender, e: e);
+		OpenDataPageLowellMinorPlanetServices_Click(sender: sender, e: e);
+		OpenDataPageAsteroidsDynamicSite_Click(sender: sender, e: e);
+		OpenDataPageNearEarthObjectsDynamicSite_Click(sender: sender, e: e);
+		OpenDataPageEarthObjectCoordinationCentre_Click(sender: sender, e: e);
 	}
 
 	/// <summary>Handles the Click event for the label that displays MPCORB flag data and initiates decoding of the flags.</summary>
@@ -2976,7 +2822,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The source of the event, typically the Observatory Codes button.</param>
 	/// <param name="e">An <see cref="EventArgs"/> object that contains the event data.</param>
 	/// <remarks>Opens the <see cref="ObservatoryCodesForm"/> as a modal dialog to display the list of observatory codes.</remarks>
-	private void ToolStripMenuItemObservatoryCodes_Click(object sender, EventArgs e)
+	private void ObservatoryCodes_Click(object sender, EventArgs e)
 	{
 		// Open the ObservatoryCodesForm as a modal dialog to display the list of observatory codes. The form is set to be topmost based on the current state of the main form to ensure it appears above other windows.
 		using ObservatoryCodesForm formObservatoryCodes = new();
@@ -3020,7 +2866,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to set the icon set to Fatcow.</remarks>
-	private void ToolStripMenuItemIconSetFatcow_Click(object sender, EventArgs e)
+	private void IconSetFatcow_Click(object sender, EventArgs e)
 	{
 		// TODO: Implement icon set change to Fatcow
 		_ = KryptonMessageBox.Show(text: "Fatcow icon set not implemented yet", caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
@@ -3030,7 +2876,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to set the icon set to Silk.</remarks>
-	private void ToolStripMenuItemIconSetSilk_Click(object sender, EventArgs e)
+	private void IconSetSilk_Click(object sender, EventArgs e)
 	{
 		// TODO: Implement icon set change to Silk
 		_ = KryptonMessageBox.Show(text: "Silk icon set not implemented yet", caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
@@ -3040,7 +2886,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method is used to set the icon set to Fugue.</remarks>
-	private void ToolStripMenuItemIconSetFugue_Click(object sender, EventArgs e)
+	private void IconSetFugue_Click(object sender, EventArgs e)
 	{
 		// TODO: Implement icon set change to Fugue
 		_ = KryptonMessageBox.Show(text: "Fugue icon set not implemented yet", caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
@@ -3050,7 +2896,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method toggles the option to enable copying data by double-clicking on controls.</remarks>
-	private void ToolStripMenuItemEnableCopyingByDoubleClicking_Click(object sender, EventArgs e)
+	private void EnableCopyingByDoubleClicking_Click(object sender, EventArgs e)
 	{
 		// TODO: Implement enable/disable copying by double-clicking
 		_ = KryptonMessageBox.Show(text: "Enable copying by double-clicking not implemented yet", caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
@@ -3060,7 +2906,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>This method toggles the option to enable linking to terminology.</remarks>
-	private void ToolStripMenuItemEnableLinkingToTerminology_Click(object sender, EventArgs e)
+	private void EnableLinkingToTerminology_Click(object sender, EventArgs e)
 	{
 		// TODO: Implement enable/disable linking to terminology
 		_ = KryptonMessageBox.Show(text: "Enable linking to terminology not implemented yet", caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -2153,7 +2153,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method is used to show the ASTORB data check form.</remarks>
 	private void CheckAstorbDatUpdate_Click(object sender, EventArgs e) => ShowAstorbDatUpdateCheck();
 
-	/// <summary>Handles the click event for the ToolStripButtonCheckMpcorbDat. Shows the MPCORB data check form.</summary>
+	/// <summary>Handles the click event for the ToolStripButtonCheckMpcorbDatUpdate. Shows the MPCORB data check form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>
@@ -2178,7 +2178,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method is used to open the table mode form.</remarks>
 	private void TableMode_Click(object sender, EventArgs e) => OpenTableMode();
 
-	/// <summary>Handles the click event for the DatabaseInformation_Click. Shows the database information form.</summary>
+	/// <summary>Handles the click event for the ToolStripButtonDatabaseInformation. Shows the database information form.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>
@@ -2785,7 +2785,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This event handler constructs a URL to the ESA Near-Earth Object Coordination Centre based on the current designation and opens it in the default web browser. Use this handler to provide quick access to detailed asteroid information from the application.</remarks>
 	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
 	/// <param name="e">An EventArgs object that contains the event data.</param>
-	private void OpenDataPageEarthObjectCoordinationCentre_Click(object sender, EventArgs e)
+	private void OpenDataPageNearEarthObjectCoordinationCentre_Click(object sender, EventArgs e)
 	{
 		string dataPageUrl = "https://neo.ssa.esa.int/search-for-asteroids?tab=summary&des=" + ProcessDesignationForUrl(input: labelReadableDesignationData.Text);
 		OpenWebsite(fileName: dataPageUrl);
@@ -2803,7 +2803,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		OpenDataPageLowellMinorPlanetServices_Click(sender: sender, e: e);
 		OpenDataPageAsteroidsDynamicSite_Click(sender: sender, e: e);
 		OpenDataPageNearEarthObjectsDynamicSite_Click(sender: sender, e: e);
-		OpenDataPageEarthObjectCoordinationCentre_Click(sender: sender, e: e);
+		OpenDataPageNearEarthObjectCoordinationCentre_Click(sender: sender, e: e);
 	}
 
 	/// <summary>Handles the Click event for the label that displays MPCORB flag data and initiates decoding of the flags.</summary>


### PR DESCRIPTION
This PR renames many `PlanetoidDBForm` controls and event handlers to more concise/action-oriented names, primarily in the main form and its designer wiring.

**Changes:**
- Renamed event handler methods and updated designer event subscriptions.
- Renamed the MPCORB update-check toolbar button.
- Reordered some shared dropdown initialization/ownership assignments.