### PR TITLE
Redesigned `RecordsForm`

### DIFF
--- a/Forms/RecordsForm.Designer.cs
+++ b/Forms/RecordsForm.Designer.cs
@@ -863,7 +863,7 @@ partial class RecordsForm
 		toolStripMenuItemCopyToClipboardInContextMenu.AutoToolTip = true;
 		toolStripMenuItemCopyToClipboardInContextMenu.Image = FatcowIcons16px.fatcow_page_copy_16px;
 		toolStripMenuItemCopyToClipboardInContextMenu.Name = "toolStripMenuItemCopyToClipboardInContextMenu";
-		toolStripMenuItemCopyToClipboardInContextMenu.ShortcutKeyDisplayString = "Strg+C";
+		toolStripMenuItemCopyToClipboardInContextMenu.ShortcutKeyDisplayString = "Ctrl+C";
 		toolStripMenuItemCopyToClipboardInContextMenu.ShortcutKeys = Keys.Control | Keys.C;
 		toolStripMenuItemCopyToClipboardInContextMenu.Size = new Size(213, 22);
 		toolStripMenuItemCopyToClipboardInContextMenu.Text = "&Copy to clipboard";
@@ -922,7 +922,7 @@ partial class RecordsForm
 		labelElementMeanAnomalyAtTheEpoch.TabIndex = 3;
 		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Description = "Mean anomaly at the epoch";
 		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.EnableToolTips = true;
-		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Heading = "Mean enomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Heading = "Mean anomaly at the epoch";
 		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
 		labelElementMeanAnomalyAtTheEpoch.Values.Text = "Mean anomaly at the epoch";
 		labelElementMeanAnomalyAtTheEpoch.Enter += Control_Enter;
@@ -1568,7 +1568,7 @@ partial class RecordsForm
 		// 
 		// labelValueNumberOfOppositions
 		// 
-		labelValueNumberOfOppositions.AccessibleDescription = "Shows the record value for the number of pppositions";
+		labelValueNumberOfOppositions.AccessibleDescription = "Shows the record value for the number of oppositions";
 		labelValueNumberOfOppositions.AccessibleName = "Record value for the number of oppositions";
 		labelValueNumberOfOppositions.AccessibleRole = AccessibleRole.StaticText;
 		labelValueNumberOfOppositions.ContextMenuStrip = contextMenuCopyToClipboard;

--- a/Forms/RecordsForm.Designer.cs
+++ b/Forms/RecordsForm.Designer.cs
@@ -40,66 +40,116 @@ partial class RecordsForm
 		components = new Container();
 		ComponentResourceManager resources = new ComponentResourceManager(typeof(RecordsForm));
 		kryptonPanelMain = new KryptonPanel();
-		groupBoxRecordType = new KryptonGroupBox();
-		checkButtonMax = new KryptonCheckButton();
-		checkButtonMin = new KryptonCheckButton();
 		tableLayoutPanel = new KryptonTableLayoutPanel();
+		contextMenuSaveToFile = new ContextMenuStrip(components);
+		toolStripMenuItemTextFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsLatex = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMarkdown = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAsciiDoc = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsReStructuredText = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTextile = new ToolStripMenuItem();
+		toolStripMenuItemWriterDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWord = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOdt = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsRtf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsAbiword = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsWps = new ToolStripMenuItem();
+		toolStripMenuItemSpreadsheetDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsExcel = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsOds = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsCsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsTsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPsv = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEt = new ToolStripMenuItem();
+		toolStripMenuItemXmlDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsHtml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsDocBook = new ToolStripMenuItem();
+		toolStripMenuItemConfigurationFiles = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsJson = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsToml = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsYaml = new ToolStripMenuItem();
+		toolStripMenuItemDatabaseScripts = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSql = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsSqlite = new ToolStripMenuItem();
+		toolStripMenuItemPortableDocuments = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPdf = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsPostScript = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsEpub = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsMobi = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsXps = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsFictionBook2 = new ToolStripMenuItem();
+		toolStripMenuItemSaveAsChm = new ToolStripMenuItem();
+		toolStripDropDownButtonSaveList = new ToolStripDropDownButton();
 		labelElementHeader = new KryptonLabel();
+		contextMenuCopyToClipboard = new ContextMenuStrip(components);
+		toolStripMenuItemCopyToClipboardInContextMenu = new ToolStripMenuItem();
 		labelDesignationHeader = new KryptonLabel();
 		labelValueHeader = new KryptonLabel();
-		labelElement01 = new KryptonLabel();
-		labelDesignation01 = new KryptonLabel();
-		labelValue01 = new KryptonLabel();
-		labelElement02 = new KryptonLabel();
-		labelDesignation02 = new KryptonLabel();
-		labelValue02 = new KryptonLabel();
-		labelElement03 = new KryptonLabel();
-		labelDesignation03 = new KryptonLabel();
-		labelValue03 = new KryptonLabel();
-		labelElement04 = new KryptonLabel();
-		labelDesignation04 = new KryptonLabel();
-		labelValue04 = new KryptonLabel();
-		labelElement05 = new KryptonLabel();
-		labelDesignation05 = new KryptonLabel();
-		labelValue05 = new KryptonLabel();
-		labelElement06 = new KryptonLabel();
-		labelDesignation06 = new KryptonLabel();
-		labelValue06 = new KryptonLabel();
-		labelElement07 = new KryptonLabel();
-		labelDesignation07 = new KryptonLabel();
-		labelValue07 = new KryptonLabel();
-		labelElement08 = new KryptonLabel();
-		labelDesignation08 = new KryptonLabel();
-		labelValue08 = new KryptonLabel();
-		labelElement09 = new KryptonLabel();
-		labelDesignation09 = new KryptonLabel();
-		labelValue09 = new KryptonLabel();
-		labelElement10 = new KryptonLabel();
-		labelDesignation10 = new KryptonLabel();
-		labelValue10 = new KryptonLabel();
-		labelElement11 = new KryptonLabel();
-		labelDesignation11 = new KryptonLabel();
-		labelValue11 = new KryptonLabel();
-		labelElement12 = new KryptonLabel();
-		labelDesignation12 = new KryptonLabel();
-		labelValue12 = new KryptonLabel();
-		labelElement13 = new KryptonLabel();
-		labelDesignation13 = new KryptonLabel();
-		labelValue13 = new KryptonLabel();
-		buttonStart = new KryptonButton();
-		buttonCancel = new KryptonButton();
-		progressBar = new KryptonProgressBar();
+		labelElementMeanAnomalyAtTheEpoch = new KryptonLabel();
+		labelDesignationMeanAnomalyAtTheEpoch = new KryptonLabel();
+		labelValueMeanAnomalyAtTheEpoch = new KryptonLabel();
+		labelElementArgumentOfThePerihelion = new KryptonLabel();
+		labelDesignationArgumentOfThePerihelion = new KryptonLabel();
+		labelValueArgumentOfThePerihelion = new KryptonLabel();
+		labelElementLongitudeOfTheAscendingNodeDesc = new KryptonLabel();
+		labelDesignationLongitudeOfTheAscendingNode = new KryptonLabel();
+		labelValueLongitudeOfTheAscendingNode = new KryptonLabel();
+		labelElementInclinationToTheEcliptic = new KryptonLabel();
+		labelDesignationInclinationToTheEcliptic = new KryptonLabel();
+		labelValueInclinationToTheEcliptic = new KryptonLabel();
+		labelElementOrbitalEccentricity = new KryptonLabel();
+		labelDesignationOrbitalEccentricity = new KryptonLabel();
+		labelValueOrbitalEccentricity = new KryptonLabel();
+		labelElementMeanDailyMotion = new KryptonLabel();
+		labelDesignationMeanDailyMotion = new KryptonLabel();
+		labelValueMeanDailyMotion = new KryptonLabel();
+		labelElementSemiMajorAxis = new KryptonLabel();
+		labelDesignationSemiMajorAxis = new KryptonLabel();
+		labelValueSemiMajorAxis = new KryptonLabel();
+		labelElementAbsoluteMagnitude = new KryptonLabel();
+		labelDesignationAbsoluteMagnitude = new KryptonLabel();
+		labelValueAbsoluteMagnitude = new KryptonLabel();
+		labelElementSlopeParameter = new KryptonLabel();
+		labelDesignationSlopeParameter = new KryptonLabel();
+		labelValueSlopeParameter = new KryptonLabel();
+		labelElementNumberOfOppositions = new KryptonLabel();
+		labelDesignationNumberOfOppositions = new KryptonLabel();
+		labelValueNumberOfOppositions = new KryptonLabel();
+		labelElementNumberOfObservations = new KryptonLabel();
+		labelDesignationNumberOfObservations = new KryptonLabel();
+		labelValueNumberOfObservations = new KryptonLabel();
+		labelElementRmsResidual = new KryptonLabel();
+		labelDesignationRmsResidual = new KryptonLabel();
+		labelValueRmsResidual = new KryptonLabel();
 		kryptonStatusStrip = new KryptonStatusStrip();
 		labelInformation = new ToolStripStatusLabel();
 		kryptonManager = new KryptonManager(components);
 		backgroundWorker = new BackgroundWorker();
+		toolStripContainer = new ToolStripContainer();
+		kryptonToolStripGenerateList = new KryptonToolStrip();
+		toolStripButtonStart = new ToolStripButton();
+		toolStripButtonCancel = new ToolStripButton();
+		toolStripSeparator2 = new ToolStripSeparator();
+		toolStripButtonSortOrderAscending = new ToolStripButton();
+		toolStripButtonSortOrderDescending = new ToolStripButton();
+		toolStripSeparator3 = new ToolStripSeparator();
+		kryptonToolStripProgress = new KryptonToolStrip();
+		toolStripLabelProgress = new ToolStripLabel();
+		kryptonProgressBar = new KryptonProgressBarToolStripItem();
 		((ISupportInitialize)kryptonPanelMain).BeginInit();
 		kryptonPanelMain.SuspendLayout();
-		((ISupportInitialize)groupBoxRecordType).BeginInit();
-		((ISupportInitialize)groupBoxRecordType.Panel).BeginInit();
-		groupBoxRecordType.Panel.SuspendLayout();
 		tableLayoutPanel.SuspendLayout();
+		contextMenuSaveToFile.SuspendLayout();
+		contextMenuCopyToClipboard.SuspendLayout();
 		kryptonStatusStrip.SuspendLayout();
+		toolStripContainer.BottomToolStripPanel.SuspendLayout();
+		toolStripContainer.ContentPanel.SuspendLayout();
+		toolStripContainer.TopToolStripPanel.SuspendLayout();
+		toolStripContainer.SuspendLayout();
+		kryptonToolStripGenerateList.SuspendLayout();
+		kryptonToolStripProgress.SuspendLayout();
 		SuspendLayout();
 		// 
 		// kryptonPanelMain
@@ -107,86 +157,19 @@ partial class RecordsForm
 		kryptonPanelMain.AccessibleDescription = "Groups the data";
 		kryptonPanelMain.AccessibleName = "Panel";
 		kryptonPanelMain.AccessibleRole = AccessibleRole.Pane;
-		kryptonPanelMain.Controls.Add(groupBoxRecordType);
 		kryptonPanelMain.Controls.Add(tableLayoutPanel);
-		kryptonPanelMain.Controls.Add(buttonStart);
-		kryptonPanelMain.Controls.Add(buttonCancel);
-		kryptonPanelMain.Controls.Add(progressBar);
 		kryptonPanelMain.Dock = DockStyle.Fill;
 		kryptonPanelMain.Location = new Point(0, 0);
 		kryptonPanelMain.Name = "kryptonPanelMain";
 		kryptonPanelMain.PanelBackStyle = PaletteBackStyle.FormMain;
-		kryptonPanelMain.Size = new Size(700, 560);
+		kryptonPanelMain.Size = new Size(542, 373);
 		kryptonPanelMain.TabIndex = 0;
 		kryptonPanelMain.TabStop = true;
-		// 
-		// groupBoxRecordType
-		// 
-		groupBoxRecordType.AccessibleDescription = "Groups the record type buttons";
-		groupBoxRecordType.AccessibleName = "Record type";
-		groupBoxRecordType.AccessibleRole = AccessibleRole.Grouping;
-		groupBoxRecordType.Location = new Point(14, 10);
-		// 
-		// 
-		// 
-		groupBoxRecordType.Panel.AccessibleDescription = "Groups the record type buttons";
-		groupBoxRecordType.Panel.AccessibleName = "Record type";
-		groupBoxRecordType.Panel.AccessibleRole = AccessibleRole.Grouping;
-		groupBoxRecordType.Panel.Controls.Add(checkButtonMax);
-		groupBoxRecordType.Panel.Controls.Add(checkButtonMin);
-		groupBoxRecordType.Size = new Size(220, 60);
-		groupBoxRecordType.TabIndex = 0;
-		groupBoxRecordType.Values.Heading = "Record type";
-		groupBoxRecordType.Values.Image = FatcowIcons16px.fatcow_award_star_gold_blue_16px;
-		groupBoxRecordType.Enter += Control_Enter;
-		groupBoxRecordType.Leave += Control_Leave;
-		groupBoxRecordType.MouseEnter += Control_Enter;
-		groupBoxRecordType.MouseLeave += Control_Leave;
-		// 
-		// checkButtonMax
-		// 
-		checkButtonMax.AccessibleDescription = "Selects the maximum record type";
-		checkButtonMax.AccessibleName = "Maximum";
-		checkButtonMax.AccessibleRole = AccessibleRole.PushButton;
-		checkButtonMax.ButtonStyle = ButtonStyle.Form;
-		checkButtonMax.Checked = true;
-		checkButtonMax.Location = new Point(4, 7);
-		checkButtonMax.Name = "checkButtonMax";
-		checkButtonMax.Size = new Size(100, 29);
-		checkButtonMax.TabIndex = 0;
-		checkButtonMax.ToolTipValues.Description = "Selects the maximum record type";
-		checkButtonMax.ToolTipValues.EnableToolTips = true;
-		checkButtonMax.ToolTipValues.Heading = "Maximum";
-		checkButtonMax.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		checkButtonMax.Values.DropDownArrowColor = Color.Empty;
-		checkButtonMax.Values.Text = "&Maximum";
-		checkButtonMax.Click += CheckButtonMax_Click;
-		checkButtonMax.Enter += Control_Enter;
-		checkButtonMax.Leave += Control_Leave;
-		checkButtonMax.MouseEnter += Control_Enter;
-		checkButtonMax.MouseLeave += Control_Leave;
-		// 
-		// checkButtonMin
-		// 
-		checkButtonMin.AccessibleDescription = "Selects the minimum record type";
-		checkButtonMin.AccessibleName = "Minimum";
-		checkButtonMin.AccessibleRole = AccessibleRole.PushButton;
-		checkButtonMin.ButtonStyle = ButtonStyle.Form;
-		checkButtonMin.Location = new Point(112, 7);
-		checkButtonMin.Name = "checkButtonMin";
-		checkButtonMin.Size = new Size(100, 29);
-		checkButtonMin.TabIndex = 1;
-		checkButtonMin.ToolTipValues.Description = "Selects the minimum record type";
-		checkButtonMin.ToolTipValues.EnableToolTips = true;
-		checkButtonMin.ToolTipValues.Heading = "Minimum";
-		checkButtonMin.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		checkButtonMin.Values.DropDownArrowColor = Color.Empty;
-		checkButtonMin.Values.Text = "Mi&nimum";
-		checkButtonMin.Click += CheckButtonMin_Click;
-		checkButtonMin.Enter += Control_Enter;
-		checkButtonMin.Leave += Control_Leave;
-		checkButtonMin.MouseEnter += Control_Enter;
-		checkButtonMin.MouseLeave += Control_Leave;
+		kryptonPanelMain.Text = "Main panel";
+		kryptonPanelMain.Enter += Control_Enter;
+		kryptonPanelMain.Leave += Control_Leave;
+		kryptonPanelMain.MouseEnter += Control_Enter;
+		kryptonPanelMain.MouseLeave += Control_Leave;
 		// 
 		// tableLayoutPanel
 		// 
@@ -195,53 +178,52 @@ partial class RecordsForm
 		tableLayoutPanel.AccessibleRole = AccessibleRole.Grouping;
 		tableLayoutPanel.ColumnCount = 3;
 		tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 220F));
-		tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 280F));
+		tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 188F));
 		tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+		tableLayoutPanel.ContextMenuStrip = contextMenuSaveToFile;
 		tableLayoutPanel.Controls.Add(labelElementHeader, 0, 0);
 		tableLayoutPanel.Controls.Add(labelDesignationHeader, 1, 0);
 		tableLayoutPanel.Controls.Add(labelValueHeader, 2, 0);
-		tableLayoutPanel.Controls.Add(labelElement01, 0, 1);
-		tableLayoutPanel.Controls.Add(labelDesignation01, 1, 1);
-		tableLayoutPanel.Controls.Add(labelValue01, 2, 1);
-		tableLayoutPanel.Controls.Add(labelElement02, 0, 2);
-		tableLayoutPanel.Controls.Add(labelDesignation02, 1, 2);
-		tableLayoutPanel.Controls.Add(labelValue02, 2, 2);
-		tableLayoutPanel.Controls.Add(labelElement03, 0, 3);
-		tableLayoutPanel.Controls.Add(labelDesignation03, 1, 3);
-		tableLayoutPanel.Controls.Add(labelValue03, 2, 3);
-		tableLayoutPanel.Controls.Add(labelElement04, 0, 4);
-		tableLayoutPanel.Controls.Add(labelDesignation04, 1, 4);
-		tableLayoutPanel.Controls.Add(labelValue04, 2, 4);
-		tableLayoutPanel.Controls.Add(labelElement05, 0, 5);
-		tableLayoutPanel.Controls.Add(labelDesignation05, 1, 5);
-		tableLayoutPanel.Controls.Add(labelValue05, 2, 5);
-		tableLayoutPanel.Controls.Add(labelElement06, 0, 6);
-		tableLayoutPanel.Controls.Add(labelDesignation06, 1, 6);
-		tableLayoutPanel.Controls.Add(labelValue06, 2, 6);
-		tableLayoutPanel.Controls.Add(labelElement07, 0, 7);
-		tableLayoutPanel.Controls.Add(labelDesignation07, 1, 7);
-		tableLayoutPanel.Controls.Add(labelValue07, 2, 7);
-		tableLayoutPanel.Controls.Add(labelElement08, 0, 8);
-		tableLayoutPanel.Controls.Add(labelDesignation08, 1, 8);
-		tableLayoutPanel.Controls.Add(labelValue08, 2, 8);
-		tableLayoutPanel.Controls.Add(labelElement09, 0, 9);
-		tableLayoutPanel.Controls.Add(labelDesignation09, 1, 9);
-		tableLayoutPanel.Controls.Add(labelValue09, 2, 9);
-		tableLayoutPanel.Controls.Add(labelElement10, 0, 10);
-		tableLayoutPanel.Controls.Add(labelDesignation10, 1, 10);
-		tableLayoutPanel.Controls.Add(labelValue10, 2, 10);
-		tableLayoutPanel.Controls.Add(labelElement11, 0, 11);
-		tableLayoutPanel.Controls.Add(labelDesignation11, 1, 11);
-		tableLayoutPanel.Controls.Add(labelValue11, 2, 11);
-		tableLayoutPanel.Controls.Add(labelElement12, 0, 12);
-		tableLayoutPanel.Controls.Add(labelDesignation12, 1, 12);
-		tableLayoutPanel.Controls.Add(labelValue12, 2, 12);
-		tableLayoutPanel.Controls.Add(labelElement13, 0, 13);
-		tableLayoutPanel.Controls.Add(labelDesignation13, 1, 13);
-		tableLayoutPanel.Controls.Add(labelValue13, 2, 13);
-		tableLayoutPanel.Location = new Point(14, 80);
+		tableLayoutPanel.Controls.Add(labelElementMeanAnomalyAtTheEpoch, 0, 1);
+		tableLayoutPanel.Controls.Add(labelDesignationMeanAnomalyAtTheEpoch, 1, 1);
+		tableLayoutPanel.Controls.Add(labelValueMeanAnomalyAtTheEpoch, 2, 1);
+		tableLayoutPanel.Controls.Add(labelElementArgumentOfThePerihelion, 0, 2);
+		tableLayoutPanel.Controls.Add(labelDesignationArgumentOfThePerihelion, 1, 2);
+		tableLayoutPanel.Controls.Add(labelValueArgumentOfThePerihelion, 2, 2);
+		tableLayoutPanel.Controls.Add(labelElementLongitudeOfTheAscendingNodeDesc, 0, 3);
+		tableLayoutPanel.Controls.Add(labelDesignationLongitudeOfTheAscendingNode, 1, 3);
+		tableLayoutPanel.Controls.Add(labelValueLongitudeOfTheAscendingNode, 2, 3);
+		tableLayoutPanel.Controls.Add(labelElementInclinationToTheEcliptic, 0, 4);
+		tableLayoutPanel.Controls.Add(labelDesignationInclinationToTheEcliptic, 1, 4);
+		tableLayoutPanel.Controls.Add(labelValueInclinationToTheEcliptic, 2, 4);
+		tableLayoutPanel.Controls.Add(labelElementOrbitalEccentricity, 0, 5);
+		tableLayoutPanel.Controls.Add(labelDesignationOrbitalEccentricity, 1, 5);
+		tableLayoutPanel.Controls.Add(labelValueOrbitalEccentricity, 2, 5);
+		tableLayoutPanel.Controls.Add(labelElementMeanDailyMotion, 0, 6);
+		tableLayoutPanel.Controls.Add(labelDesignationMeanDailyMotion, 1, 6);
+		tableLayoutPanel.Controls.Add(labelValueMeanDailyMotion, 2, 6);
+		tableLayoutPanel.Controls.Add(labelElementSemiMajorAxis, 0, 7);
+		tableLayoutPanel.Controls.Add(labelDesignationSemiMajorAxis, 1, 7);
+		tableLayoutPanel.Controls.Add(labelValueSemiMajorAxis, 2, 7);
+		tableLayoutPanel.Controls.Add(labelElementAbsoluteMagnitude, 0, 8);
+		tableLayoutPanel.Controls.Add(labelDesignationAbsoluteMagnitude, 1, 8);
+		tableLayoutPanel.Controls.Add(labelValueAbsoluteMagnitude, 2, 8);
+		tableLayoutPanel.Controls.Add(labelElementSlopeParameter, 0, 9);
+		tableLayoutPanel.Controls.Add(labelDesignationSlopeParameter, 1, 9);
+		tableLayoutPanel.Controls.Add(labelValueSlopeParameter, 2, 9);
+		tableLayoutPanel.Controls.Add(labelElementNumberOfOppositions, 0, 10);
+		tableLayoutPanel.Controls.Add(labelDesignationNumberOfOppositions, 1, 10);
+		tableLayoutPanel.Controls.Add(labelValueNumberOfOppositions, 2, 10);
+		tableLayoutPanel.Controls.Add(labelElementNumberOfObservations, 0, 11);
+		tableLayoutPanel.Controls.Add(labelDesignationNumberOfObservations, 1, 11);
+		tableLayoutPanel.Controls.Add(labelValueNumberOfObservations, 2, 11);
+		tableLayoutPanel.Controls.Add(labelElementRmsResidual, 0, 12);
+		tableLayoutPanel.Controls.Add(labelDesignationRmsResidual, 1, 12);
+		tableLayoutPanel.Controls.Add(labelValueRmsResidual, 2, 12);
+		tableLayoutPanel.Dock = DockStyle.Fill;
+		tableLayoutPanel.Location = new Point(0, 0);
 		tableLayoutPanel.Name = "tableLayoutPanel";
-		tableLayoutPanel.RowCount = 14;
+		tableLayoutPanel.RowCount = 13;
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
@@ -255,15 +237,596 @@ partial class RecordsForm
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
 		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
-		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
-		tableLayoutPanel.Size = new Size(670, 406);
+		tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
+		tableLayoutPanel.Size = new Size(542, 373);
 		tableLayoutPanel.TabIndex = 1;
+		tableLayoutPanel.Enter += Control_Enter;
+		tableLayoutPanel.Leave += Control_Leave;
+		tableLayoutPanel.MouseEnter += Control_Enter;
+		tableLayoutPanel.MouseLeave += Control_Leave;
+		// 
+		// contextMenuSaveToFile
+		// 
+		contextMenuSaveToFile.AccessibleDescription = "Save the list as file";
+		contextMenuSaveToFile.AccessibleName = "Save list";
+		contextMenuSaveToFile.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuSaveToFile.AllowClickThrough = true;
+		contextMenuSaveToFile.Font = new Font("Segoe UI", 9F);
+		contextMenuSaveToFile.Items.AddRange(new ToolStripItem[] { toolStripMenuItemTextFiles, toolStripMenuItemWriterDocuments, toolStripMenuItemSpreadsheetDocuments, toolStripMenuItemXmlDocuments, toolStripMenuItemConfigurationFiles, toolStripMenuItemDatabaseScripts, toolStripMenuItemPortableDocuments });
+		contextMenuSaveToFile.Name = "contextMenuSaveList";
+		contextMenuSaveToFile.OwnerItem = toolStripDropDownButtonSaveList;
+		contextMenuSaveToFile.Size = new Size(202, 158);
+		contextMenuSaveToFile.TabStop = true;
+		contextMenuSaveToFile.Text = "&Save list";
+		contextMenuSaveToFile.MouseEnter += Control_Enter;
+		contextMenuSaveToFile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemTextFiles
+		// 
+		toolStripMenuItemTextFiles.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemTextFiles.AccessibleName = "Save as text file";
+		toolStripMenuItemTextFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemTextFiles.AutoToolTip = true;
+		toolStripMenuItemTextFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsText, toolStripMenuItemSaveAsLatex, toolStripMenuItemSaveAsMarkdown, toolStripMenuItemSaveAsAsciiDoc, toolStripMenuItemSaveAsReStructuredText, toolStripMenuItemSaveAsTextile });
+		toolStripMenuItemTextFiles.Image = FatcowIcons16px.fatcow_file_extension_txt_16px;
+		toolStripMenuItemTextFiles.Name = "toolStripMenuItemTextFiles";
+		toolStripMenuItemTextFiles.Size = new Size(201, 22);
+		toolStripMenuItemTextFiles.Text = "&Text files";
+		toolStripMenuItemTextFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemTextFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsText
+		// 
+		toolStripMenuItemSaveAsText.AccessibleDescription = "Saves the list as text file";
+		toolStripMenuItemSaveAsText.AccessibleName = "Save as text";
+		toolStripMenuItemSaveAsText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsText.AutoToolTip = true;
+		toolStripMenuItemSaveAsText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsText.Name = "toolStripMenuItemSaveAsText";
+		toolStripMenuItemSaveAsText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsText.Text = "Save as &text";
+		toolStripMenuItemSaveAsText.Click += ToolStripMenuItemSaveAsText_Click;
+		toolStripMenuItemSaveAsText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsLatex
+		// 
+		toolStripMenuItemSaveAsLatex.AccessibleDescription = "Saves the list as Latex file";
+		toolStripMenuItemSaveAsLatex.AccessibleName = "Save as Latex";
+		toolStripMenuItemSaveAsLatex.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsLatex.AutoToolTip = true;
+		toolStripMenuItemSaveAsLatex.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsLatex.Name = "toolStripMenuItemSaveAsLatex";
+		toolStripMenuItemSaveAsLatex.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsLatex.Text = "Save as &Latex";
+		toolStripMenuItemSaveAsLatex.Click += ToolStripMenuItemSaveAsLatex_Click;
+		toolStripMenuItemSaveAsLatex.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsLatex.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMarkdown
+		// 
+		toolStripMenuItemSaveAsMarkdown.AccessibleDescription = "Saves the list as Markdown file";
+		toolStripMenuItemSaveAsMarkdown.AccessibleName = "Save as Markdown";
+		toolStripMenuItemSaveAsMarkdown.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMarkdown.AutoToolTip = true;
+		toolStripMenuItemSaveAsMarkdown.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsMarkdown.Name = "toolStripMenuItemSaveAsMarkdown";
+		toolStripMenuItemSaveAsMarkdown.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsMarkdown.Text = "Save as &Markdown";
+		toolStripMenuItemSaveAsMarkdown.Click += ToolStripMenuItemSaveAsMarkdown_Click;
+		toolStripMenuItemSaveAsMarkdown.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMarkdown.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAsciiDoc
+		// 
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleDescription = "Saves the list as AsciiDoc file";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleName = "Save as AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAsciiDoc.AutoToolTip = true;
+		toolStripMenuItemSaveAsAsciiDoc.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsAsciiDoc.Name = "toolStripMenuItemSaveAsAsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsAsciiDoc.Text = "Save as &AsciiDoc";
+		toolStripMenuItemSaveAsAsciiDoc.Click += ToolStripMenuItemSaveAsAsciiDoc_Click;
+		toolStripMenuItemSaveAsAsciiDoc.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAsciiDoc.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsReStructuredText
+		// 
+		toolStripMenuItemSaveAsReStructuredText.AccessibleDescription = "Saves the list as reStructuredText file";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleName = "Save as reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsReStructuredText.AutoToolTip = true;
+		toolStripMenuItemSaveAsReStructuredText.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsReStructuredText.Name = "toolStripMenuItemSaveAsReStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsReStructuredText.Text = "Save as &reStructuredText";
+		toolStripMenuItemSaveAsReStructuredText.Click += ToolStripMenuItemSaveAsReStructuredText_Click;
+		toolStripMenuItemSaveAsReStructuredText.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsReStructuredText.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTextile
+		// 
+		toolStripMenuItemSaveAsTextile.AccessibleDescription = "Saves the list as Textile file";
+		toolStripMenuItemSaveAsTextile.AccessibleName = "Save as Textile";
+		toolStripMenuItemSaveAsTextile.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTextile.AutoToolTip = true;
+		toolStripMenuItemSaveAsTextile.Image = FatcowIcons16px.fatcow_page_white_text_16px;
+		toolStripMenuItemSaveAsTextile.Name = "toolStripMenuItemSaveAsTextile";
+		toolStripMenuItemSaveAsTextile.Size = new Size(201, 22);
+		toolStripMenuItemSaveAsTextile.Text = "Save as Te&xtile";
+		toolStripMenuItemSaveAsTextile.Click += ToolStripMenuItemSaveAsTextile_Click;
+		toolStripMenuItemSaveAsTextile.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTextile.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemWriterDocuments
+		// 
+		toolStripMenuItemWriterDocuments.AccessibleDescription = "Saves the list as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleName = "Save as writer document";
+		toolStripMenuItemWriterDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemWriterDocuments.AutoToolTip = true;
+		toolStripMenuItemWriterDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsWord, toolStripMenuItemSaveAsOdt, toolStripMenuItemSaveAsRtf, toolStripMenuItemSaveAsAbiword, toolStripMenuItemSaveAsWps });
+		toolStripMenuItemWriterDocuments.Image = FatcowIcons16px.fatcow_file_extension_doc_16px;
+		toolStripMenuItemWriterDocuments.Name = "toolStripMenuItemWriterDocuments";
+		toolStripMenuItemWriterDocuments.Size = new Size(201, 22);
+		toolStripMenuItemWriterDocuments.Text = "&Writer documents";
+		toolStripMenuItemWriterDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemWriterDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWord
+		// 
+		toolStripMenuItemSaveAsWord.AccessibleDescription = "Saves the list as Word file";
+		toolStripMenuItemSaveAsWord.AccessibleName = "Save as Word";
+		toolStripMenuItemSaveAsWord.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWord.AutoToolTip = true;
+		toolStripMenuItemSaveAsWord.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWord.Name = "toolStripMenuItemSaveAsWord";
+		toolStripMenuItemSaveAsWord.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWord.Text = "Save as &Word Text (DOCX)";
+		toolStripMenuItemSaveAsWord.Click += ToolStripMenuItemSaveAsWord_Click;
+		toolStripMenuItemSaveAsWord.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWord.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOdt
+		// 
+		toolStripMenuItemSaveAsOdt.AccessibleDescription = "Saves the list as ODT file";
+		toolStripMenuItemSaveAsOdt.AccessibleName = "Save as ODT";
+		toolStripMenuItemSaveAsOdt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOdt.AutoToolTip = true;
+		toolStripMenuItemSaveAsOdt.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsOdt.Name = "toolStripMenuItemSaveAsOdt";
+		toolStripMenuItemSaveAsOdt.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsOdt.Text = "Save as &OpenDocument Text (ODT)";
+		toolStripMenuItemSaveAsOdt.Click += ToolStripMenuItemSaveAsOdt_Click;
+		toolStripMenuItemSaveAsOdt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOdt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsRtf
+		// 
+		toolStripMenuItemSaveAsRtf.AccessibleDescription = "Saves the list as RTF file";
+		toolStripMenuItemSaveAsRtf.AccessibleName = "Save as RTF";
+		toolStripMenuItemSaveAsRtf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsRtf.AutoToolTip = true;
+		toolStripMenuItemSaveAsRtf.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsRtf.Name = "toolStripMenuItemSaveAsRtf";
+		toolStripMenuItemSaveAsRtf.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsRtf.Text = "Save as &Rich Text Format (RTF)";
+		toolStripMenuItemSaveAsRtf.Click += ToolStripMenuItemSaveAsRtf_Click;
+		toolStripMenuItemSaveAsRtf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsRtf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsAbiword
+		// 
+		toolStripMenuItemSaveAsAbiword.AccessibleDescription = "Saves the list as Abiword file";
+		toolStripMenuItemSaveAsAbiword.AccessibleName = "Save as Abiword";
+		toolStripMenuItemSaveAsAbiword.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsAbiword.AutoToolTip = true;
+		toolStripMenuItemSaveAsAbiword.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsAbiword.Name = "toolStripMenuItemSaveAsAbiword";
+		toolStripMenuItemSaveAsAbiword.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsAbiword.Text = "Save as &Abiword file (ABW)";
+		toolStripMenuItemSaveAsAbiword.Click += ToolStripMenuItemSaveAsAbiword_Click;
+		toolStripMenuItemSaveAsAbiword.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsAbiword.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsWps
+		// 
+		toolStripMenuItemSaveAsWps.AccessibleDescription = "Saves the list as WPS file";
+		toolStripMenuItemSaveAsWps.AccessibleName = "Save as WPS";
+		toolStripMenuItemSaveAsWps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsWps.AutoToolTip = true;
+		toolStripMenuItemSaveAsWps.Image = FatcowIcons16px.fatcow_page_white_word_16px;
+		toolStripMenuItemSaveAsWps.Name = "toolStripMenuItemSaveAsWps";
+		toolStripMenuItemSaveAsWps.Size = new Size(257, 22);
+		toolStripMenuItemSaveAsWps.Text = "Save as W&PS Office Writer (WPS)";
+		toolStripMenuItemSaveAsWps.Click += ToolStripMenuItemSaveAsWps_Click;
+		toolStripMenuItemSaveAsWps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsWps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSpreadsheetDocuments
+		// 
+		toolStripMenuItemSpreadsheetDocuments.AccessibleDescription = "Saves the list as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleName = "Save as spreadsheet document";
+		toolStripMenuItemSpreadsheetDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSpreadsheetDocuments.AutoToolTip = true;
+		toolStripMenuItemSpreadsheetDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsExcel, toolStripMenuItemSaveAsOds, toolStripMenuItemSaveAsCsv, toolStripMenuItemSaveAsTsv, toolStripMenuItemSaveAsPsv, toolStripMenuItemSaveAsEt });
+		toolStripMenuItemSpreadsheetDocuments.Image = FatcowIcons16px.fatcow_file_extension_xls_16px;
+		toolStripMenuItemSpreadsheetDocuments.Name = "toolStripMenuItemSpreadsheetDocuments";
+		toolStripMenuItemSpreadsheetDocuments.Size = new Size(201, 22);
+		toolStripMenuItemSpreadsheetDocuments.Text = "&Spreadsheet documents";
+		toolStripMenuItemSpreadsheetDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemSpreadsheetDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsExcel
+		// 
+		toolStripMenuItemSaveAsExcel.AccessibleDescription = "Saves the list as Excel file";
+		toolStripMenuItemSaveAsExcel.AccessibleName = "Save as Excel";
+		toolStripMenuItemSaveAsExcel.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsExcel.AutoToolTip = true;
+		toolStripMenuItemSaveAsExcel.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsExcel.Name = "toolStripMenuItemSaveAsExcel";
+		toolStripMenuItemSaveAsExcel.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsExcel.Text = "Save as &Excel Spreadsheet (XLSX)";
+		toolStripMenuItemSaveAsExcel.Click += ToolStripMenuItemSaveAsExcel_Click;
+		toolStripMenuItemSaveAsExcel.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsExcel.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsOds
+		// 
+		toolStripMenuItemSaveAsOds.AccessibleDescription = "Saves the list as ODS file";
+		toolStripMenuItemSaveAsOds.AccessibleName = "Save as ODS";
+		toolStripMenuItemSaveAsOds.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsOds.AutoToolTip = true;
+		toolStripMenuItemSaveAsOds.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsOds.Name = "toolStripMenuItemSaveAsOds";
+		toolStripMenuItemSaveAsOds.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsOds.Text = "Save as &OpenDocument Spreadsheet (ODS)";
+		toolStripMenuItemSaveAsOds.Click += ToolStripMenuItemSaveAsOds_Click;
+		toolStripMenuItemSaveAsOds.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsOds.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsCsv
+		// 
+		toolStripMenuItemSaveAsCsv.AccessibleDescription = "Saves the list as CSV file";
+		toolStripMenuItemSaveAsCsv.AccessibleName = "Save as CSV";
+		toolStripMenuItemSaveAsCsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsCsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsCsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsCsv.Name = "toolStripMenuItemSaveAsCsv";
+		toolStripMenuItemSaveAsCsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsCsv.Text = "Save as &Comma separated value (CSV)";
+		toolStripMenuItemSaveAsCsv.Click += ToolStripMenuItemSaveAsCsv_Click;
+		toolStripMenuItemSaveAsCsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsCsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsTsv
+		// 
+		toolStripMenuItemSaveAsTsv.AccessibleDescription = "Saves the list as TSV file";
+		toolStripMenuItemSaveAsTsv.AccessibleName = "Save as TSV";
+		toolStripMenuItemSaveAsTsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsTsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsTsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsTsv.Name = "toolStripMenuItemSaveAsTsv";
+		toolStripMenuItemSaveAsTsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsTsv.Text = "Save as &Tabulator separated value (TSV)";
+		toolStripMenuItemSaveAsTsv.Click += ToolStripMenuItemSaveAsTsv_Click;
+		toolStripMenuItemSaveAsTsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsTsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPsv
+		// 
+		toolStripMenuItemSaveAsPsv.AccessibleDescription = "Saves the list as PSV file";
+		toolStripMenuItemSaveAsPsv.AccessibleName = "Save as PSV";
+		toolStripMenuItemSaveAsPsv.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPsv.AutoToolTip = true;
+		toolStripMenuItemSaveAsPsv.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsPsv.Name = "toolStripMenuItemSaveAsPsv";
+		toolStripMenuItemSaveAsPsv.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsPsv.Text = "Save as &Pipe separated value (PSV)";
+		toolStripMenuItemSaveAsPsv.Click += ToolStripMenuItemSaveAsPsv_Click;
+		toolStripMenuItemSaveAsPsv.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPsv.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEt
+		// 
+		toolStripMenuItemSaveAsEt.AccessibleDescription = "Saves the list as ET";
+		toolStripMenuItemSaveAsEt.AccessibleName = "Save as ET";
+		toolStripMenuItemSaveAsEt.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEt.AutoToolTip = true;
+		toolStripMenuItemSaveAsEt.Image = FatcowIcons16px.fatcow_page_white_excel_16px;
+		toolStripMenuItemSaveAsEt.Name = "toolStripMenuItemSaveAsEt";
+		toolStripMenuItemSaveAsEt.Size = new Size(301, 22);
+		toolStripMenuItemSaveAsEt.Text = "Save as &WPS Office Spreadsheet (ET)";
+		toolStripMenuItemSaveAsEt.Click += ToolStripMenuItemSaveAsEt_Click;
+		toolStripMenuItemSaveAsEt.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEt.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemXmlDocuments
+		// 
+		toolStripMenuItemXmlDocuments.AccessibleDescription = "Saves the list as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleName = "Save as XML documents";
+		toolStripMenuItemXmlDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemXmlDocuments.AutoToolTip = true;
+		toolStripMenuItemXmlDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsHtml, toolStripMenuItemSaveAsXml, toolStripMenuItemSaveAsDocBook });
+		toolStripMenuItemXmlDocuments.Image = FatcowIcons16px.fatcow_file_extension_bin_16px;
+		toolStripMenuItemXmlDocuments.Name = "toolStripMenuItemXmlDocuments";
+		toolStripMenuItemXmlDocuments.Size = new Size(201, 22);
+		toolStripMenuItemXmlDocuments.Text = "&XML documents";
+		toolStripMenuItemXmlDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemXmlDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsHtml
+		// 
+		toolStripMenuItemSaveAsHtml.AccessibleDescription = "Saves the list as HTML file";
+		toolStripMenuItemSaveAsHtml.AccessibleName = "Save as HTML";
+		toolStripMenuItemSaveAsHtml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsHtml.AutoToolTip = true;
+		toolStripMenuItemSaveAsHtml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsHtml.Name = "toolStripMenuItemSaveAsHtml";
+		toolStripMenuItemSaveAsHtml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsHtml.Text = "Save as &HTML";
+		toolStripMenuItemSaveAsHtml.Click += ToolStripMenuItemSaveAsHtml_Click;
+		toolStripMenuItemSaveAsHtml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsHtml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXml
+		// 
+		toolStripMenuItemSaveAsXml.AccessibleDescription = "Saves the list as XML file";
+		toolStripMenuItemSaveAsXml.AccessibleName = "Save as XML";
+		toolStripMenuItemSaveAsXml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXml.AutoToolTip = true;
+		toolStripMenuItemSaveAsXml.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsXml.Name = "toolStripMenuItemSaveAsXml";
+		toolStripMenuItemSaveAsXml.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsXml.Text = "Save as &XML";
+		toolStripMenuItemSaveAsXml.Click += ToolStripMenuItemSaveAsXml_Click;
+		toolStripMenuItemSaveAsXml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsDocBook
+		// 
+		toolStripMenuItemSaveAsDocBook.AccessibleDescription = "Saves the list as DocBook file";
+		toolStripMenuItemSaveAsDocBook.AccessibleName = "Save as DocBook";
+		toolStripMenuItemSaveAsDocBook.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsDocBook.AutoToolTip = true;
+		toolStripMenuItemSaveAsDocBook.Image = FatcowIcons16px.fatcow_page_white_code_16px;
+		toolStripMenuItemSaveAsDocBook.Name = "toolStripMenuItemSaveAsDocBook";
+		toolStripMenuItemSaveAsDocBook.Size = new Size(163, 22);
+		toolStripMenuItemSaveAsDocBook.Text = "Save as &DocBook";
+		toolStripMenuItemSaveAsDocBook.Click += ToolStripMenuItemSaveAsDocBook_Click;
+		toolStripMenuItemSaveAsDocBook.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsDocBook.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemConfigurationFiles
+		// 
+		toolStripMenuItemConfigurationFiles.AccessibleDescription = "Saves the list as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleName = "Save as configuration file";
+		toolStripMenuItemConfigurationFiles.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemConfigurationFiles.AutoToolTip = true;
+		toolStripMenuItemConfigurationFiles.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsJson, toolStripMenuItemSaveAsToml, toolStripMenuItemSaveAsYaml });
+		toolStripMenuItemConfigurationFiles.Image = FatcowIcons16px.fatcow_file_extension_bat_16px;
+		toolStripMenuItemConfigurationFiles.Name = "toolStripMenuItemConfigurationFiles";
+		toolStripMenuItemConfigurationFiles.Size = new Size(201, 22);
+		toolStripMenuItemConfigurationFiles.Text = "&Configuration files";
+		toolStripMenuItemConfigurationFiles.MouseEnter += Control_Enter;
+		toolStripMenuItemConfigurationFiles.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsJson
+		// 
+		toolStripMenuItemSaveAsJson.AccessibleDescription = "Saves the list as JSON file";
+		toolStripMenuItemSaveAsJson.AccessibleName = "Save as JSON";
+		toolStripMenuItemSaveAsJson.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsJson.AutoToolTip = true;
+		toolStripMenuItemSaveAsJson.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsJson.Name = "toolStripMenuItemSaveAsJson";
+		toolStripMenuItemSaveAsJson.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsJson.Text = "Save as &JSON";
+		toolStripMenuItemSaveAsJson.Click += ToolStripMenuItemSaveAsJson_Click;
+		toolStripMenuItemSaveAsJson.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsJson.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsToml
+		// 
+		toolStripMenuItemSaveAsToml.AccessibleDescription = "Saves the list as TOML file";
+		toolStripMenuItemSaveAsToml.AccessibleName = "Save as TOML";
+		toolStripMenuItemSaveAsToml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsToml.AutoToolTip = true;
+		toolStripMenuItemSaveAsToml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsToml.Name = "toolStripMenuItemSaveAsToml";
+		toolStripMenuItemSaveAsToml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsToml.Text = "Save as &TOML";
+		toolStripMenuItemSaveAsToml.Click += ToolStripMenuItemSaveAsToml_Click;
+		toolStripMenuItemSaveAsToml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsToml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsYaml
+		// 
+		toolStripMenuItemSaveAsYaml.AccessibleDescription = "Saves the list as YAML file";
+		toolStripMenuItemSaveAsYaml.AccessibleName = "Save as YAML";
+		toolStripMenuItemSaveAsYaml.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsYaml.AutoToolTip = true;
+		toolStripMenuItemSaveAsYaml.Image = FatcowIcons16px.fatcow_page_white_code_red_16px;
+		toolStripMenuItemSaveAsYaml.Name = "toolStripMenuItemSaveAsYaml";
+		toolStripMenuItemSaveAsYaml.Size = new Size(146, 22);
+		toolStripMenuItemSaveAsYaml.Text = "Save as &YAML";
+		toolStripMenuItemSaveAsYaml.Click += ToolStripMenuItemSaveAsYaml_Click;
+		toolStripMenuItemSaveAsYaml.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsYaml.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDatabaseScripts
+		// 
+		toolStripMenuItemDatabaseScripts.AccessibleDescription = "Saves the list as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleName = "Save as database script";
+		toolStripMenuItemDatabaseScripts.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDatabaseScripts.AutoToolTip = true;
+		toolStripMenuItemDatabaseScripts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsSql, toolStripMenuItemSaveAsSqlite });
+		toolStripMenuItemDatabaseScripts.Image = FatcowIcons16px.fatcow_file_extension_ptb_16px;
+		toolStripMenuItemDatabaseScripts.Name = "toolStripMenuItemDatabaseScripts";
+		toolStripMenuItemDatabaseScripts.Size = new Size(201, 22);
+		toolStripMenuItemDatabaseScripts.Text = "&Database scripts";
+		toolStripMenuItemDatabaseScripts.MouseEnter += Control_Enter;
+		toolStripMenuItemDatabaseScripts.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSql
+		// 
+		toolStripMenuItemSaveAsSql.AccessibleDescription = "Saves the list as SQL script";
+		toolStripMenuItemSaveAsSql.AccessibleName = "Save as SQL";
+		toolStripMenuItemSaveAsSql.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSql.AutoToolTip = true;
+		toolStripMenuItemSaveAsSql.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSql.Name = "toolStripMenuItemSaveAsSql";
+		toolStripMenuItemSaveAsSql.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSql.Text = "Save as &SQL script";
+		toolStripMenuItemSaveAsSql.Click += ToolStripMenuItemSaveAsSql_Click;
+		toolStripMenuItemSaveAsSql.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSql.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsSqlite
+		// 
+		toolStripMenuItemSaveAsSqlite.AccessibleDescription = "Saves the list as SQLite file";
+		toolStripMenuItemSaveAsSqlite.AccessibleName = "Save as SQLite";
+		toolStripMenuItemSaveAsSqlite.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsSqlite.AutoToolTip = true;
+		toolStripMenuItemSaveAsSqlite.Image = FatcowIcons16px.fatcow_page_white_database_16px;
+		toolStripMenuItemSaveAsSqlite.Name = "toolStripMenuItemSaveAsSqlite";
+		toolStripMenuItemSaveAsSqlite.Size = new Size(168, 22);
+		toolStripMenuItemSaveAsSqlite.Text = "Save as SQ&Lite";
+		toolStripMenuItemSaveAsSqlite.Click += ToolStripMenuItemSaveAsSqlite_Click;
+		toolStripMenuItemSaveAsSqlite.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsSqlite.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemPortableDocuments
+		// 
+		toolStripMenuItemPortableDocuments.AccessibleDescription = "Saves the list as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleName = "Save as portable document";
+		toolStripMenuItemPortableDocuments.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemPortableDocuments.AutoToolTip = true;
+		toolStripMenuItemPortableDocuments.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSaveAsPdf, toolStripMenuItemSaveAsPostScript, toolStripMenuItemSaveAsEpub, toolStripMenuItemSaveAsMobi, toolStripMenuItemSaveAsXps, toolStripMenuItemSaveAsFictionBook2, toolStripMenuItemSaveAsChm });
+		toolStripMenuItemPortableDocuments.Image = FatcowIcons16px.fatcow_file_extension_pdf_16px;
+		toolStripMenuItemPortableDocuments.Name = "toolStripMenuItemPortableDocuments";
+		toolStripMenuItemPortableDocuments.Size = new Size(201, 22);
+		toolStripMenuItemPortableDocuments.Text = "&Portable documents";
+		toolStripMenuItemPortableDocuments.MouseEnter += Control_Enter;
+		toolStripMenuItemPortableDocuments.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPdf
+		// 
+		toolStripMenuItemSaveAsPdf.AccessibleDescription = "Saves the list as PDF file";
+		toolStripMenuItemSaveAsPdf.AccessibleName = "Save as PDF";
+		toolStripMenuItemSaveAsPdf.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPdf.AutoToolTip = true;
+		toolStripMenuItemSaveAsPdf.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPdf.Name = "toolStripMenuItemSaveAsPdf";
+		toolStripMenuItemSaveAsPdf.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPdf.Text = "Save as &PDF";
+		toolStripMenuItemSaveAsPdf.Click += ToolStripMenuItemSaveAsPdf_Click;
+		toolStripMenuItemSaveAsPdf.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPdf.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsPostScript
+		// 
+		toolStripMenuItemSaveAsPostScript.AccessibleDescription = "Saves the list as PostScript file";
+		toolStripMenuItemSaveAsPostScript.AccessibleName = "Save as PostScript";
+		toolStripMenuItemSaveAsPostScript.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsPostScript.AutoToolTip = true;
+		toolStripMenuItemSaveAsPostScript.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsPostScript.Name = "toolStripMenuItemSaveAsPostScript";
+		toolStripMenuItemSaveAsPostScript.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsPostScript.Text = "Save as Post&Script (PS)";
+		toolStripMenuItemSaveAsPostScript.Click += ToolStripMenuItemSaveAsPostScript_Click;
+		toolStripMenuItemSaveAsPostScript.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsPostScript.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsEpub
+		// 
+		toolStripMenuItemSaveAsEpub.AccessibleDescription = "Saves the list as EPUB file";
+		toolStripMenuItemSaveAsEpub.AccessibleName = "Save as EPUB";
+		toolStripMenuItemSaveAsEpub.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsEpub.AutoToolTip = true;
+		toolStripMenuItemSaveAsEpub.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsEpub.Name = "toolStripMenuItemSaveAsEpub";
+		toolStripMenuItemSaveAsEpub.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsEpub.Text = "Save as &EPUB";
+		toolStripMenuItemSaveAsEpub.Click += ToolStripMenuItemSaveAsEpub_Click;
+		toolStripMenuItemSaveAsEpub.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsEpub.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsMobi
+		// 
+		toolStripMenuItemSaveAsMobi.AccessibleDescription = "Saves the list as MOBI file";
+		toolStripMenuItemSaveAsMobi.AccessibleName = "Save as MOBI";
+		toolStripMenuItemSaveAsMobi.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsMobi.AutoToolTip = true;
+		toolStripMenuItemSaveAsMobi.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsMobi.Name = "toolStripMenuItemSaveAsMobi";
+		toolStripMenuItemSaveAsMobi.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsMobi.Text = "Save as &MOBI";
+		toolStripMenuItemSaveAsMobi.Click += ToolStripMenuItemSaveAsMobi_Click;
+		toolStripMenuItemSaveAsMobi.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsMobi.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsXps
+		// 
+		toolStripMenuItemSaveAsXps.AccessibleDescription = "Saves the list as XPS file";
+		toolStripMenuItemSaveAsXps.AccessibleName = "Save as XPS";
+		toolStripMenuItemSaveAsXps.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsXps.AutoToolTip = true;
+		toolStripMenuItemSaveAsXps.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsXps.Name = "toolStripMenuItemSaveAsXps";
+		toolStripMenuItemSaveAsXps.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsXps.Text = "Save as &XPS";
+		toolStripMenuItemSaveAsXps.Click += ToolStripMenuItemSaveAsXps_Click;
+		toolStripMenuItemSaveAsXps.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsXps.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsFictionBook2
+		// 
+		toolStripMenuItemSaveAsFictionBook2.AccessibleDescription = "Saves the list as FictionBook2 file";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleName = "Save as FB2";
+		toolStripMenuItemSaveAsFictionBook2.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsFictionBook2.AutoToolTip = true;
+		toolStripMenuItemSaveAsFictionBook2.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsFictionBook2.Name = "toolStripMenuItemSaveAsFictionBook2";
+		toolStripMenuItemSaveAsFictionBook2.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsFictionBook2.Text = "Save as &FictionBook2 (FB2)";
+		toolStripMenuItemSaveAsFictionBook2.Click += ToolStripMenuItemSaveAsFictionBook2_Click;
+		toolStripMenuItemSaveAsFictionBook2.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsFictionBook2.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemSaveAsChm
+		// 
+		toolStripMenuItemSaveAsChm.AccessibleDescription = "Saves the list as CHM file";
+		toolStripMenuItemSaveAsChm.AccessibleName = "Save as CHM";
+		toolStripMenuItemSaveAsChm.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSaveAsChm.AutoToolTip = true;
+		toolStripMenuItemSaveAsChm.Image = FatcowIcons16px.fatcow_page_white_acrobat_16px;
+		toolStripMenuItemSaveAsChm.Name = "toolStripMenuItemSaveAsChm";
+		toolStripMenuItemSaveAsChm.Size = new Size(214, 22);
+		toolStripMenuItemSaveAsChm.Text = "Save as &CHM";
+		toolStripMenuItemSaveAsChm.Click += ToolStripMenuItemSaveAsChm_Click;
+		toolStripMenuItemSaveAsChm.MouseEnter += Control_Enter;
+		toolStripMenuItemSaveAsChm.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonSaveList
+		// 
+		toolStripDropDownButtonSaveList.AccessibleDescription = "Saves the list as file";
+		toolStripDropDownButtonSaveList.AccessibleName = "Save list";
+		toolStripDropDownButtonSaveList.AccessibleRole = AccessibleRole.ButtonDropDown;
+		toolStripDropDownButtonSaveList.DropDown = contextMenuSaveToFile;
+		toolStripDropDownButtonSaveList.Image = FatcowIcons16px.fatcow_diskette_16px;
+		toolStripDropDownButtonSaveList.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonSaveList.Name = "toolStripDropDownButtonSaveList";
+		toolStripDropDownButtonSaveList.Size = new Size(78, 22);
+		toolStripDropDownButtonSaveList.Text = "&Save list";
+		toolStripDropDownButtonSaveList.MouseEnter += Control_Enter;
+		toolStripDropDownButtonSaveList.MouseLeave += Control_Leave;
 		// 
 		// labelElementHeader
 		// 
 		labelElementHeader.AccessibleDescription = "Column header for orbital element names";
 		labelElementHeader.AccessibleName = "Orbital element header";
 		labelElementHeader.AccessibleRole = AccessibleRole.StaticText;
+		labelElementHeader.ContextMenuStrip = contextMenuCopyToClipboard;
 		labelElementHeader.Dock = DockStyle.Fill;
 		labelElementHeader.LabelStyle = LabelStyle.BoldPanel;
 		labelElementHeader.Location = new Point(3, 3);
@@ -273,23 +836,57 @@ partial class RecordsForm
 		labelElementHeader.Values.Text = "Orbital element";
 		labelElementHeader.Enter += Control_Enter;
 		labelElementHeader.Leave += Control_Leave;
+		labelElementHeader.MouseDown += Control_MouseDown;
 		labelElementHeader.MouseEnter += Control_Enter;
 		labelElementHeader.MouseLeave += Control_Leave;
+		// 
+		// contextMenuCopyToClipboard
+		// 
+		contextMenuCopyToClipboard.AccessibleDescription = "Shows the context menu for copying database information to the clipboard";
+		contextMenuCopyToClipboard.AccessibleName = "Context menu for copying database information to the clipboard";
+		contextMenuCopyToClipboard.AccessibleRole = AccessibleRole.MenuPopup;
+		contextMenuCopyToClipboard.AllowClickThrough = true;
+		contextMenuCopyToClipboard.Font = new Font("Segoe UI", 9F);
+		contextMenuCopyToClipboard.Items.AddRange(new ToolStripItem[] { toolStripMenuItemCopyToClipboardInContextMenu });
+		contextMenuCopyToClipboard.Name = "contextMenuStrip";
+		contextMenuCopyToClipboard.Size = new Size(214, 26);
+		contextMenuCopyToClipboard.TabStop = true;
+		contextMenuCopyToClipboard.Text = "Copy to clipboard";
+		contextMenuCopyToClipboard.MouseEnter += Control_Enter;
+		contextMenuCopyToClipboard.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemCopyToClipboardInContextMenu
+		// 
+		toolStripMenuItemCopyToClipboardInContextMenu.AccessibleDescription = "Copies the text/value to the clipboard";
+		toolStripMenuItemCopyToClipboardInContextMenu.AccessibleName = "Copy to clipboard";
+		toolStripMenuItemCopyToClipboardInContextMenu.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemCopyToClipboardInContextMenu.AutoToolTip = true;
+		toolStripMenuItemCopyToClipboardInContextMenu.Image = FatcowIcons16px.fatcow_page_copy_16px;
+		toolStripMenuItemCopyToClipboardInContextMenu.Name = "toolStripMenuItemCopyToClipboardInContextMenu";
+		toolStripMenuItemCopyToClipboardInContextMenu.ShortcutKeyDisplayString = "Strg+C";
+		toolStripMenuItemCopyToClipboardInContextMenu.ShortcutKeys = Keys.Control | Keys.C;
+		toolStripMenuItemCopyToClipboardInContextMenu.Size = new Size(213, 22);
+		toolStripMenuItemCopyToClipboardInContextMenu.Text = "&Copy to clipboard";
+		toolStripMenuItemCopyToClipboardInContextMenu.Click += CopyToClipboard_DoubleClick;
+		toolStripMenuItemCopyToClipboardInContextMenu.MouseEnter += Control_Enter;
+		toolStripMenuItemCopyToClipboardInContextMenu.MouseLeave += Control_Leave;
 		// 
 		// labelDesignationHeader
 		// 
 		labelDesignationHeader.AccessibleDescription = "Column header for readable designations";
 		labelDesignationHeader.AccessibleName = "Readable designation header";
 		labelDesignationHeader.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationHeader.ContextMenuStrip = contextMenuCopyToClipboard;
 		labelDesignationHeader.Dock = DockStyle.Fill;
 		labelDesignationHeader.LabelStyle = LabelStyle.BoldPanel;
 		labelDesignationHeader.Location = new Point(223, 3);
 		labelDesignationHeader.Name = "labelDesignationHeader";
-		labelDesignationHeader.Size = new Size(274, 23);
+		labelDesignationHeader.Size = new Size(182, 23);
 		labelDesignationHeader.TabIndex = 1;
 		labelDesignationHeader.Values.Text = "Readable designation";
 		labelDesignationHeader.Enter += Control_Enter;
 		labelDesignationHeader.Leave += Control_Leave;
+		labelDesignationHeader.MouseDown += Control_MouseDown;
 		labelDesignationHeader.MouseEnter += Control_Enter;
 		labelDesignationHeader.MouseLeave += Control_Leave;
 		// 
@@ -298,885 +895,835 @@ partial class RecordsForm
 		labelValueHeader.AccessibleDescription = "Column header for record values";
 		labelValueHeader.AccessibleName = "Value header";
 		labelValueHeader.AccessibleRole = AccessibleRole.StaticText;
+		labelValueHeader.ContextMenuStrip = contextMenuCopyToClipboard;
 		labelValueHeader.Dock = DockStyle.Fill;
 		labelValueHeader.LabelStyle = LabelStyle.BoldPanel;
-		labelValueHeader.Location = new Point(503, 3);
+		labelValueHeader.Location = new Point(411, 3);
 		labelValueHeader.Name = "labelValueHeader";
-		labelValueHeader.Size = new Size(164, 23);
+		labelValueHeader.Size = new Size(128, 23);
 		labelValueHeader.TabIndex = 2;
 		labelValueHeader.Values.Text = "Value";
 		labelValueHeader.Enter += Control_Enter;
 		labelValueHeader.Leave += Control_Leave;
+		labelValueHeader.MouseDown += Control_MouseDown;
 		labelValueHeader.MouseEnter += Control_Enter;
 		labelValueHeader.MouseLeave += Control_Leave;
 		// 
-		// labelElement01
-		// 
-		labelElement01.AccessibleDescription = "Orbital element: Mean Anomaly at the Epoch";
-		labelElement01.AccessibleName = "Mean Anomaly at the Epoch";
-		labelElement01.AccessibleRole = AccessibleRole.StaticText;
-		labelElement01.Dock = DockStyle.Fill;
-		labelElement01.Location = new Point(3, 32);
-		labelElement01.Name = "labelElement01";
-		labelElement01.Size = new Size(214, 23);
-		labelElement01.TabIndex = 3;
-		labelElement01.ToolTipValues.Description = "Mean Anomaly at the Epoch";
-		labelElement01.ToolTipValues.EnableToolTips = true;
-		labelElement01.ToolTipValues.Heading = "Mean Anomaly at the Epoch";
-		labelElement01.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement01.Values.Text = "Mean Anomaly at the Epoch";
-		labelElement01.Enter += Control_Enter;
-		labelElement01.Leave += Control_Leave;
-		labelElement01.MouseEnter += Control_Enter;
-		labelElement01.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation01
-		// 
-		labelDesignation01.AccessibleDescription = "Shows the readable designation for Mean Anomaly record";
-		labelDesignation01.AccessibleName = "Readable designation for Mean Anomaly";
-		labelDesignation01.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation01.Dock = DockStyle.Fill;
-		labelDesignation01.Location = new Point(223, 32);
-		labelDesignation01.Name = "labelDesignation01";
-		labelDesignation01.Size = new Size(274, 23);
-		labelDesignation01.TabIndex = 4;
-		labelDesignation01.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Mean Anomaly at the Epoch.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation01.ToolTipValues.EnableToolTips = true;
-		labelDesignation01.ToolTipValues.Heading = "Readable designation for Mean Anomaly";
-		labelDesignation01.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation01.Values.Text = "-";
-		labelDesignation01.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation01.Enter += Control_Enter;
-		labelDesignation01.Leave += Control_Leave;
-		labelDesignation01.MouseEnter += Control_Enter;
-		labelDesignation01.MouseLeave += Control_Leave;
-		// 
-		// labelValue01
-		// 
-		labelValue01.AccessibleDescription = "Shows the record value for Mean Anomaly at the Epoch";
-		labelValue01.AccessibleName = "Record value for Mean Anomaly at the Epoch";
-		labelValue01.AccessibleRole = AccessibleRole.StaticText;
-		labelValue01.Dock = DockStyle.Fill;
-		labelValue01.Location = new Point(503, 32);
-		labelValue01.Name = "labelValue01";
-		labelValue01.Size = new Size(164, 23);
-		labelValue01.TabIndex = 5;
-		labelValue01.ToolTipValues.Description = "Shows the record value for Mean Anomaly at the Epoch.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue01.ToolTipValues.EnableToolTips = true;
-		labelValue01.ToolTipValues.Heading = "Record value for Mean Anomaly at the Epoch";
-		labelValue01.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue01.Values.Text = "-";
-		labelValue01.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue01.Enter += Control_Enter;
-		labelValue01.Leave += Control_Leave;
-		labelValue01.MouseEnter += Control_Enter;
-		labelValue01.MouseLeave += Control_Leave;
-		// 
-		// labelElement02
-		// 
-		labelElement02.AccessibleDescription = "Orbital element: Argument of Perihelion";
-		labelElement02.AccessibleName = "Argument of Perihelion";
-		labelElement02.AccessibleRole = AccessibleRole.StaticText;
-		labelElement02.Dock = DockStyle.Fill;
-		labelElement02.Location = new Point(3, 61);
-		labelElement02.Name = "labelElement02";
-		labelElement02.Size = new Size(214, 23);
-		labelElement02.TabIndex = 6;
-		labelElement02.ToolTipValues.Description = "Argument of Perihelion";
-		labelElement02.ToolTipValues.EnableToolTips = true;
-		labelElement02.ToolTipValues.Heading = "Argument of Perihelion";
-		labelElement02.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement02.Values.Text = "Argument of Perihelion";
-		labelElement02.Enter += Control_Enter;
-		labelElement02.Leave += Control_Leave;
-		labelElement02.MouseEnter += Control_Enter;
-		labelElement02.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation02
-		// 
-		labelDesignation02.AccessibleDescription = "Shows the readable designation for Argument of Perihelion record";
-		labelDesignation02.AccessibleName = "Readable designation for Argument of Perihelion";
-		labelDesignation02.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation02.Dock = DockStyle.Fill;
-		labelDesignation02.Location = new Point(223, 61);
-		labelDesignation02.Name = "labelDesignation02";
-		labelDesignation02.Size = new Size(274, 23);
-		labelDesignation02.TabIndex = 7;
-		labelDesignation02.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Argument of Perihelion.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation02.ToolTipValues.EnableToolTips = true;
-		labelDesignation02.ToolTipValues.Heading = "Readable designation for Argument of Perihelion";
-		labelDesignation02.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation02.Values.Text = "-";
-		labelDesignation02.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation02.Enter += Control_Enter;
-		labelDesignation02.Leave += Control_Leave;
-		labelDesignation02.MouseEnter += Control_Enter;
-		labelDesignation02.MouseLeave += Control_Leave;
-		// 
-		// labelValue02
-		// 
-		labelValue02.AccessibleDescription = "Shows the record value for Argument of Perihelion";
-		labelValue02.AccessibleName = "Record value for Argument of Perihelion";
-		labelValue02.AccessibleRole = AccessibleRole.StaticText;
-		labelValue02.Dock = DockStyle.Fill;
-		labelValue02.Location = new Point(503, 61);
-		labelValue02.Name = "labelValue02";
-		labelValue02.Size = new Size(164, 23);
-		labelValue02.TabIndex = 8;
-		labelValue02.ToolTipValues.Description = "Shows the record value for Argument of Perihelion.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue02.ToolTipValues.EnableToolTips = true;
-		labelValue02.ToolTipValues.Heading = "Record value for Argument of Perihelion";
-		labelValue02.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue02.Values.Text = "-";
-		labelValue02.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue02.Enter += Control_Enter;
-		labelValue02.Leave += Control_Leave;
-		labelValue02.MouseEnter += Control_Enter;
-		labelValue02.MouseLeave += Control_Leave;
-		// 
-		// labelElement03
-		// 
-		labelElement03.AccessibleDescription = "Orbital element: Longitude of the Ascending Node";
-		labelElement03.AccessibleName = "Longitude of the Ascending Node";
-		labelElement03.AccessibleRole = AccessibleRole.StaticText;
-		labelElement03.Dock = DockStyle.Fill;
-		labelElement03.Location = new Point(3, 90);
-		labelElement03.Name = "labelElement03";
-		labelElement03.Size = new Size(214, 23);
-		labelElement03.TabIndex = 9;
-		labelElement03.ToolTipValues.Description = "Longitude of the Ascending Node";
-		labelElement03.ToolTipValues.EnableToolTips = true;
-		labelElement03.ToolTipValues.Heading = "Longitude of the Ascending Node";
-		labelElement03.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement03.Values.Text = "Longitude of the Ascending Node";
-		labelElement03.Enter += Control_Enter;
-		labelElement03.Leave += Control_Leave;
-		labelElement03.MouseEnter += Control_Enter;
-		labelElement03.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation03
-		// 
-		labelDesignation03.AccessibleDescription = "Shows the readable designation for Longitude of the Ascending Node record";
-		labelDesignation03.AccessibleName = "Readable designation for Longitude of the Ascending Node";
-		labelDesignation03.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation03.Dock = DockStyle.Fill;
-		labelDesignation03.Location = new Point(223, 90);
-		labelDesignation03.Name = "labelDesignation03";
-		labelDesignation03.Size = new Size(274, 23);
-		labelDesignation03.TabIndex = 10;
-		labelDesignation03.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Longitude of the Ascending Node.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation03.ToolTipValues.EnableToolTips = true;
-		labelDesignation03.ToolTipValues.Heading = "Readable designation for Longitude of the Ascending Node";
-		labelDesignation03.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation03.Values.Text = "-";
-		labelDesignation03.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation03.Enter += Control_Enter;
-		labelDesignation03.Leave += Control_Leave;
-		labelDesignation03.MouseEnter += Control_Enter;
-		labelDesignation03.MouseLeave += Control_Leave;
-		// 
-		// labelValue03
-		// 
-		labelValue03.AccessibleDescription = "Shows the record value for Longitude of the Ascending Node";
-		labelValue03.AccessibleName = "Record value for Longitude of the Ascending Node";
-		labelValue03.AccessibleRole = AccessibleRole.StaticText;
-		labelValue03.Dock = DockStyle.Fill;
-		labelValue03.Location = new Point(503, 90);
-		labelValue03.Name = "labelValue03";
-		labelValue03.Size = new Size(164, 23);
-		labelValue03.TabIndex = 11;
-		labelValue03.ToolTipValues.Description = "Shows the record value for Longitude of the Ascending Node.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue03.ToolTipValues.EnableToolTips = true;
-		labelValue03.ToolTipValues.Heading = "Record value for Longitude of the Ascending Node";
-		labelValue03.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue03.Values.Text = "-";
-		labelValue03.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue03.Enter += Control_Enter;
-		labelValue03.Leave += Control_Leave;
-		labelValue03.MouseEnter += Control_Enter;
-		labelValue03.MouseLeave += Control_Leave;
-		// 
-		// labelElement04
-		// 
-		labelElement04.AccessibleDescription = "Orbital element: Inclination to the Ecliptic";
-		labelElement04.AccessibleName = "Inclination to the Ecliptic";
-		labelElement04.AccessibleRole = AccessibleRole.StaticText;
-		labelElement04.Dock = DockStyle.Fill;
-		labelElement04.Location = new Point(3, 119);
-		labelElement04.Name = "labelElement04";
-		labelElement04.Size = new Size(214, 23);
-		labelElement04.TabIndex = 12;
-		labelElement04.ToolTipValues.Description = "Inclination to the Ecliptic";
-		labelElement04.ToolTipValues.EnableToolTips = true;
-		labelElement04.ToolTipValues.Heading = "Inclination to the Ecliptic";
-		labelElement04.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement04.Values.Text = "Inclination to the Ecliptic";
-		labelElement04.Enter += Control_Enter;
-		labelElement04.Leave += Control_Leave;
-		labelElement04.MouseEnter += Control_Enter;
-		labelElement04.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation04
-		// 
-		labelDesignation04.AccessibleDescription = "Shows the readable designation for Inclination to the Ecliptic record";
-		labelDesignation04.AccessibleName = "Readable designation for Inclination to the Ecliptic";
-		labelDesignation04.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation04.Dock = DockStyle.Fill;
-		labelDesignation04.Location = new Point(223, 119);
-		labelDesignation04.Name = "labelDesignation04";
-		labelDesignation04.Size = new Size(274, 23);
-		labelDesignation04.TabIndex = 13;
-		labelDesignation04.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Inclination to the Ecliptic.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation04.ToolTipValues.EnableToolTips = true;
-		labelDesignation04.ToolTipValues.Heading = "Readable designation for Inclination to the Ecliptic";
-		labelDesignation04.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation04.Values.Text = "-";
-		labelDesignation04.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation04.Enter += Control_Enter;
-		labelDesignation04.Leave += Control_Leave;
-		labelDesignation04.MouseEnter += Control_Enter;
-		labelDesignation04.MouseLeave += Control_Leave;
-		// 
-		// labelValue04
-		// 
-		labelValue04.AccessibleDescription = "Shows the record value for Inclination to the Ecliptic";
-		labelValue04.AccessibleName = "Record value for Inclination to the Ecliptic";
-		labelValue04.AccessibleRole = AccessibleRole.StaticText;
-		labelValue04.Dock = DockStyle.Fill;
-		labelValue04.Location = new Point(503, 119);
-		labelValue04.Name = "labelValue04";
-		labelValue04.Size = new Size(164, 23);
-		labelValue04.TabIndex = 14;
-		labelValue04.ToolTipValues.Description = "Shows the record value for Inclination to the Ecliptic.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue04.ToolTipValues.EnableToolTips = true;
-		labelValue04.ToolTipValues.Heading = "Record value for Inclination to the Ecliptic";
-		labelValue04.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue04.Values.Text = "-";
-		labelValue04.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue04.Enter += Control_Enter;
-		labelValue04.Leave += Control_Leave;
-		labelValue04.MouseEnter += Control_Enter;
-		labelValue04.MouseLeave += Control_Leave;
-		// 
-		// labelElement05
-		// 
-		labelElement05.AccessibleDescription = "Orbital element: Orbital Eccentricity";
-		labelElement05.AccessibleName = "Orbital Eccentricity";
-		labelElement05.AccessibleRole = AccessibleRole.StaticText;
-		labelElement05.Dock = DockStyle.Fill;
-		labelElement05.Location = new Point(3, 148);
-		labelElement05.Name = "labelElement05";
-		labelElement05.Size = new Size(214, 23);
-		labelElement05.TabIndex = 15;
-		labelElement05.ToolTipValues.Description = "Orbital Eccentricity";
-		labelElement05.ToolTipValues.EnableToolTips = true;
-		labelElement05.ToolTipValues.Heading = "Orbital Eccentricity";
-		labelElement05.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement05.Values.Text = "Orbital Eccentricity";
-		labelElement05.Enter += Control_Enter;
-		labelElement05.Leave += Control_Leave;
-		labelElement05.MouseEnter += Control_Enter;
-		labelElement05.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation05
-		// 
-		labelDesignation05.AccessibleDescription = "Shows the readable designation for Orbital Eccentricity record";
-		labelDesignation05.AccessibleName = "Readable designation for Orbital Eccentricity";
-		labelDesignation05.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation05.Dock = DockStyle.Fill;
-		labelDesignation05.Location = new Point(223, 148);
-		labelDesignation05.Name = "labelDesignation05";
-		labelDesignation05.Size = new Size(274, 23);
-		labelDesignation05.TabIndex = 16;
-		labelDesignation05.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Orbital Eccentricity.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation05.ToolTipValues.EnableToolTips = true;
-		labelDesignation05.ToolTipValues.Heading = "Readable designation for Orbital Eccentricity";
-		labelDesignation05.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation05.Values.Text = "-";
-		labelDesignation05.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation05.Enter += Control_Enter;
-		labelDesignation05.Leave += Control_Leave;
-		labelDesignation05.MouseEnter += Control_Enter;
-		labelDesignation05.MouseLeave += Control_Leave;
-		// 
-		// labelValue05
-		// 
-		labelValue05.AccessibleDescription = "Shows the record value for Orbital Eccentricity";
-		labelValue05.AccessibleName = "Record value for Orbital Eccentricity";
-		labelValue05.AccessibleRole = AccessibleRole.StaticText;
-		labelValue05.Dock = DockStyle.Fill;
-		labelValue05.Location = new Point(503, 148);
-		labelValue05.Name = "labelValue05";
-		labelValue05.Size = new Size(164, 23);
-		labelValue05.TabIndex = 17;
-		labelValue05.ToolTipValues.Description = "Shows the record value for Orbital Eccentricity.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue05.ToolTipValues.EnableToolTips = true;
-		labelValue05.ToolTipValues.Heading = "Record value for Orbital Eccentricity";
-		labelValue05.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue05.Values.Text = "-";
-		labelValue05.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue05.Enter += Control_Enter;
-		labelValue05.Leave += Control_Leave;
-		labelValue05.MouseEnter += Control_Enter;
-		labelValue05.MouseLeave += Control_Leave;
-		// 
-		// labelElement06
-		// 
-		labelElement06.AccessibleDescription = "Orbital element: Mean Daily Motion";
-		labelElement06.AccessibleName = "Mean Daily Motion";
-		labelElement06.AccessibleRole = AccessibleRole.StaticText;
-		labelElement06.Dock = DockStyle.Fill;
-		labelElement06.Location = new Point(3, 177);
-		labelElement06.Name = "labelElement06";
-		labelElement06.Size = new Size(214, 23);
-		labelElement06.TabIndex = 18;
-		labelElement06.ToolTipValues.Description = "Mean Daily Motion";
-		labelElement06.ToolTipValues.EnableToolTips = true;
-		labelElement06.ToolTipValues.Heading = "Mean Daily Motion";
-		labelElement06.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement06.Values.Text = "Mean Daily Motion";
-		labelElement06.Enter += Control_Enter;
-		labelElement06.Leave += Control_Leave;
-		labelElement06.MouseEnter += Control_Enter;
-		labelElement06.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation06
-		// 
-		labelDesignation06.AccessibleDescription = "Shows the readable designation for Mean Daily Motion record";
-		labelDesignation06.AccessibleName = "Readable designation for Mean Daily Motion";
-		labelDesignation06.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation06.Dock = DockStyle.Fill;
-		labelDesignation06.Location = new Point(223, 177);
-		labelDesignation06.Name = "labelDesignation06";
-		labelDesignation06.Size = new Size(274, 23);
-		labelDesignation06.TabIndex = 19;
-		labelDesignation06.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Mean Daily Motion.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation06.ToolTipValues.EnableToolTips = true;
-		labelDesignation06.ToolTipValues.Heading = "Readable designation for Mean Daily Motion";
-		labelDesignation06.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation06.Values.Text = "-";
-		labelDesignation06.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation06.Enter += Control_Enter;
-		labelDesignation06.Leave += Control_Leave;
-		labelDesignation06.MouseEnter += Control_Enter;
-		labelDesignation06.MouseLeave += Control_Leave;
-		// 
-		// labelValue06
-		// 
-		labelValue06.AccessibleDescription = "Shows the record value for Mean Daily Motion";
-		labelValue06.AccessibleName = "Record value for Mean Daily Motion";
-		labelValue06.AccessibleRole = AccessibleRole.StaticText;
-		labelValue06.Dock = DockStyle.Fill;
-		labelValue06.Location = new Point(503, 177);
-		labelValue06.Name = "labelValue06";
-		labelValue06.Size = new Size(164, 23);
-		labelValue06.TabIndex = 20;
-		labelValue06.ToolTipValues.Description = "Shows the record value for Mean Daily Motion.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue06.ToolTipValues.EnableToolTips = true;
-		labelValue06.ToolTipValues.Heading = "Record value for Mean Daily Motion";
-		labelValue06.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue06.Values.Text = "-";
-		labelValue06.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue06.Enter += Control_Enter;
-		labelValue06.Leave += Control_Leave;
-		labelValue06.MouseEnter += Control_Enter;
-		labelValue06.MouseLeave += Control_Leave;
-		// 
-		// labelElement07
-		// 
-		labelElement07.AccessibleDescription = "Orbital element: Semi-Major Axis";
-		labelElement07.AccessibleName = "Semi-Major Axis";
-		labelElement07.AccessibleRole = AccessibleRole.StaticText;
-		labelElement07.Dock = DockStyle.Fill;
-		labelElement07.Location = new Point(3, 206);
-		labelElement07.Name = "labelElement07";
-		labelElement07.Size = new Size(214, 23);
-		labelElement07.TabIndex = 21;
-		labelElement07.ToolTipValues.Description = "Semi-Major Axis";
-		labelElement07.ToolTipValues.EnableToolTips = true;
-		labelElement07.ToolTipValues.Heading = "Semi-Major Axis";
-		labelElement07.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement07.Values.Text = "Semi-Major Axis";
-		labelElement07.Enter += Control_Enter;
-		labelElement07.Leave += Control_Leave;
-		labelElement07.MouseEnter += Control_Enter;
-		labelElement07.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation07
-		// 
-		labelDesignation07.AccessibleDescription = "Shows the readable designation for Semi-Major Axis record";
-		labelDesignation07.AccessibleName = "Readable designation for Semi-Major Axis";
-		labelDesignation07.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation07.Dock = DockStyle.Fill;
-		labelDesignation07.Location = new Point(223, 206);
-		labelDesignation07.Name = "labelDesignation07";
-		labelDesignation07.Size = new Size(274, 23);
-		labelDesignation07.TabIndex = 22;
-		labelDesignation07.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Semi-Major Axis.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation07.ToolTipValues.EnableToolTips = true;
-		labelDesignation07.ToolTipValues.Heading = "Readable designation for Semi-Major Axis";
-		labelDesignation07.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation07.Values.Text = "-";
-		labelDesignation07.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation07.Enter += Control_Enter;
-		labelDesignation07.Leave += Control_Leave;
-		labelDesignation07.MouseEnter += Control_Enter;
-		labelDesignation07.MouseLeave += Control_Leave;
-		// 
-		// labelValue07
-		// 
-		labelValue07.AccessibleDescription = "Shows the record value for Semi-Major Axis";
-		labelValue07.AccessibleName = "Record value for Semi-Major Axis";
-		labelValue07.AccessibleRole = AccessibleRole.StaticText;
-		labelValue07.Dock = DockStyle.Fill;
-		labelValue07.Location = new Point(503, 206);
-		labelValue07.Name = "labelValue07";
-		labelValue07.Size = new Size(164, 23);
-		labelValue07.TabIndex = 23;
-		labelValue07.ToolTipValues.Description = "Shows the record value for Semi-Major Axis.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue07.ToolTipValues.EnableToolTips = true;
-		labelValue07.ToolTipValues.Heading = "Record value for Semi-Major Axis";
-		labelValue07.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue07.Values.Text = "-";
-		labelValue07.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue07.Enter += Control_Enter;
-		labelValue07.Leave += Control_Leave;
-		labelValue07.MouseEnter += Control_Enter;
-		labelValue07.MouseLeave += Control_Leave;
-		// 
-		// labelElement08
-		// 
-		labelElement08.AccessibleDescription = "Orbital element: Absolute Magnitude (H)";
-		labelElement08.AccessibleName = "Absolute Magnitude";
-		labelElement08.AccessibleRole = AccessibleRole.StaticText;
-		labelElement08.Dock = DockStyle.Fill;
-		labelElement08.Location = new Point(3, 235);
-		labelElement08.Name = "labelElement08";
-		labelElement08.Size = new Size(214, 23);
-		labelElement08.TabIndex = 24;
-		labelElement08.ToolTipValues.Description = "Absolute Magnitude (H)";
-		labelElement08.ToolTipValues.EnableToolTips = true;
-		labelElement08.ToolTipValues.Heading = "Absolute Magnitude (H)";
-		labelElement08.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement08.Values.Text = "Absolute Magnitude (H)";
-		labelElement08.Enter += Control_Enter;
-		labelElement08.Leave += Control_Leave;
-		labelElement08.MouseEnter += Control_Enter;
-		labelElement08.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation08
-		// 
-		labelDesignation08.AccessibleDescription = "Shows the readable designation for Absolute Magnitude record";
-		labelDesignation08.AccessibleName = "Readable designation for Absolute Magnitude";
-		labelDesignation08.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation08.Dock = DockStyle.Fill;
-		labelDesignation08.Location = new Point(223, 235);
-		labelDesignation08.Name = "labelDesignation08";
-		labelDesignation08.Size = new Size(274, 23);
-		labelDesignation08.TabIndex = 25;
-		labelDesignation08.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Absolute Magnitude.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation08.ToolTipValues.EnableToolTips = true;
-		labelDesignation08.ToolTipValues.Heading = "Readable designation for Absolute Magnitude";
-		labelDesignation08.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation08.Values.Text = "-";
-		labelDesignation08.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation08.Enter += Control_Enter;
-		labelDesignation08.Leave += Control_Leave;
-		labelDesignation08.MouseEnter += Control_Enter;
-		labelDesignation08.MouseLeave += Control_Leave;
-		// 
-		// labelValue08
-		// 
-		labelValue08.AccessibleDescription = "Shows the record value for Absolute Magnitude";
-		labelValue08.AccessibleName = "Record value for Absolute Magnitude";
-		labelValue08.AccessibleRole = AccessibleRole.StaticText;
-		labelValue08.Dock = DockStyle.Fill;
-		labelValue08.Location = new Point(503, 235);
-		labelValue08.Name = "labelValue08";
-		labelValue08.Size = new Size(164, 23);
-		labelValue08.TabIndex = 26;
-		labelValue08.ToolTipValues.Description = "Shows the record value for Absolute Magnitude.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue08.ToolTipValues.EnableToolTips = true;
-		labelValue08.ToolTipValues.Heading = "Record value for Absolute Magnitude";
-		labelValue08.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue08.Values.Text = "-";
-		labelValue08.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue08.Enter += Control_Enter;
-		labelValue08.Leave += Control_Leave;
-		labelValue08.MouseEnter += Control_Enter;
-		labelValue08.MouseLeave += Control_Leave;
-		// 
-		// labelElement09
-		// 
-		labelElement09.AccessibleDescription = "Orbital element: Slope Parameter (G)";
-		labelElement09.AccessibleName = "Slope Parameter";
-		labelElement09.AccessibleRole = AccessibleRole.StaticText;
-		labelElement09.Dock = DockStyle.Fill;
-		labelElement09.Location = new Point(3, 264);
-		labelElement09.Name = "labelElement09";
-		labelElement09.Size = new Size(214, 23);
-		labelElement09.TabIndex = 27;
-		labelElement09.ToolTipValues.Description = "Slope Parameter (G)";
-		labelElement09.ToolTipValues.EnableToolTips = true;
-		labelElement09.ToolTipValues.Heading = "Slope Parameter (G)";
-		labelElement09.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement09.Values.Text = "Slope Parameter (G)";
-		labelElement09.Enter += Control_Enter;
-		labelElement09.Leave += Control_Leave;
-		labelElement09.MouseEnter += Control_Enter;
-		labelElement09.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation09
-		// 
-		labelDesignation09.AccessibleDescription = "Shows the readable designation for Slope Parameter record";
-		labelDesignation09.AccessibleName = "Readable designation for Slope Parameter";
-		labelDesignation09.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation09.Dock = DockStyle.Fill;
-		labelDesignation09.Location = new Point(223, 264);
-		labelDesignation09.Name = "labelDesignation09";
-		labelDesignation09.Size = new Size(274, 23);
-		labelDesignation09.TabIndex = 28;
-		labelDesignation09.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Slope Parameter.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation09.ToolTipValues.EnableToolTips = true;
-		labelDesignation09.ToolTipValues.Heading = "Readable designation for Slope Parameter";
-		labelDesignation09.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation09.Values.Text = "-";
-		labelDesignation09.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation09.Enter += Control_Enter;
-		labelDesignation09.Leave += Control_Leave;
-		labelDesignation09.MouseEnter += Control_Enter;
-		labelDesignation09.MouseLeave += Control_Leave;
-		// 
-		// labelValue09
-		// 
-		labelValue09.AccessibleDescription = "Shows the record value for Slope Parameter";
-		labelValue09.AccessibleName = "Record value for Slope Parameter";
-		labelValue09.AccessibleRole = AccessibleRole.StaticText;
-		labelValue09.Dock = DockStyle.Fill;
-		labelValue09.Location = new Point(503, 264);
-		labelValue09.Name = "labelValue09";
-		labelValue09.Size = new Size(164, 23);
-		labelValue09.TabIndex = 29;
-		labelValue09.ToolTipValues.Description = "Shows the record value for Slope Parameter.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue09.ToolTipValues.EnableToolTips = true;
-		labelValue09.ToolTipValues.Heading = "Record value for Slope Parameter";
-		labelValue09.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue09.Values.Text = "-";
-		labelValue09.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue09.Enter += Control_Enter;
-		labelValue09.Leave += Control_Leave;
-		labelValue09.MouseEnter += Control_Enter;
-		labelValue09.MouseLeave += Control_Leave;
-		// 
-		// labelElement10
-		// 
-		labelElement10.AccessibleDescription = "Orbital element: Number of Oppositions";
-		labelElement10.AccessibleName = "Number of Oppositions";
-		labelElement10.AccessibleRole = AccessibleRole.StaticText;
-		labelElement10.Dock = DockStyle.Fill;
-		labelElement10.Location = new Point(3, 293);
-		labelElement10.Name = "labelElement10";
-		labelElement10.Size = new Size(214, 23);
-		labelElement10.TabIndex = 30;
-		labelElement10.ToolTipValues.Description = "Number of Oppositions";
-		labelElement10.ToolTipValues.EnableToolTips = true;
-		labelElement10.ToolTipValues.Heading = "Number of Oppositions";
-		labelElement10.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement10.Values.Text = "Number of Oppositions";
-		labelElement10.Enter += Control_Enter;
-		labelElement10.Leave += Control_Leave;
-		labelElement10.MouseEnter += Control_Enter;
-		labelElement10.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation10
-		// 
-		labelDesignation10.AccessibleDescription = "Shows the readable designation for Number of Oppositions record";
-		labelDesignation10.AccessibleName = "Readable designation for Number of Oppositions";
-		labelDesignation10.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation10.Dock = DockStyle.Fill;
-		labelDesignation10.Location = new Point(223, 293);
-		labelDesignation10.Name = "labelDesignation10";
-		labelDesignation10.Size = new Size(274, 23);
-		labelDesignation10.TabIndex = 31;
-		labelDesignation10.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Number of Oppositions.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation10.ToolTipValues.EnableToolTips = true;
-		labelDesignation10.ToolTipValues.Heading = "Readable designation for Number of Oppositions";
-		labelDesignation10.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation10.Values.Text = "-";
-		labelDesignation10.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation10.Enter += Control_Enter;
-		labelDesignation10.Leave += Control_Leave;
-		labelDesignation10.MouseEnter += Control_Enter;
-		labelDesignation10.MouseLeave += Control_Leave;
-		// 
-		// labelValue10
-		// 
-		labelValue10.AccessibleDescription = "Shows the record value for Number of Oppositions";
-		labelValue10.AccessibleName = "Record value for Number of Oppositions";
-		labelValue10.AccessibleRole = AccessibleRole.StaticText;
-		labelValue10.Dock = DockStyle.Fill;
-		labelValue10.Location = new Point(503, 293);
-		labelValue10.Name = "labelValue10";
-		labelValue10.Size = new Size(164, 23);
-		labelValue10.TabIndex = 32;
-		labelValue10.ToolTipValues.Description = "Shows the record value for Number of Oppositions.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue10.ToolTipValues.EnableToolTips = true;
-		labelValue10.ToolTipValues.Heading = "Record value for Number of Oppositions";
-		labelValue10.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue10.Values.Text = "-";
-		labelValue10.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue10.Enter += Control_Enter;
-		labelValue10.Leave += Control_Leave;
-		labelValue10.MouseEnter += Control_Enter;
-		labelValue10.MouseLeave += Control_Leave;
-		// 
-		// labelElement11
-		// 
-		labelElement11.AccessibleDescription = "Orbital element: Number of Observations";
-		labelElement11.AccessibleName = "Number of Observations";
-		labelElement11.AccessibleRole = AccessibleRole.StaticText;
-		labelElement11.Dock = DockStyle.Fill;
-		labelElement11.Location = new Point(3, 322);
-		labelElement11.Name = "labelElement11";
-		labelElement11.Size = new Size(214, 23);
-		labelElement11.TabIndex = 33;
-		labelElement11.ToolTipValues.Description = "Number of Observations";
-		labelElement11.ToolTipValues.EnableToolTips = true;
-		labelElement11.ToolTipValues.Heading = "Number of Observations";
-		labelElement11.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement11.Values.Text = "Number of Observations";
-		labelElement11.Enter += Control_Enter;
-		labelElement11.Leave += Control_Leave;
-		labelElement11.MouseEnter += Control_Enter;
-		labelElement11.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation11
-		// 
-		labelDesignation11.AccessibleDescription = "Shows the readable designation for Number of Observations record";
-		labelDesignation11.AccessibleName = "Readable designation for Number of Observations";
-		labelDesignation11.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation11.Dock = DockStyle.Fill;
-		labelDesignation11.Location = new Point(223, 322);
-		labelDesignation11.Name = "labelDesignation11";
-		labelDesignation11.Size = new Size(274, 23);
-		labelDesignation11.TabIndex = 34;
-		labelDesignation11.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Number of Observations.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation11.ToolTipValues.EnableToolTips = true;
-		labelDesignation11.ToolTipValues.Heading = "Readable designation for Number of Observations";
-		labelDesignation11.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation11.Values.Text = "-";
-		labelDesignation11.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation11.Enter += Control_Enter;
-		labelDesignation11.Leave += Control_Leave;
-		labelDesignation11.MouseEnter += Control_Enter;
-		labelDesignation11.MouseLeave += Control_Leave;
-		// 
-		// labelValue11
-		// 
-		labelValue11.AccessibleDescription = "Shows the record value for Number of Observations";
-		labelValue11.AccessibleName = "Record value for Number of Observations";
-		labelValue11.AccessibleRole = AccessibleRole.StaticText;
-		labelValue11.Dock = DockStyle.Fill;
-		labelValue11.Location = new Point(503, 322);
-		labelValue11.Name = "labelValue11";
-		labelValue11.Size = new Size(164, 23);
-		labelValue11.TabIndex = 35;
-		labelValue11.ToolTipValues.Description = "Shows the record value for Number of Observations.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue11.ToolTipValues.EnableToolTips = true;
-		labelValue11.ToolTipValues.Heading = "Record value for Number of Observations";
-		labelValue11.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue11.Values.Text = "-";
-		labelValue11.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue11.Enter += Control_Enter;
-		labelValue11.Leave += Control_Leave;
-		labelValue11.MouseEnter += Control_Enter;
-		labelValue11.MouseLeave += Control_Leave;
-		// 
-		// labelElement12
-		// 
-		labelElement12.AccessibleDescription = "Orbital element: Observation Span";
-		labelElement12.AccessibleName = "Observation Span";
-		labelElement12.AccessibleRole = AccessibleRole.StaticText;
-		labelElement12.Dock = DockStyle.Fill;
-		labelElement12.Location = new Point(3, 351);
-		labelElement12.Name = "labelElement12";
-		labelElement12.Size = new Size(214, 23);
-		labelElement12.TabIndex = 36;
-		labelElement12.ToolTipValues.Description = "Observation Span";
-		labelElement12.ToolTipValues.EnableToolTips = true;
-		labelElement12.ToolTipValues.Heading = "Observation Span";
-		labelElement12.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement12.Values.Text = "Observation Span";
-		labelElement12.Enter += Control_Enter;
-		labelElement12.Leave += Control_Leave;
-		labelElement12.MouseEnter += Control_Enter;
-		labelElement12.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation12
-		// 
-		labelDesignation12.AccessibleDescription = "Shows the readable designation for Observation Span record";
-		labelDesignation12.AccessibleName = "Readable designation for Observation Span";
-		labelDesignation12.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation12.Dock = DockStyle.Fill;
-		labelDesignation12.Location = new Point(223, 351);
-		labelDesignation12.Name = "labelDesignation12";
-		labelDesignation12.Size = new Size(274, 23);
-		labelDesignation12.TabIndex = 37;
-		labelDesignation12.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for Observation Span.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation12.ToolTipValues.EnableToolTips = true;
-		labelDesignation12.ToolTipValues.Heading = "Readable designation for Observation Span";
-		labelDesignation12.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation12.Values.Text = "-";
-		labelDesignation12.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation12.Enter += Control_Enter;
-		labelDesignation12.Leave += Control_Leave;
-		labelDesignation12.MouseEnter += Control_Enter;
-		labelDesignation12.MouseLeave += Control_Leave;
-		// 
-		// labelValue12
-		// 
-		labelValue12.AccessibleDescription = "Shows the record value for Observation Span";
-		labelValue12.AccessibleName = "Record value for Observation Span";
-		labelValue12.AccessibleRole = AccessibleRole.StaticText;
-		labelValue12.Dock = DockStyle.Fill;
-		labelValue12.Location = new Point(503, 351);
-		labelValue12.Name = "labelValue12";
-		labelValue12.Size = new Size(164, 23);
-		labelValue12.TabIndex = 38;
-		labelValue12.ToolTipValues.Description = "Shows the record value for Observation Span.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue12.ToolTipValues.EnableToolTips = true;
-		labelValue12.ToolTipValues.Heading = "Record value for Observation Span";
-		labelValue12.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue12.Values.Text = "-";
-		labelValue12.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue12.Enter += Control_Enter;
-		labelValue12.Leave += Control_Leave;
-		labelValue12.MouseEnter += Control_Enter;
-		labelValue12.MouseLeave += Control_Leave;
-		// 
-		// labelElement13
-		// 
-		labelElement13.AccessibleDescription = "Orbital element: RMS Residual";
-		labelElement13.AccessibleName = "RMS Residual";
-		labelElement13.AccessibleRole = AccessibleRole.StaticText;
-		labelElement13.Dock = DockStyle.Fill;
-		labelElement13.Location = new Point(3, 380);
-		labelElement13.Name = "labelElement13";
-		labelElement13.Size = new Size(214, 23);
-		labelElement13.TabIndex = 39;
-		labelElement13.ToolTipValues.Description = "RMS Residual";
-		labelElement13.ToolTipValues.EnableToolTips = true;
-		labelElement13.ToolTipValues.Heading = "RMS Residual";
-		labelElement13.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelElement13.Values.Text = "RMS Residual";
-		labelElement13.Enter += Control_Enter;
-		labelElement13.Leave += Control_Leave;
-		labelElement13.MouseEnter += Control_Enter;
-		labelElement13.MouseLeave += Control_Leave;
-		// 
-		// labelDesignation13
-		// 
-		labelDesignation13.AccessibleDescription = "Shows the readable designation for RMS Residual record";
-		labelDesignation13.AccessibleName = "Readable designation for RMS Residual";
-		labelDesignation13.AccessibleRole = AccessibleRole.StaticText;
-		labelDesignation13.Dock = DockStyle.Fill;
-		labelDesignation13.Location = new Point(223, 380);
-		labelDesignation13.Name = "labelDesignation13";
-		labelDesignation13.Size = new Size(274, 23);
-		labelDesignation13.TabIndex = 40;
-		labelDesignation13.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for RMS Residual.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelDesignation13.ToolTipValues.EnableToolTips = true;
-		labelDesignation13.ToolTipValues.Heading = "Readable designation for RMS Residual";
-		labelDesignation13.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelDesignation13.Values.Text = "-";
-		labelDesignation13.DoubleClick += CopyToClipboard_DoubleClick;
-		labelDesignation13.Enter += Control_Enter;
-		labelDesignation13.Leave += Control_Leave;
-		labelDesignation13.MouseEnter += Control_Enter;
-		labelDesignation13.MouseLeave += Control_Leave;
-		// 
-		// labelValue13
-		// 
-		labelValue13.AccessibleDescription = "Shows the record value for RMS Residual";
-		labelValue13.AccessibleName = "Record value for RMS Residual";
-		labelValue13.AccessibleRole = AccessibleRole.StaticText;
-		labelValue13.Dock = DockStyle.Fill;
-		labelValue13.Location = new Point(503, 380);
-		labelValue13.Name = "labelValue13";
-		labelValue13.Size = new Size(164, 23);
-		labelValue13.TabIndex = 41;
-		labelValue13.ToolTipValues.Description = "Shows the record value for RMS Residual.\r\nDouble-click or right-click to copy the information to the clipboard.";
-		labelValue13.ToolTipValues.EnableToolTips = true;
-		labelValue13.ToolTipValues.Heading = "Record value for RMS Residual";
-		labelValue13.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		labelValue13.Values.Text = "-";
-		labelValue13.DoubleClick += CopyToClipboard_DoubleClick;
-		labelValue13.Enter += Control_Enter;
-		labelValue13.Leave += Control_Leave;
-		labelValue13.MouseEnter += Control_Enter;
-		labelValue13.MouseLeave += Control_Leave;
-		// 
-		// buttonStart
-		// 
-		buttonStart.AccessibleDescription = "Starts the record detection scan";
-		buttonStart.AccessibleName = "Start scan";
-		buttonStart.AccessibleRole = AccessibleRole.PushButton;
-		buttonStart.Location = new Point(14, 498);
-		buttonStart.Name = "buttonStart";
-		buttonStart.Size = new Size(85, 29);
-		buttonStart.TabIndex = 2;
-		buttonStart.ToolTipValues.Description = "Starts the record detection scan";
-		buttonStart.ToolTipValues.EnableToolTips = true;
-		buttonStart.ToolTipValues.Heading = "Start";
-		buttonStart.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		buttonStart.Values.DropDownArrowColor = Color.Empty;
-		buttonStart.Values.Image = FatcowIcons16px.fatcow_resultset_next_16px;
-		buttonStart.Values.Text = "&Start";
-		buttonStart.Click += ButtonStart_Click;
-		buttonStart.Enter += Control_Enter;
-		buttonStart.Leave += Control_Leave;
-		buttonStart.MouseEnter += Control_Enter;
-		buttonStart.MouseLeave += Control_Leave;
-		// 
-		// buttonCancel
-		// 
-		buttonCancel.AccessibleDescription = "Cancels the record detection scan";
-		buttonCancel.AccessibleName = "Cancel scan";
-		buttonCancel.AccessibleRole = AccessibleRole.PushButton;
-		buttonCancel.Enabled = false;
-		buttonCancel.Location = new Point(107, 498);
-		buttonCancel.Name = "buttonCancel";
-		buttonCancel.Size = new Size(85, 29);
-		buttonCancel.TabIndex = 3;
-		buttonCancel.ToolTipValues.Description = "Cancels the record detection scan";
-		buttonCancel.ToolTipValues.EnableToolTips = true;
-		buttonCancel.ToolTipValues.Heading = "Cancel";
-		buttonCancel.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		buttonCancel.Values.DropDownArrowColor = Color.Empty;
-		buttonCancel.Values.Image = FatcowIcons16px.fatcow_cancel_16px;
-		buttonCancel.Values.Text = "&Cancel";
-		buttonCancel.Click += ButtonCancel_Click;
-		buttonCancel.Enter += Control_Enter;
-		buttonCancel.Leave += Control_Leave;
-		buttonCancel.MouseEnter += Control_Enter;
-		buttonCancel.MouseLeave += Control_Leave;
-		// 
-		// progressBar
-		// 
-		progressBar.AccessibleDescription = "Shows the progress of the record detection";
-		progressBar.AccessibleName = "Progress bar";
-		progressBar.AccessibleRole = AccessibleRole.ProgressBar;
-		progressBar.Enabled = false;
-		progressBar.Location = new Point(200, 498);
-		progressBar.Name = "progressBar";
-		progressBar.Size = new Size(400, 29);
-		progressBar.TabIndex = 4;
-		progressBar.Text = "0 %";
-		progressBar.TextBackdropColor = Color.Empty;
-		progressBar.TextShadowColor = Color.Empty;
-		progressBar.Values.Text = "0 %";
-		progressBar.MouseEnter += Control_Enter;
-		progressBar.MouseLeave += Control_Leave;
+		// labelElementMeanAnomalyAtTheEpoch
+		// 
+		labelElementMeanAnomalyAtTheEpoch.AccessibleDescription = "Orbital element: mean anomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.AccessibleName = "Mean anomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.AccessibleRole = AccessibleRole.StaticText;
+		labelElementMeanAnomalyAtTheEpoch.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementMeanAnomalyAtTheEpoch.Dock = DockStyle.Fill;
+		labelElementMeanAnomalyAtTheEpoch.Location = new Point(3, 32);
+		labelElementMeanAnomalyAtTheEpoch.Name = "labelElementMeanAnomalyAtTheEpoch";
+		labelElementMeanAnomalyAtTheEpoch.Size = new Size(214, 23);
+		labelElementMeanAnomalyAtTheEpoch.TabIndex = 3;
+		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Description = "Mean anomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.EnableToolTips = true;
+		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Heading = "Mean enomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementMeanAnomalyAtTheEpoch.Values.Text = "Mean anomaly at the epoch";
+		labelElementMeanAnomalyAtTheEpoch.Enter += Control_Enter;
+		labelElementMeanAnomalyAtTheEpoch.Leave += Control_Leave;
+		labelElementMeanAnomalyAtTheEpoch.MouseDown += Control_MouseDown;
+		labelElementMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
+		labelElementMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationMeanAnomalyAtTheEpoch
+		// 
+		labelDesignationMeanAnomalyAtTheEpoch.AccessibleDescription = "Shows the readable designation for the mean anomaly record";
+		labelDesignationMeanAnomalyAtTheEpoch.AccessibleName = "Readable designation for the mean anomaly";
+		labelDesignationMeanAnomalyAtTheEpoch.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationMeanAnomalyAtTheEpoch.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationMeanAnomalyAtTheEpoch.Dock = DockStyle.Fill;
+		labelDesignationMeanAnomalyAtTheEpoch.Location = new Point(223, 32);
+		labelDesignationMeanAnomalyAtTheEpoch.Name = "labelDesignationMeanAnomalyAtTheEpoch";
+		labelDesignationMeanAnomalyAtTheEpoch.Size = new Size(182, 23);
+		labelDesignationMeanAnomalyAtTheEpoch.TabIndex = 4;
+		labelDesignationMeanAnomalyAtTheEpoch.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the mean anomaly at the epoch.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationMeanAnomalyAtTheEpoch.ToolTipValues.EnableToolTips = true;
+		labelDesignationMeanAnomalyAtTheEpoch.ToolTipValues.Heading = "Readable designation for the mean anomaly";
+		labelDesignationMeanAnomalyAtTheEpoch.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationMeanAnomalyAtTheEpoch.Values.Text = "-";
+		labelDesignationMeanAnomalyAtTheEpoch.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationMeanAnomalyAtTheEpoch.Enter += Control_Enter;
+		labelDesignationMeanAnomalyAtTheEpoch.Leave += Control_Leave;
+		labelDesignationMeanAnomalyAtTheEpoch.MouseDown += Control_MouseDown;
+		labelDesignationMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
+		labelDesignationMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
+		// 
+		// labelValueMeanAnomalyAtTheEpoch
+		// 
+		labelValueMeanAnomalyAtTheEpoch.AccessibleDescription = "Shows the record value for the mean anomaly at the epoch";
+		labelValueMeanAnomalyAtTheEpoch.AccessibleName = "Record value for the mean anomaly at the epoch";
+		labelValueMeanAnomalyAtTheEpoch.AccessibleRole = AccessibleRole.StaticText;
+		labelValueMeanAnomalyAtTheEpoch.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueMeanAnomalyAtTheEpoch.Dock = DockStyle.Fill;
+		labelValueMeanAnomalyAtTheEpoch.Location = new Point(411, 32);
+		labelValueMeanAnomalyAtTheEpoch.Name = "labelValueMeanAnomalyAtTheEpoch";
+		labelValueMeanAnomalyAtTheEpoch.Size = new Size(128, 23);
+		labelValueMeanAnomalyAtTheEpoch.TabIndex = 5;
+		labelValueMeanAnomalyAtTheEpoch.ToolTipValues.Description = "Shows the record value for the mean anomaly at the epoch.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueMeanAnomalyAtTheEpoch.ToolTipValues.EnableToolTips = true;
+		labelValueMeanAnomalyAtTheEpoch.ToolTipValues.Heading = "Record value for the mean anomaly at the epoch";
+		labelValueMeanAnomalyAtTheEpoch.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueMeanAnomalyAtTheEpoch.Values.Text = "-";
+		labelValueMeanAnomalyAtTheEpoch.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueMeanAnomalyAtTheEpoch.Enter += Control_Enter;
+		labelValueMeanAnomalyAtTheEpoch.Leave += Control_Leave;
+		labelValueMeanAnomalyAtTheEpoch.MouseDown += Control_MouseDown;
+		labelValueMeanAnomalyAtTheEpoch.MouseEnter += Control_Enter;
+		labelValueMeanAnomalyAtTheEpoch.MouseLeave += Control_Leave;
+		// 
+		// labelElementArgumentOfThePerihelion
+		// 
+		labelElementArgumentOfThePerihelion.AccessibleDescription = "Orbital element: Argument of the perihelion";
+		labelElementArgumentOfThePerihelion.AccessibleName = "Argument of the perihelion";
+		labelElementArgumentOfThePerihelion.AccessibleRole = AccessibleRole.StaticText;
+		labelElementArgumentOfThePerihelion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementArgumentOfThePerihelion.Dock = DockStyle.Fill;
+		labelElementArgumentOfThePerihelion.Location = new Point(3, 61);
+		labelElementArgumentOfThePerihelion.Name = "labelElementArgumentOfThePerihelion";
+		labelElementArgumentOfThePerihelion.Size = new Size(214, 23);
+		labelElementArgumentOfThePerihelion.TabIndex = 6;
+		labelElementArgumentOfThePerihelion.ToolTipValues.Description = "Argument of the perihelion";
+		labelElementArgumentOfThePerihelion.ToolTipValues.EnableToolTips = true;
+		labelElementArgumentOfThePerihelion.ToolTipValues.Heading = "Argument of the perihelion";
+		labelElementArgumentOfThePerihelion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementArgumentOfThePerihelion.Values.Text = "Argument of the perihelion";
+		labelElementArgumentOfThePerihelion.Enter += Control_Enter;
+		labelElementArgumentOfThePerihelion.Leave += Control_Leave;
+		labelElementArgumentOfThePerihelion.MouseDown += Control_MouseDown;
+		labelElementArgumentOfThePerihelion.MouseEnter += Control_Enter;
+		labelElementArgumentOfThePerihelion.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationArgumentOfThePerihelion
+		// 
+		labelDesignationArgumentOfThePerihelion.AccessibleDescription = "Shows the readable designation for the argument of the perihelion record";
+		labelDesignationArgumentOfThePerihelion.AccessibleName = "Readable designation for the argument of the perihelion";
+		labelDesignationArgumentOfThePerihelion.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationArgumentOfThePerihelion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationArgumentOfThePerihelion.Dock = DockStyle.Fill;
+		labelDesignationArgumentOfThePerihelion.Location = new Point(223, 61);
+		labelDesignationArgumentOfThePerihelion.Name = "labelDesignationArgumentOfThePerihelion";
+		labelDesignationArgumentOfThePerihelion.Size = new Size(182, 23);
+		labelDesignationArgumentOfThePerihelion.TabIndex = 7;
+		labelDesignationArgumentOfThePerihelion.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the argument of the perihelion.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationArgumentOfThePerihelion.ToolTipValues.EnableToolTips = true;
+		labelDesignationArgumentOfThePerihelion.ToolTipValues.Heading = "Readable designation for the argument of the perihelion";
+		labelDesignationArgumentOfThePerihelion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationArgumentOfThePerihelion.Values.Text = "-";
+		labelDesignationArgumentOfThePerihelion.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationArgumentOfThePerihelion.Enter += Control_Enter;
+		labelDesignationArgumentOfThePerihelion.Leave += Control_Leave;
+		labelDesignationArgumentOfThePerihelion.MouseDown += Control_MouseDown;
+		labelDesignationArgumentOfThePerihelion.MouseEnter += Control_Enter;
+		labelDesignationArgumentOfThePerihelion.MouseLeave += Control_Leave;
+		// 
+		// labelValueArgumentOfThePerihelion
+		// 
+		labelValueArgumentOfThePerihelion.AccessibleDescription = "Shows the record value for the argument of the perihelion";
+		labelValueArgumentOfThePerihelion.AccessibleName = "Record value for the argument of the perihelion";
+		labelValueArgumentOfThePerihelion.AccessibleRole = AccessibleRole.StaticText;
+		labelValueArgumentOfThePerihelion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueArgumentOfThePerihelion.Dock = DockStyle.Fill;
+		labelValueArgumentOfThePerihelion.Location = new Point(411, 61);
+		labelValueArgumentOfThePerihelion.Name = "labelValueArgumentOfThePerihelion";
+		labelValueArgumentOfThePerihelion.Size = new Size(128, 23);
+		labelValueArgumentOfThePerihelion.TabIndex = 8;
+		labelValueArgumentOfThePerihelion.ToolTipValues.Description = "Shows the record value for the argument of the perihelion.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueArgumentOfThePerihelion.ToolTipValues.EnableToolTips = true;
+		labelValueArgumentOfThePerihelion.ToolTipValues.Heading = "Record value for the argument of the perihelion";
+		labelValueArgumentOfThePerihelion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueArgumentOfThePerihelion.Values.Text = "-";
+		labelValueArgumentOfThePerihelion.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueArgumentOfThePerihelion.Enter += Control_Enter;
+		labelValueArgumentOfThePerihelion.Leave += Control_Leave;
+		labelValueArgumentOfThePerihelion.MouseDown += Control_MouseDown;
+		labelValueArgumentOfThePerihelion.MouseEnter += Control_Enter;
+		labelValueArgumentOfThePerihelion.MouseLeave += Control_Leave;
+		// 
+		// labelElementLongitudeOfTheAscendingNodeDesc
+		// 
+		labelElementLongitudeOfTheAscendingNodeDesc.AccessibleDescription = "Orbital element: Longitude of the ascending node";
+		labelElementLongitudeOfTheAscendingNodeDesc.AccessibleName = "Longitude of the ascending node";
+		labelElementLongitudeOfTheAscendingNodeDesc.AccessibleRole = AccessibleRole.StaticText;
+		labelElementLongitudeOfTheAscendingNodeDesc.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementLongitudeOfTheAscendingNodeDesc.Dock = DockStyle.Fill;
+		labelElementLongitudeOfTheAscendingNodeDesc.Location = new Point(3, 90);
+		labelElementLongitudeOfTheAscendingNodeDesc.Name = "labelElementLongitudeOfTheAscendingNodeDesc";
+		labelElementLongitudeOfTheAscendingNodeDesc.Size = new Size(214, 23);
+		labelElementLongitudeOfTheAscendingNodeDesc.TabIndex = 9;
+		labelElementLongitudeOfTheAscendingNodeDesc.ToolTipValues.Description = "Longitude of the ascending node";
+		labelElementLongitudeOfTheAscendingNodeDesc.ToolTipValues.EnableToolTips = true;
+		labelElementLongitudeOfTheAscendingNodeDesc.ToolTipValues.Heading = "Longitude of the ascending node";
+		labelElementLongitudeOfTheAscendingNodeDesc.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementLongitudeOfTheAscendingNodeDesc.Values.Text = "Longitude of the ascending node";
+		labelElementLongitudeOfTheAscendingNodeDesc.Enter += Control_Enter;
+		labelElementLongitudeOfTheAscendingNodeDesc.Leave += Control_Leave;
+		labelElementLongitudeOfTheAscendingNodeDesc.MouseDown += Control_MouseDown;
+		labelElementLongitudeOfTheAscendingNodeDesc.MouseEnter += Control_Enter;
+		labelElementLongitudeOfTheAscendingNodeDesc.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationLongitudeOfTheAscendingNode
+		// 
+		labelDesignationLongitudeOfTheAscendingNode.AccessibleDescription = "Shows the readable designation for Longitude of the ascending node record";
+		labelDesignationLongitudeOfTheAscendingNode.AccessibleName = "Readable designation for the longitude of the ascending node";
+		labelDesignationLongitudeOfTheAscendingNode.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationLongitudeOfTheAscendingNode.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationLongitudeOfTheAscendingNode.Dock = DockStyle.Fill;
+		labelDesignationLongitudeOfTheAscendingNode.Location = new Point(223, 90);
+		labelDesignationLongitudeOfTheAscendingNode.Name = "labelDesignationLongitudeOfTheAscendingNode";
+		labelDesignationLongitudeOfTheAscendingNode.Size = new Size(182, 23);
+		labelDesignationLongitudeOfTheAscendingNode.TabIndex = 10;
+		labelDesignationLongitudeOfTheAscendingNode.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the longitude of the ascending node.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationLongitudeOfTheAscendingNode.ToolTipValues.EnableToolTips = true;
+		labelDesignationLongitudeOfTheAscendingNode.ToolTipValues.Heading = "Readable designation for the longitude of the ascending node";
+		labelDesignationLongitudeOfTheAscendingNode.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationLongitudeOfTheAscendingNode.Values.Text = "-";
+		labelDesignationLongitudeOfTheAscendingNode.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationLongitudeOfTheAscendingNode.Enter += Control_Enter;
+		labelDesignationLongitudeOfTheAscendingNode.Leave += Control_Leave;
+		labelDesignationLongitudeOfTheAscendingNode.MouseDown += Control_MouseDown;
+		labelDesignationLongitudeOfTheAscendingNode.MouseEnter += Control_Enter;
+		labelDesignationLongitudeOfTheAscendingNode.MouseLeave += Control_Leave;
+		// 
+		// labelValueLongitudeOfTheAscendingNode
+		// 
+		labelValueLongitudeOfTheAscendingNode.AccessibleDescription = "Shows the record value for the longitude of the ascending node";
+		labelValueLongitudeOfTheAscendingNode.AccessibleName = "Record value for the longitude of the ascending node";
+		labelValueLongitudeOfTheAscendingNode.AccessibleRole = AccessibleRole.StaticText;
+		labelValueLongitudeOfTheAscendingNode.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueLongitudeOfTheAscendingNode.Dock = DockStyle.Fill;
+		labelValueLongitudeOfTheAscendingNode.Location = new Point(411, 90);
+		labelValueLongitudeOfTheAscendingNode.Name = "labelValueLongitudeOfTheAscendingNode";
+		labelValueLongitudeOfTheAscendingNode.Size = new Size(128, 23);
+		labelValueLongitudeOfTheAscendingNode.TabIndex = 11;
+		labelValueLongitudeOfTheAscendingNode.ToolTipValues.Description = "Shows the record value for the longitude of the ascending node.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueLongitudeOfTheAscendingNode.ToolTipValues.EnableToolTips = true;
+		labelValueLongitudeOfTheAscendingNode.ToolTipValues.Heading = "Record value for the longitude of the ascending node";
+		labelValueLongitudeOfTheAscendingNode.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueLongitudeOfTheAscendingNode.Values.Text = "-";
+		labelValueLongitudeOfTheAscendingNode.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueLongitudeOfTheAscendingNode.Enter += Control_Enter;
+		labelValueLongitudeOfTheAscendingNode.Leave += Control_Leave;
+		labelValueLongitudeOfTheAscendingNode.MouseDown += Control_MouseDown;
+		labelValueLongitudeOfTheAscendingNode.MouseEnter += Control_Enter;
+		labelValueLongitudeOfTheAscendingNode.MouseLeave += Control_Leave;
+		// 
+		// labelElementInclinationToTheEcliptic
+		// 
+		labelElementInclinationToTheEcliptic.AccessibleDescription = "Orbital element: Inclination to the ecliptic";
+		labelElementInclinationToTheEcliptic.AccessibleName = "Inclination to the ecliptic";
+		labelElementInclinationToTheEcliptic.AccessibleRole = AccessibleRole.StaticText;
+		labelElementInclinationToTheEcliptic.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementInclinationToTheEcliptic.Dock = DockStyle.Fill;
+		labelElementInclinationToTheEcliptic.Location = new Point(3, 119);
+		labelElementInclinationToTheEcliptic.Name = "labelElementInclinationToTheEcliptic";
+		labelElementInclinationToTheEcliptic.Size = new Size(214, 23);
+		labelElementInclinationToTheEcliptic.TabIndex = 12;
+		labelElementInclinationToTheEcliptic.ToolTipValues.Description = "Inclination to the ecliptic";
+		labelElementInclinationToTheEcliptic.ToolTipValues.EnableToolTips = true;
+		labelElementInclinationToTheEcliptic.ToolTipValues.Heading = "Inclination to the ecliptic";
+		labelElementInclinationToTheEcliptic.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementInclinationToTheEcliptic.Values.Text = "Inclination to the ecliptic";
+		labelElementInclinationToTheEcliptic.Enter += Control_Enter;
+		labelElementInclinationToTheEcliptic.Leave += Control_Leave;
+		labelElementInclinationToTheEcliptic.MouseDown += Control_MouseDown;
+		labelElementInclinationToTheEcliptic.MouseEnter += Control_Enter;
+		labelElementInclinationToTheEcliptic.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationInclinationToTheEcliptic
+		// 
+		labelDesignationInclinationToTheEcliptic.AccessibleDescription = "Shows the readable designation for the inclination to the ecliptic record";
+		labelDesignationInclinationToTheEcliptic.AccessibleName = "Readable designation for the inclination to the ecliptic";
+		labelDesignationInclinationToTheEcliptic.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationInclinationToTheEcliptic.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationInclinationToTheEcliptic.Dock = DockStyle.Fill;
+		labelDesignationInclinationToTheEcliptic.Location = new Point(223, 119);
+		labelDesignationInclinationToTheEcliptic.Name = "labelDesignationInclinationToTheEcliptic";
+		labelDesignationInclinationToTheEcliptic.Size = new Size(182, 23);
+		labelDesignationInclinationToTheEcliptic.TabIndex = 13;
+		labelDesignationInclinationToTheEcliptic.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the inclination to the ecliptic.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationInclinationToTheEcliptic.ToolTipValues.EnableToolTips = true;
+		labelDesignationInclinationToTheEcliptic.ToolTipValues.Heading = "Readable designation for the inclination to the ecliptic";
+		labelDesignationInclinationToTheEcliptic.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationInclinationToTheEcliptic.Values.Text = "-";
+		labelDesignationInclinationToTheEcliptic.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationInclinationToTheEcliptic.Enter += Control_Enter;
+		labelDesignationInclinationToTheEcliptic.Leave += Control_Leave;
+		labelDesignationInclinationToTheEcliptic.MouseDown += Control_MouseDown;
+		labelDesignationInclinationToTheEcliptic.MouseEnter += Control_Enter;
+		labelDesignationInclinationToTheEcliptic.MouseLeave += Control_Leave;
+		// 
+		// labelValueInclinationToTheEcliptic
+		// 
+		labelValueInclinationToTheEcliptic.AccessibleDescription = "Shows the record value for the inclination to the ecliptic";
+		labelValueInclinationToTheEcliptic.AccessibleName = "Record value for the inclination to the ecliptic";
+		labelValueInclinationToTheEcliptic.AccessibleRole = AccessibleRole.StaticText;
+		labelValueInclinationToTheEcliptic.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueInclinationToTheEcliptic.Dock = DockStyle.Fill;
+		labelValueInclinationToTheEcliptic.Location = new Point(411, 119);
+		labelValueInclinationToTheEcliptic.Name = "labelValueInclinationToTheEcliptic";
+		labelValueInclinationToTheEcliptic.Size = new Size(128, 23);
+		labelValueInclinationToTheEcliptic.TabIndex = 14;
+		labelValueInclinationToTheEcliptic.ToolTipValues.Description = "Shows the record value for the inclination to the ecliptic.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueInclinationToTheEcliptic.ToolTipValues.EnableToolTips = true;
+		labelValueInclinationToTheEcliptic.ToolTipValues.Heading = "Record value for the inclination to the ecliptic";
+		labelValueInclinationToTheEcliptic.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueInclinationToTheEcliptic.Values.Text = "-";
+		labelValueInclinationToTheEcliptic.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueInclinationToTheEcliptic.Enter += Control_Enter;
+		labelValueInclinationToTheEcliptic.Leave += Control_Leave;
+		labelValueInclinationToTheEcliptic.MouseDown += Control_MouseDown;
+		labelValueInclinationToTheEcliptic.MouseEnter += Control_Enter;
+		labelValueInclinationToTheEcliptic.MouseLeave += Control_Leave;
+		// 
+		// labelElementOrbitalEccentricity
+		// 
+		labelElementOrbitalEccentricity.AccessibleDescription = "Orbital element: Orbital eccentricity";
+		labelElementOrbitalEccentricity.AccessibleName = "Orbital eccentricity";
+		labelElementOrbitalEccentricity.AccessibleRole = AccessibleRole.StaticText;
+		labelElementOrbitalEccentricity.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementOrbitalEccentricity.Dock = DockStyle.Fill;
+		labelElementOrbitalEccentricity.Location = new Point(3, 148);
+		labelElementOrbitalEccentricity.Name = "labelElementOrbitalEccentricity";
+		labelElementOrbitalEccentricity.Size = new Size(214, 23);
+		labelElementOrbitalEccentricity.TabIndex = 15;
+		labelElementOrbitalEccentricity.ToolTipValues.Description = "Orbital eccentricity";
+		labelElementOrbitalEccentricity.ToolTipValues.EnableToolTips = true;
+		labelElementOrbitalEccentricity.ToolTipValues.Heading = "Orbital eccentricity";
+		labelElementOrbitalEccentricity.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementOrbitalEccentricity.Values.Text = "Orbital eccentricity";
+		labelElementOrbitalEccentricity.Enter += Control_Enter;
+		labelElementOrbitalEccentricity.Leave += Control_Leave;
+		labelElementOrbitalEccentricity.MouseDown += Control_MouseDown;
+		labelElementOrbitalEccentricity.MouseEnter += Control_Enter;
+		labelElementOrbitalEccentricity.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationOrbitalEccentricity
+		// 
+		labelDesignationOrbitalEccentricity.AccessibleDescription = "Shows the readable designation for orbital eccentricity record";
+		labelDesignationOrbitalEccentricity.AccessibleName = "Readable designation for orbital eccentricity";
+		labelDesignationOrbitalEccentricity.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationOrbitalEccentricity.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationOrbitalEccentricity.Dock = DockStyle.Fill;
+		labelDesignationOrbitalEccentricity.Location = new Point(223, 148);
+		labelDesignationOrbitalEccentricity.Name = "labelDesignationOrbitalEccentricity";
+		labelDesignationOrbitalEccentricity.Size = new Size(182, 23);
+		labelDesignationOrbitalEccentricity.TabIndex = 16;
+		labelDesignationOrbitalEccentricity.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the orbital eccentricity.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationOrbitalEccentricity.ToolTipValues.EnableToolTips = true;
+		labelDesignationOrbitalEccentricity.ToolTipValues.Heading = "Readable designation for the orbital eccentricity";
+		labelDesignationOrbitalEccentricity.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationOrbitalEccentricity.Values.Text = "-";
+		labelDesignationOrbitalEccentricity.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationOrbitalEccentricity.Enter += Control_Enter;
+		labelDesignationOrbitalEccentricity.Leave += Control_Leave;
+		labelDesignationOrbitalEccentricity.MouseDown += Control_MouseDown;
+		labelDesignationOrbitalEccentricity.MouseEnter += Control_Enter;
+		labelDesignationOrbitalEccentricity.MouseLeave += Control_Leave;
+		// 
+		// labelValueOrbitalEccentricity
+		// 
+		labelValueOrbitalEccentricity.AccessibleDescription = "Shows the record value for the orbital eccentricity";
+		labelValueOrbitalEccentricity.AccessibleName = "Record value for the orbital eccentricity";
+		labelValueOrbitalEccentricity.AccessibleRole = AccessibleRole.StaticText;
+		labelValueOrbitalEccentricity.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueOrbitalEccentricity.Dock = DockStyle.Fill;
+		labelValueOrbitalEccentricity.Location = new Point(411, 148);
+		labelValueOrbitalEccentricity.Name = "labelValueOrbitalEccentricity";
+		labelValueOrbitalEccentricity.Size = new Size(128, 23);
+		labelValueOrbitalEccentricity.TabIndex = 17;
+		labelValueOrbitalEccentricity.ToolTipValues.Description = "Shows the record value for the orbital eccentricity.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueOrbitalEccentricity.ToolTipValues.EnableToolTips = true;
+		labelValueOrbitalEccentricity.ToolTipValues.Heading = "Record value for the orbital eccentricity";
+		labelValueOrbitalEccentricity.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueOrbitalEccentricity.Values.Text = "-";
+		labelValueOrbitalEccentricity.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueOrbitalEccentricity.Enter += Control_Enter;
+		labelValueOrbitalEccentricity.Leave += Control_Leave;
+		labelValueOrbitalEccentricity.MouseDown += Control_MouseDown;
+		labelValueOrbitalEccentricity.MouseEnter += Control_Enter;
+		labelValueOrbitalEccentricity.MouseLeave += Control_Leave;
+		// 
+		// labelElementMeanDailyMotion
+		// 
+		labelElementMeanDailyMotion.AccessibleDescription = "Orbital element: Mean daily motion";
+		labelElementMeanDailyMotion.AccessibleName = "Mean daily motion";
+		labelElementMeanDailyMotion.AccessibleRole = AccessibleRole.StaticText;
+		labelElementMeanDailyMotion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementMeanDailyMotion.Dock = DockStyle.Fill;
+		labelElementMeanDailyMotion.Location = new Point(3, 177);
+		labelElementMeanDailyMotion.Name = "labelElementMeanDailyMotion";
+		labelElementMeanDailyMotion.Size = new Size(214, 23);
+		labelElementMeanDailyMotion.TabIndex = 18;
+		labelElementMeanDailyMotion.ToolTipValues.Description = "Mean daily motion";
+		labelElementMeanDailyMotion.ToolTipValues.EnableToolTips = true;
+		labelElementMeanDailyMotion.ToolTipValues.Heading = "Mean daily motion";
+		labelElementMeanDailyMotion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementMeanDailyMotion.Values.Text = "Mean daily motion";
+		labelElementMeanDailyMotion.Enter += Control_Enter;
+		labelElementMeanDailyMotion.Leave += Control_Leave;
+		labelElementMeanDailyMotion.MouseDown += Control_MouseDown;
+		labelElementMeanDailyMotion.MouseEnter += Control_Enter;
+		labelElementMeanDailyMotion.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationMeanDailyMotion
+		// 
+		labelDesignationMeanDailyMotion.AccessibleDescription = "Shows the readable designation for the mean daily motion record";
+		labelDesignationMeanDailyMotion.AccessibleName = "Readable designation for the mean daily motion";
+		labelDesignationMeanDailyMotion.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationMeanDailyMotion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationMeanDailyMotion.Dock = DockStyle.Fill;
+		labelDesignationMeanDailyMotion.Location = new Point(223, 177);
+		labelDesignationMeanDailyMotion.Name = "labelDesignationMeanDailyMotion";
+		labelDesignationMeanDailyMotion.Size = new Size(182, 23);
+		labelDesignationMeanDailyMotion.TabIndex = 19;
+		labelDesignationMeanDailyMotion.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the mean daily motion.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationMeanDailyMotion.ToolTipValues.EnableToolTips = true;
+		labelDesignationMeanDailyMotion.ToolTipValues.Heading = "Readable designation for the mean daily motion";
+		labelDesignationMeanDailyMotion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationMeanDailyMotion.Values.Text = "-";
+		labelDesignationMeanDailyMotion.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationMeanDailyMotion.Enter += Control_Enter;
+		labelDesignationMeanDailyMotion.Leave += Control_Leave;
+		labelDesignationMeanDailyMotion.MouseDown += Control_MouseDown;
+		labelDesignationMeanDailyMotion.MouseEnter += Control_Enter;
+		labelDesignationMeanDailyMotion.MouseLeave += Control_Leave;
+		// 
+		// labelValueMeanDailyMotion
+		// 
+		labelValueMeanDailyMotion.AccessibleDescription = "Shows the record value for mean daily motion";
+		labelValueMeanDailyMotion.AccessibleName = "Record value for the mean daily motion";
+		labelValueMeanDailyMotion.AccessibleRole = AccessibleRole.StaticText;
+		labelValueMeanDailyMotion.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueMeanDailyMotion.Dock = DockStyle.Fill;
+		labelValueMeanDailyMotion.Location = new Point(411, 177);
+		labelValueMeanDailyMotion.Name = "labelValueMeanDailyMotion";
+		labelValueMeanDailyMotion.Size = new Size(128, 23);
+		labelValueMeanDailyMotion.TabIndex = 20;
+		labelValueMeanDailyMotion.ToolTipValues.Description = "Shows the record value for the mean daily motion.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueMeanDailyMotion.ToolTipValues.EnableToolTips = true;
+		labelValueMeanDailyMotion.ToolTipValues.Heading = "Record value for mean daily motion";
+		labelValueMeanDailyMotion.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueMeanDailyMotion.Values.Text = "-";
+		labelValueMeanDailyMotion.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueMeanDailyMotion.Enter += Control_Enter;
+		labelValueMeanDailyMotion.Leave += Control_Leave;
+		labelValueMeanDailyMotion.MouseDown += Control_MouseDown;
+		labelValueMeanDailyMotion.MouseEnter += Control_Enter;
+		labelValueMeanDailyMotion.MouseLeave += Control_Leave;
+		// 
+		// labelElementSemiMajorAxis
+		// 
+		labelElementSemiMajorAxis.AccessibleDescription = "Orbital element: Semi-major axis";
+		labelElementSemiMajorAxis.AccessibleName = "Semi-major axis";
+		labelElementSemiMajorAxis.AccessibleRole = AccessibleRole.StaticText;
+		labelElementSemiMajorAxis.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementSemiMajorAxis.Dock = DockStyle.Fill;
+		labelElementSemiMajorAxis.Location = new Point(3, 206);
+		labelElementSemiMajorAxis.Name = "labelElementSemiMajorAxis";
+		labelElementSemiMajorAxis.Size = new Size(214, 23);
+		labelElementSemiMajorAxis.TabIndex = 21;
+		labelElementSemiMajorAxis.ToolTipValues.Description = "Semi-major axis";
+		labelElementSemiMajorAxis.ToolTipValues.EnableToolTips = true;
+		labelElementSemiMajorAxis.ToolTipValues.Heading = "Semi-major axis";
+		labelElementSemiMajorAxis.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementSemiMajorAxis.Values.Text = "Semi-major axis";
+		labelElementSemiMajorAxis.Enter += Control_Enter;
+		labelElementSemiMajorAxis.Leave += Control_Leave;
+		labelElementSemiMajorAxis.MouseDown += Control_MouseDown;
+		labelElementSemiMajorAxis.MouseEnter += Control_Enter;
+		labelElementSemiMajorAxis.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationSemiMajorAxis
+		// 
+		labelDesignationSemiMajorAxis.AccessibleDescription = "Shows the readable designation for the semi-major axis record";
+		labelDesignationSemiMajorAxis.AccessibleName = "Readable designation for the semi-major axis";
+		labelDesignationSemiMajorAxis.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationSemiMajorAxis.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationSemiMajorAxis.Dock = DockStyle.Fill;
+		labelDesignationSemiMajorAxis.Location = new Point(223, 206);
+		labelDesignationSemiMajorAxis.Name = "labelDesignationSemiMajorAxis";
+		labelDesignationSemiMajorAxis.Size = new Size(182, 23);
+		labelDesignationSemiMajorAxis.TabIndex = 22;
+		labelDesignationSemiMajorAxis.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the semi-major axis.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationSemiMajorAxis.ToolTipValues.EnableToolTips = true;
+		labelDesignationSemiMajorAxis.ToolTipValues.Heading = "Readable designation for semi-major axis";
+		labelDesignationSemiMajorAxis.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationSemiMajorAxis.Values.Text = "-";
+		labelDesignationSemiMajorAxis.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationSemiMajorAxis.Enter += Control_Enter;
+		labelDesignationSemiMajorAxis.Leave += Control_Leave;
+		labelDesignationSemiMajorAxis.MouseDown += Control_MouseDown;
+		labelDesignationSemiMajorAxis.MouseEnter += Control_Enter;
+		labelDesignationSemiMajorAxis.MouseLeave += Control_Leave;
+		// 
+		// labelValueSemiMajorAxis
+		// 
+		labelValueSemiMajorAxis.AccessibleDescription = "Shows the record value for the semi-major axis";
+		labelValueSemiMajorAxis.AccessibleName = "Record value for the semi-major axis";
+		labelValueSemiMajorAxis.AccessibleRole = AccessibleRole.StaticText;
+		labelValueSemiMajorAxis.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueSemiMajorAxis.Dock = DockStyle.Fill;
+		labelValueSemiMajorAxis.Location = new Point(411, 206);
+		labelValueSemiMajorAxis.Name = "labelValueSemiMajorAxis";
+		labelValueSemiMajorAxis.Size = new Size(128, 23);
+		labelValueSemiMajorAxis.TabIndex = 23;
+		labelValueSemiMajorAxis.ToolTipValues.Description = "Shows the record value for the semi-major axis.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueSemiMajorAxis.ToolTipValues.EnableToolTips = true;
+		labelValueSemiMajorAxis.ToolTipValues.Heading = "Record value for the semi-major axis";
+		labelValueSemiMajorAxis.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueSemiMajorAxis.Values.Text = "-";
+		labelValueSemiMajorAxis.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueSemiMajorAxis.Enter += Control_Enter;
+		labelValueSemiMajorAxis.Leave += Control_Leave;
+		labelValueSemiMajorAxis.MouseDown += Control_MouseDown;
+		labelValueSemiMajorAxis.MouseEnter += Control_Enter;
+		labelValueSemiMajorAxis.MouseLeave += Control_Leave;
+		// 
+		// labelElementAbsoluteMagnitude
+		// 
+		labelElementAbsoluteMagnitude.AccessibleDescription = "Orbital element: Absolute magnitude (H)";
+		labelElementAbsoluteMagnitude.AccessibleName = "Absolute magnitude";
+		labelElementAbsoluteMagnitude.AccessibleRole = AccessibleRole.StaticText;
+		labelElementAbsoluteMagnitude.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementAbsoluteMagnitude.Dock = DockStyle.Fill;
+		labelElementAbsoluteMagnitude.Location = new Point(3, 235);
+		labelElementAbsoluteMagnitude.Name = "labelElementAbsoluteMagnitude";
+		labelElementAbsoluteMagnitude.Size = new Size(214, 23);
+		labelElementAbsoluteMagnitude.TabIndex = 24;
+		labelElementAbsoluteMagnitude.ToolTipValues.Description = "Absolute magnitude (H)";
+		labelElementAbsoluteMagnitude.ToolTipValues.EnableToolTips = true;
+		labelElementAbsoluteMagnitude.ToolTipValues.Heading = "Absolute magnitude (H)";
+		labelElementAbsoluteMagnitude.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementAbsoluteMagnitude.Values.Text = "Absolute magnitude (H)";
+		labelElementAbsoluteMagnitude.Enter += Control_Enter;
+		labelElementAbsoluteMagnitude.Leave += Control_Leave;
+		labelElementAbsoluteMagnitude.MouseDown += Control_MouseDown;
+		labelElementAbsoluteMagnitude.MouseEnter += Control_Enter;
+		labelElementAbsoluteMagnitude.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationAbsoluteMagnitude
+		// 
+		labelDesignationAbsoluteMagnitude.AccessibleDescription = "Shows the readable designation for the absolute magnitude record";
+		labelDesignationAbsoluteMagnitude.AccessibleName = "Readable designation for the absolute magnitude";
+		labelDesignationAbsoluteMagnitude.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationAbsoluteMagnitude.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationAbsoluteMagnitude.Dock = DockStyle.Fill;
+		labelDesignationAbsoluteMagnitude.Location = new Point(223, 235);
+		labelDesignationAbsoluteMagnitude.Name = "labelDesignationAbsoluteMagnitude";
+		labelDesignationAbsoluteMagnitude.Size = new Size(182, 23);
+		labelDesignationAbsoluteMagnitude.TabIndex = 25;
+		labelDesignationAbsoluteMagnitude.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the absolute magnitude.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationAbsoluteMagnitude.ToolTipValues.EnableToolTips = true;
+		labelDesignationAbsoluteMagnitude.ToolTipValues.Heading = "Readable designation for the absolute magnitude";
+		labelDesignationAbsoluteMagnitude.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationAbsoluteMagnitude.Values.Text = "-";
+		labelDesignationAbsoluteMagnitude.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationAbsoluteMagnitude.Enter += Control_Enter;
+		labelDesignationAbsoluteMagnitude.Leave += Control_Leave;
+		labelDesignationAbsoluteMagnitude.MouseDown += Control_MouseDown;
+		labelDesignationAbsoluteMagnitude.MouseEnter += Control_Enter;
+		labelDesignationAbsoluteMagnitude.MouseLeave += Control_Leave;
+		// 
+		// labelValueAbsoluteMagnitude
+		// 
+		labelValueAbsoluteMagnitude.AccessibleDescription = "Shows the record value for the absolute magnitude";
+		labelValueAbsoluteMagnitude.AccessibleName = "Record value for the absolute magnitude";
+		labelValueAbsoluteMagnitude.AccessibleRole = AccessibleRole.StaticText;
+		labelValueAbsoluteMagnitude.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueAbsoluteMagnitude.Dock = DockStyle.Fill;
+		labelValueAbsoluteMagnitude.Location = new Point(411, 235);
+		labelValueAbsoluteMagnitude.Name = "labelValueAbsoluteMagnitude";
+		labelValueAbsoluteMagnitude.Size = new Size(128, 23);
+		labelValueAbsoluteMagnitude.TabIndex = 26;
+		labelValueAbsoluteMagnitude.ToolTipValues.Description = "Shows the record value for the absolute magnitude.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueAbsoluteMagnitude.ToolTipValues.EnableToolTips = true;
+		labelValueAbsoluteMagnitude.ToolTipValues.Heading = "Record value for the absolute magnitude";
+		labelValueAbsoluteMagnitude.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueAbsoluteMagnitude.Values.Text = "-";
+		labelValueAbsoluteMagnitude.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueAbsoluteMagnitude.Enter += Control_Enter;
+		labelValueAbsoluteMagnitude.Leave += Control_Leave;
+		labelValueAbsoluteMagnitude.MouseDown += Control_MouseDown;
+		labelValueAbsoluteMagnitude.MouseEnter += Control_Enter;
+		labelValueAbsoluteMagnitude.MouseLeave += Control_Leave;
+		// 
+		// labelElementSlopeParameter
+		// 
+		labelElementSlopeParameter.AccessibleDescription = "Orbital element: Slope parameter (G)";
+		labelElementSlopeParameter.AccessibleName = "Slope parameter";
+		labelElementSlopeParameter.AccessibleRole = AccessibleRole.StaticText;
+		labelElementSlopeParameter.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementSlopeParameter.Dock = DockStyle.Fill;
+		labelElementSlopeParameter.Location = new Point(3, 264);
+		labelElementSlopeParameter.Name = "labelElementSlopeParameter";
+		labelElementSlopeParameter.Size = new Size(214, 23);
+		labelElementSlopeParameter.TabIndex = 27;
+		labelElementSlopeParameter.ToolTipValues.Description = "Slope parameter (G)";
+		labelElementSlopeParameter.ToolTipValues.EnableToolTips = true;
+		labelElementSlopeParameter.ToolTipValues.Heading = "Slope parameter (G)";
+		labelElementSlopeParameter.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementSlopeParameter.Values.Text = "Slope parameter (G)";
+		labelElementSlopeParameter.Enter += Control_Enter;
+		labelElementSlopeParameter.Leave += Control_Leave;
+		labelElementSlopeParameter.MouseDown += Control_MouseDown;
+		labelElementSlopeParameter.MouseEnter += Control_Enter;
+		labelElementSlopeParameter.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationSlopeParameter
+		// 
+		labelDesignationSlopeParameter.AccessibleDescription = "Shows the readable designation for the slope parameter record";
+		labelDesignationSlopeParameter.AccessibleName = "Readable designation for the slope parameter";
+		labelDesignationSlopeParameter.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationSlopeParameter.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationSlopeParameter.Dock = DockStyle.Fill;
+		labelDesignationSlopeParameter.Location = new Point(223, 264);
+		labelDesignationSlopeParameter.Name = "labelDesignationSlopeParameter";
+		labelDesignationSlopeParameter.Size = new Size(182, 23);
+		labelDesignationSlopeParameter.TabIndex = 28;
+		labelDesignationSlopeParameter.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the slope parameter.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationSlopeParameter.ToolTipValues.EnableToolTips = true;
+		labelDesignationSlopeParameter.ToolTipValues.Heading = "Readable designation for the slope parameter";
+		labelDesignationSlopeParameter.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationSlopeParameter.Values.Text = "-";
+		labelDesignationSlopeParameter.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationSlopeParameter.Enter += Control_Enter;
+		labelDesignationSlopeParameter.Leave += Control_Leave;
+		labelDesignationSlopeParameter.MouseDown += Control_MouseDown;
+		labelDesignationSlopeParameter.MouseEnter += Control_Enter;
+		labelDesignationSlopeParameter.MouseLeave += Control_Leave;
+		// 
+		// labelValueSlopeParameter
+		// 
+		labelValueSlopeParameter.AccessibleDescription = "Shows the record value for the slope parameter";
+		labelValueSlopeParameter.AccessibleName = "Record value for the slope parameter";
+		labelValueSlopeParameter.AccessibleRole = AccessibleRole.StaticText;
+		labelValueSlopeParameter.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueSlopeParameter.Dock = DockStyle.Fill;
+		labelValueSlopeParameter.Location = new Point(411, 264);
+		labelValueSlopeParameter.Name = "labelValueSlopeParameter";
+		labelValueSlopeParameter.Size = new Size(128, 23);
+		labelValueSlopeParameter.TabIndex = 29;
+		labelValueSlopeParameter.ToolTipValues.Description = "Shows the record value for the slope parameter.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueSlopeParameter.ToolTipValues.EnableToolTips = true;
+		labelValueSlopeParameter.ToolTipValues.Heading = "Record value for the slope parameter";
+		labelValueSlopeParameter.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueSlopeParameter.Values.Text = "-";
+		labelValueSlopeParameter.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueSlopeParameter.Enter += Control_Enter;
+		labelValueSlopeParameter.Leave += Control_Leave;
+		labelValueSlopeParameter.MouseDown += Control_MouseDown;
+		labelValueSlopeParameter.MouseEnter += Control_Enter;
+		labelValueSlopeParameter.MouseLeave += Control_Leave;
+		// 
+		// labelElementNumberOfOppositions
+		// 
+		labelElementNumberOfOppositions.AccessibleDescription = "Orbital element: Number of oppositions";
+		labelElementNumberOfOppositions.AccessibleName = "Number of oppositions";
+		labelElementNumberOfOppositions.AccessibleRole = AccessibleRole.StaticText;
+		labelElementNumberOfOppositions.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementNumberOfOppositions.Dock = DockStyle.Fill;
+		labelElementNumberOfOppositions.Location = new Point(3, 293);
+		labelElementNumberOfOppositions.Name = "labelElementNumberOfOppositions";
+		labelElementNumberOfOppositions.Size = new Size(214, 23);
+		labelElementNumberOfOppositions.TabIndex = 30;
+		labelElementNumberOfOppositions.ToolTipValues.Description = "Number of oppositions";
+		labelElementNumberOfOppositions.ToolTipValues.EnableToolTips = true;
+		labelElementNumberOfOppositions.ToolTipValues.Heading = "Number of oppositions";
+		labelElementNumberOfOppositions.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementNumberOfOppositions.Values.Text = "Number of oppositions";
+		labelElementNumberOfOppositions.Enter += Control_Enter;
+		labelElementNumberOfOppositions.Leave += Control_Leave;
+		labelElementNumberOfOppositions.MouseDown += Control_MouseDown;
+		labelElementNumberOfOppositions.MouseEnter += Control_Enter;
+		labelElementNumberOfOppositions.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationNumberOfOppositions
+		// 
+		labelDesignationNumberOfOppositions.AccessibleDescription = "Shows the readable designation for the number of oppositions record";
+		labelDesignationNumberOfOppositions.AccessibleName = "Readable designation for the number of oppositions";
+		labelDesignationNumberOfOppositions.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationNumberOfOppositions.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationNumberOfOppositions.Dock = DockStyle.Fill;
+		labelDesignationNumberOfOppositions.Location = new Point(223, 293);
+		labelDesignationNumberOfOppositions.Name = "labelDesignationNumberOfOppositions";
+		labelDesignationNumberOfOppositions.Size = new Size(182, 23);
+		labelDesignationNumberOfOppositions.TabIndex = 31;
+		labelDesignationNumberOfOppositions.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the number of oppositions.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationNumberOfOppositions.ToolTipValues.EnableToolTips = true;
+		labelDesignationNumberOfOppositions.ToolTipValues.Heading = "Readable designation for the number of oppositions";
+		labelDesignationNumberOfOppositions.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationNumberOfOppositions.Values.Text = "-";
+		labelDesignationNumberOfOppositions.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationNumberOfOppositions.Enter += Control_Enter;
+		labelDesignationNumberOfOppositions.Leave += Control_Leave;
+		labelDesignationNumberOfOppositions.MouseDown += Control_MouseDown;
+		labelDesignationNumberOfOppositions.MouseEnter += Control_Enter;
+		labelDesignationNumberOfOppositions.MouseLeave += Control_Leave;
+		// 
+		// labelValueNumberOfOppositions
+		// 
+		labelValueNumberOfOppositions.AccessibleDescription = "Shows the record value for the number of pppositions";
+		labelValueNumberOfOppositions.AccessibleName = "Record value for the number of oppositions";
+		labelValueNumberOfOppositions.AccessibleRole = AccessibleRole.StaticText;
+		labelValueNumberOfOppositions.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueNumberOfOppositions.Dock = DockStyle.Fill;
+		labelValueNumberOfOppositions.Location = new Point(411, 293);
+		labelValueNumberOfOppositions.Name = "labelValueNumberOfOppositions";
+		labelValueNumberOfOppositions.Size = new Size(128, 23);
+		labelValueNumberOfOppositions.TabIndex = 32;
+		labelValueNumberOfOppositions.ToolTipValues.Description = "Shows the record value for the number of oppositions.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueNumberOfOppositions.ToolTipValues.EnableToolTips = true;
+		labelValueNumberOfOppositions.ToolTipValues.Heading = "Record value for the number of oppositions";
+		labelValueNumberOfOppositions.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueNumberOfOppositions.Values.Text = "-";
+		labelValueNumberOfOppositions.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueNumberOfOppositions.Enter += Control_Enter;
+		labelValueNumberOfOppositions.Leave += Control_Leave;
+		labelValueNumberOfOppositions.MouseDown += Control_MouseDown;
+		labelValueNumberOfOppositions.MouseEnter += Control_Enter;
+		labelValueNumberOfOppositions.MouseLeave += Control_Leave;
+		// 
+		// labelElementNumberOfObservations
+		// 
+		labelElementNumberOfObservations.AccessibleDescription = "Orbital element: Number of observations";
+		labelElementNumberOfObservations.AccessibleName = "Number of observations";
+		labelElementNumberOfObservations.AccessibleRole = AccessibleRole.StaticText;
+		labelElementNumberOfObservations.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementNumberOfObservations.Dock = DockStyle.Fill;
+		labelElementNumberOfObservations.Location = new Point(3, 322);
+		labelElementNumberOfObservations.Name = "labelElementNumberOfObservations";
+		labelElementNumberOfObservations.Size = new Size(214, 23);
+		labelElementNumberOfObservations.TabIndex = 33;
+		labelElementNumberOfObservations.ToolTipValues.Description = "Number of observations";
+		labelElementNumberOfObservations.ToolTipValues.EnableToolTips = true;
+		labelElementNumberOfObservations.ToolTipValues.Heading = "Number of observations";
+		labelElementNumberOfObservations.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementNumberOfObservations.Values.Text = "Number of observations";
+		labelElementNumberOfObservations.Enter += Control_Enter;
+		labelElementNumberOfObservations.Leave += Control_Leave;
+		labelElementNumberOfObservations.MouseDown += Control_MouseDown;
+		labelElementNumberOfObservations.MouseEnter += Control_Enter;
+		labelElementNumberOfObservations.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationNumberOfObservations
+		// 
+		labelDesignationNumberOfObservations.AccessibleDescription = "Shows the readable designation for the number of the observations record";
+		labelDesignationNumberOfObservations.AccessibleName = "Readable designation for the number of the observations";
+		labelDesignationNumberOfObservations.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationNumberOfObservations.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationNumberOfObservations.Dock = DockStyle.Fill;
+		labelDesignationNumberOfObservations.Location = new Point(223, 322);
+		labelDesignationNumberOfObservations.Name = "labelDesignationNumberOfObservations";
+		labelDesignationNumberOfObservations.Size = new Size(182, 23);
+		labelDesignationNumberOfObservations.TabIndex = 34;
+		labelDesignationNumberOfObservations.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the number of the observations.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationNumberOfObservations.ToolTipValues.EnableToolTips = true;
+		labelDesignationNumberOfObservations.ToolTipValues.Heading = "Readable designation for the number of the observations";
+		labelDesignationNumberOfObservations.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationNumberOfObservations.Values.Text = "-";
+		labelDesignationNumberOfObservations.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationNumberOfObservations.Enter += Control_Enter;
+		labelDesignationNumberOfObservations.Leave += Control_Leave;
+		labelDesignationNumberOfObservations.MouseDown += Control_MouseDown;
+		labelDesignationNumberOfObservations.MouseEnter += Control_Enter;
+		labelDesignationNumberOfObservations.MouseLeave += Control_Leave;
+		// 
+		// labelValueNumberOfObservations
+		// 
+		labelValueNumberOfObservations.AccessibleDescription = "Shows the record value for the number of the observations";
+		labelValueNumberOfObservations.AccessibleName = "Record value for the number of the observations";
+		labelValueNumberOfObservations.AccessibleRole = AccessibleRole.StaticText;
+		labelValueNumberOfObservations.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueNumberOfObservations.Dock = DockStyle.Fill;
+		labelValueNumberOfObservations.Location = new Point(411, 322);
+		labelValueNumberOfObservations.Name = "labelValueNumberOfObservations";
+		labelValueNumberOfObservations.Size = new Size(128, 23);
+		labelValueNumberOfObservations.TabIndex = 35;
+		labelValueNumberOfObservations.ToolTipValues.Description = "Shows the record value for the number of the observations.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueNumberOfObservations.ToolTipValues.EnableToolTips = true;
+		labelValueNumberOfObservations.ToolTipValues.Heading = "Record value for the number of the observations";
+		labelValueNumberOfObservations.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueNumberOfObservations.Values.Text = "-";
+		labelValueNumberOfObservations.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueNumberOfObservations.Enter += Control_Enter;
+		labelValueNumberOfObservations.Leave += Control_Leave;
+		labelValueNumberOfObservations.MouseDown += Control_MouseDown;
+		labelValueNumberOfObservations.MouseEnter += Control_Enter;
+		labelValueNumberOfObservations.MouseLeave += Control_Leave;
+		// 
+		// labelElementRmsResidual
+		// 
+		labelElementRmsResidual.AccessibleDescription = "Orbital element: RMS residual";
+		labelElementRmsResidual.AccessibleName = "RMS residual";
+		labelElementRmsResidual.AccessibleRole = AccessibleRole.StaticText;
+		labelElementRmsResidual.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelElementRmsResidual.Dock = DockStyle.Fill;
+		labelElementRmsResidual.Location = new Point(3, 351);
+		labelElementRmsResidual.Name = "labelElementRmsResidual";
+		labelElementRmsResidual.Size = new Size(214, 23);
+		labelElementRmsResidual.TabIndex = 39;
+		labelElementRmsResidual.ToolTipValues.Description = "RMS residual";
+		labelElementRmsResidual.ToolTipValues.EnableToolTips = true;
+		labelElementRmsResidual.ToolTipValues.Heading = "RMS residual";
+		labelElementRmsResidual.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelElementRmsResidual.Values.Text = "RMS residual";
+		labelElementRmsResidual.Enter += Control_Enter;
+		labelElementRmsResidual.Leave += Control_Leave;
+		labelElementRmsResidual.MouseDown += Control_MouseDown;
+		labelElementRmsResidual.MouseEnter += Control_Enter;
+		labelElementRmsResidual.MouseLeave += Control_Leave;
+		// 
+		// labelDesignationRmsResidual
+		// 
+		labelDesignationRmsResidual.AccessibleDescription = "Shows the readable designation for the RMS residual record";
+		labelDesignationRmsResidual.AccessibleName = "Readable designation for the RMS residual";
+		labelDesignationRmsResidual.AccessibleRole = AccessibleRole.StaticText;
+		labelDesignationRmsResidual.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelDesignationRmsResidual.Dock = DockStyle.Fill;
+		labelDesignationRmsResidual.Location = new Point(223, 351);
+		labelDesignationRmsResidual.Name = "labelDesignationRmsResidual";
+		labelDesignationRmsResidual.Size = new Size(182, 23);
+		labelDesignationRmsResidual.TabIndex = 40;
+		labelDesignationRmsResidual.ToolTipValues.Description = "Shows the readable designation of the asteroid with the record value for the RMS residual.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelDesignationRmsResidual.ToolTipValues.EnableToolTips = true;
+		labelDesignationRmsResidual.ToolTipValues.Heading = "Readable designation for the RMS residual";
+		labelDesignationRmsResidual.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelDesignationRmsResidual.Values.Text = "-";
+		labelDesignationRmsResidual.DoubleClick += CopyToClipboard_DoubleClick;
+		labelDesignationRmsResidual.Enter += Control_Enter;
+		labelDesignationRmsResidual.Leave += Control_Leave;
+		labelDesignationRmsResidual.MouseDown += Control_MouseDown;
+		labelDesignationRmsResidual.MouseEnter += Control_Enter;
+		labelDesignationRmsResidual.MouseLeave += Control_Leave;
+		// 
+		// labelValueRmsResidual
+		// 
+		labelValueRmsResidual.AccessibleDescription = "Shows the record value for the RMS residual";
+		labelValueRmsResidual.AccessibleName = "Record value for the RMS residual";
+		labelValueRmsResidual.AccessibleRole = AccessibleRole.StaticText;
+		labelValueRmsResidual.ContextMenuStrip = contextMenuCopyToClipboard;
+		labelValueRmsResidual.Dock = DockStyle.Fill;
+		labelValueRmsResidual.Location = new Point(411, 351);
+		labelValueRmsResidual.Name = "labelValueRmsResidual";
+		labelValueRmsResidual.Size = new Size(128, 23);
+		labelValueRmsResidual.TabIndex = 41;
+		labelValueRmsResidual.ToolTipValues.Description = "Shows the record value for the RMS residual.\r\nDouble-click or right-click to copy the information to the clipboard.";
+		labelValueRmsResidual.ToolTipValues.EnableToolTips = true;
+		labelValueRmsResidual.ToolTipValues.Heading = "Record value for the RMS residual";
+		labelValueRmsResidual.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
+		labelValueRmsResidual.Values.Text = "-";
+		labelValueRmsResidual.DoubleClick += CopyToClipboard_DoubleClick;
+		labelValueRmsResidual.Enter += Control_Enter;
+		labelValueRmsResidual.Leave += Control_Leave;
+		labelValueRmsResidual.MouseDown += Control_MouseDown;
+		labelValueRmsResidual.MouseEnter += Control_Enter;
+		labelValueRmsResidual.MouseLeave += Control_Leave;
 		// 
 		// kryptonStatusStrip
 		// 
@@ -1185,19 +1732,22 @@ partial class RecordsForm
 		kryptonStatusStrip.AccessibleRole = AccessibleRole.StatusBar;
 		kryptonStatusStrip.AllowClickThrough = true;
 		kryptonStatusStrip.AllowItemReorder = true;
+		kryptonStatusStrip.Dock = DockStyle.None;
 		kryptonStatusStrip.Font = new Font("Segoe UI", 9F);
 		kryptonStatusStrip.Items.AddRange(new ToolStripItem[] { labelInformation });
-		kryptonStatusStrip.Location = new Point(0, 538);
+		kryptonStatusStrip.Location = new Point(0, 0);
 		kryptonStatusStrip.Name = "kryptonStatusStrip";
 		kryptonStatusStrip.Padding = new Padding(1, 0, 16, 0);
 		kryptonStatusStrip.ProgressBars = null;
 		kryptonStatusStrip.RenderMode = ToolStripRenderMode.ManagerRenderMode;
 		kryptonStatusStrip.ShowItemToolTips = true;
-		kryptonStatusStrip.Size = new Size(700, 22);
+		kryptonStatusStrip.Size = new Size(542, 22);
 		kryptonStatusStrip.SizingGrip = false;
 		kryptonStatusStrip.TabIndex = 6;
 		kryptonStatusStrip.TabStop = true;
 		kryptonStatusStrip.Text = "Status bar";
+		kryptonStatusStrip.MouseEnter += Control_Enter;
+		kryptonStatusStrip.MouseLeave += Control_Leave;
 		// 
 		// labelInformation
 		// 
@@ -1210,6 +1760,8 @@ partial class RecordsForm
 		labelInformation.Size = new Size(144, 17);
 		labelInformation.Text = "some information here";
 		labelInformation.ToolTipText = "Show some information";
+		labelInformation.MouseEnter += Control_Enter;
+		labelInformation.MouseLeave += Control_Leave;
 		// 
 		// kryptonManager
 		// 
@@ -1222,92 +1774,348 @@ partial class RecordsForm
 		backgroundWorker.WorkerReportsProgress = true;
 		backgroundWorker.WorkerSupportsCancellation = true;
 		// 
+		// toolStripContainer
+		// 
+		toolStripContainer.AccessibleDescription = "Container";
+		toolStripContainer.AccessibleName = "Container";
+		toolStripContainer.AccessibleRole = AccessibleRole.Pane;
+		// 
+		// toolStripContainer.BottomToolStripPanel
+		// 
+		toolStripContainer.BottomToolStripPanel.AccessibleDescription = "Bottom panel";
+		toolStripContainer.BottomToolStripPanel.AccessibleName = "Bottom panel";
+		toolStripContainer.BottomToolStripPanel.AccessibleRole = AccessibleRole.Pane;
+		toolStripContainer.BottomToolStripPanel.Controls.Add(kryptonStatusStrip);
+		// 
+		// toolStripContainer.ContentPanel
+		// 
+		toolStripContainer.ContentPanel.AccessibleDescription = "Content panel";
+		toolStripContainer.ContentPanel.AccessibleName = "Content panel";
+		toolStripContainer.ContentPanel.AccessibleRole = AccessibleRole.Pane;
+		toolStripContainer.ContentPanel.Controls.Add(kryptonPanelMain);
+		toolStripContainer.ContentPanel.Size = new Size(542, 373);
+		toolStripContainer.Dock = DockStyle.Fill;
+		// 
+		// toolStripContainer.LeftToolStripPanel
+		// 
+		toolStripContainer.LeftToolStripPanel.AccessibleDescription = "Left panel";
+		toolStripContainer.LeftToolStripPanel.AccessibleName = "Left panel";
+		toolStripContainer.LeftToolStripPanel.AccessibleRole = AccessibleRole.Pane;
+		toolStripContainer.Location = new Point(0, 0);
+		toolStripContainer.Name = "toolStripContainer";
+		// 
+		// toolStripContainer.RightToolStripPanel
+		// 
+		toolStripContainer.RightToolStripPanel.AccessibleDescription = "Right panel";
+		toolStripContainer.RightToolStripPanel.AccessibleName = "Right panel";
+		toolStripContainer.RightToolStripPanel.AccessibleRole = AccessibleRole.Pane;
+		toolStripContainer.Size = new Size(542, 445);
+		toolStripContainer.TabIndex = 8;
+		toolStripContainer.Text = "toolStripContainer";
+		// 
+		// toolStripContainer.TopToolStripPanel
+		// 
+		toolStripContainer.TopToolStripPanel.AccessibleDescription = "Top panel";
+		toolStripContainer.TopToolStripPanel.AccessibleName = "Top panel";
+		toolStripContainer.TopToolStripPanel.AccessibleRole = AccessibleRole.Pane;
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripGenerateList);
+		toolStripContainer.TopToolStripPanel.Controls.Add(kryptonToolStripProgress);
+		toolStripContainer.Enter += Control_Enter;
+		toolStripContainer.Leave += Control_Leave;
+		toolStripContainer.MouseEnter += Control_Enter;
+		toolStripContainer.MouseLeave += Control_Leave;
+		// 
+		// kryptonToolStripGenerateList
+		// 
+		kryptonToolStripGenerateList.AccessibleDescription = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleName = "Toolbar of generating list";
+		kryptonToolStripGenerateList.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripGenerateList.AllowClickThrough = true;
+		kryptonToolStripGenerateList.AllowItemReorder = true;
+		kryptonToolStripGenerateList.Dock = DockStyle.None;
+		kryptonToolStripGenerateList.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripGenerateList.Items.AddRange(new ToolStripItem[] { toolStripButtonStart, toolStripButtonCancel, toolStripSeparator2, toolStripButtonSortOrderAscending, toolStripButtonSortOrderDescending, toolStripSeparator3, toolStripDropDownButtonSaveList });
+		kryptonToolStripGenerateList.Location = new Point(0, 0);
+		kryptonToolStripGenerateList.Name = "kryptonToolStripGenerateList";
+		kryptonToolStripGenerateList.Size = new Size(542, 25);
+		kryptonToolStripGenerateList.Stretch = true;
+		kryptonToolStripGenerateList.TabIndex = 1;
+		kryptonToolStripGenerateList.TabStop = true;
+		kryptonToolStripGenerateList.Text = "Toolbar of generating list";
+		kryptonToolStripGenerateList.Enter += Control_Enter;
+		kryptonToolStripGenerateList.Leave += Control_Leave;
+		kryptonToolStripGenerateList.MouseEnter += Control_Enter;
+		kryptonToolStripGenerateList.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonStart
+		// 
+		toolStripButtonStart.AccessibleDescription = "Starts the record detection scan";
+		toolStripButtonStart.AccessibleName = "Start scan";
+		toolStripButtonStart.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonStart.Image = FatcowIcons16px.fatcow_resultset_next_16px;
+		toolStripButtonStart.ImageTransparentColor = Color.Magenta;
+		toolStripButtonStart.Name = "toolStripButtonStart";
+		toolStripButtonStart.Size = new Size(51, 22);
+		toolStripButtonStart.Text = "&Start";
+		toolStripButtonStart.Click += Start_Click;
+		toolStripButtonStart.MouseEnter += Control_Enter;
+		toolStripButtonStart.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonCancel
+		// 
+		toolStripButtonCancel.AccessibleDescription = "Cancels the record detection scan";
+		toolStripButtonCancel.AccessibleName = "Cancel scan";
+		toolStripButtonCancel.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonCancel.Image = FatcowIcons16px.fatcow_cancel_16px;
+		toolStripButtonCancel.ImageTransparentColor = Color.Magenta;
+		toolStripButtonCancel.Name = "toolStripButtonCancel";
+		toolStripButtonCancel.Size = new Size(63, 22);
+		toolStripButtonCancel.Text = "&Cancel";
+		toolStripButtonCancel.Click += Cancel_Click;
+		toolStripButtonCancel.MouseEnter += Control_Enter;
+		toolStripButtonCancel.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator2
+		// 
+		toolStripSeparator2.AccessibleDescription = "Just a separator";
+		toolStripSeparator2.AccessibleName = "Just a separator";
+		toolStripSeparator2.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator2.Name = "toolStripSeparator2";
+		toolStripSeparator2.Size = new Size(6, 25);
+		toolStripSeparator2.MouseEnter += Control_Enter;
+		toolStripSeparator2.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonSortOrderAscending
+		// 
+		toolStripButtonSortOrderAscending.AccessibleDescription = "Selects the ascending sort order";
+		toolStripButtonSortOrderAscending.AccessibleName = "Ascending sort order";
+		toolStripButtonSortOrderAscending.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonSortOrderAscending.Checked = true;
+		toolStripButtonSortOrderAscending.CheckOnClick = true;
+		toolStripButtonSortOrderAscending.CheckState = CheckState.Checked;
+		toolStripButtonSortOrderAscending.Image = FatcowIcons16px.fatcow_sort_ascending_16px;
+		toolStripButtonSortOrderAscending.ImageTransparentColor = Color.Magenta;
+		toolStripButtonSortOrderAscending.Name = "toolStripButtonSortOrderAscending";
+		toolStripButtonSortOrderAscending.Size = new Size(83, 22);
+		toolStripButtonSortOrderAscending.Text = "&Ascending";
+		toolStripButtonSortOrderAscending.Click += SetAscendingSortOrder_Click;
+		toolStripButtonSortOrderAscending.MouseEnter += Control_Enter;
+		toolStripButtonSortOrderAscending.MouseLeave += Control_Leave;
+		// 
+		// toolStripButtonSortOrderDescending
+		// 
+		toolStripButtonSortOrderDescending.AccessibleDescription = "Selects the descending sort order";
+		toolStripButtonSortOrderDescending.AccessibleName = "Descending sort order";
+		toolStripButtonSortOrderDescending.AccessibleRole = AccessibleRole.PushButton;
+		toolStripButtonSortOrderDescending.CheckOnClick = true;
+		toolStripButtonSortOrderDescending.Image = FatcowIcons16px.fatcow_sort_descending_16px;
+		toolStripButtonSortOrderDescending.ImageTransparentColor = Color.Magenta;
+		toolStripButtonSortOrderDescending.Name = "toolStripButtonSortOrderDescending";
+		toolStripButtonSortOrderDescending.Size = new Size(89, 22);
+		toolStripButtonSortOrderDescending.Text = "&Descending";
+		toolStripButtonSortOrderDescending.Click += SetDescendingSortOrder_Click;
+		toolStripButtonSortOrderDescending.MouseEnter += Control_Enter;
+		toolStripButtonSortOrderDescending.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator3
+		// 
+		toolStripSeparator3.AccessibleDescription = "Just a separator";
+		toolStripSeparator3.AccessibleName = "Just a separator";
+		toolStripSeparator3.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator3.Name = "toolStripSeparator3";
+		toolStripSeparator3.Size = new Size(6, 25);
+		toolStripSeparator3.MouseEnter += Control_Enter;
+		toolStripSeparator3.MouseLeave += Control_Leave;
+		// 
+		// kryptonToolStripProgress
+		// 
+		kryptonToolStripProgress.AccessibleDescription = "Toolbar of progress";
+		kryptonToolStripProgress.AccessibleName = "Toolbar of progress";
+		kryptonToolStripProgress.AccessibleRole = AccessibleRole.ToolBar;
+		kryptonToolStripProgress.AllowClickThrough = true;
+		kryptonToolStripProgress.AllowItemReorder = true;
+		kryptonToolStripProgress.Dock = DockStyle.None;
+		kryptonToolStripProgress.Font = new Font("Segoe UI", 9F);
+		kryptonToolStripProgress.Items.AddRange(new ToolStripItem[] { toolStripLabelProgress, kryptonProgressBar });
+		kryptonToolStripProgress.Location = new Point(0, 25);
+		kryptonToolStripProgress.Name = "kryptonToolStripProgress";
+		kryptonToolStripProgress.Size = new Size(542, 25);
+		kryptonToolStripProgress.Stretch = true;
+		kryptonToolStripProgress.TabIndex = 2;
+		kryptonToolStripProgress.TabStop = true;
+		kryptonToolStripProgress.Text = "Toolbar of progress";
+		kryptonToolStripProgress.Enter += Control_Enter;
+		kryptonToolStripProgress.Leave += Control_Leave;
+		kryptonToolStripProgress.MouseEnter += Control_Enter;
+		kryptonToolStripProgress.MouseLeave += Control_Leave;
+		// 
+		// toolStripLabelProgress
+		// 
+		toolStripLabelProgress.AccessibleDescription = "Shows the progress of comparing";
+		toolStripLabelProgress.AccessibleName = "Loading progress";
+		toolStripLabelProgress.AccessibleRole = AccessibleRole.StaticText;
+		toolStripLabelProgress.AutoToolTip = true;
+		toolStripLabelProgress.Name = "toolStripLabelProgress";
+		toolStripLabelProgress.Size = new Size(52, 22);
+		toolStripLabelProgress.Text = "Pro&gress";
+		toolStripLabelProgress.MouseEnter += Control_Enter;
+		toolStripLabelProgress.MouseLeave += Control_Leave;
+		// 
+		// kryptonProgressBar
+		// 
+		kryptonProgressBar.AccessibleDescription = "Shows the progress of loading observation data";
+		kryptonProgressBar.AccessibleName = "Loading progress";
+		kryptonProgressBar.AccessibleRole = AccessibleRole.ProgressBar;
+		kryptonProgressBar.AutoToolTip = true;
+		kryptonProgressBar.Name = "kryptonProgressBar";
+		kryptonProgressBar.Size = new Size(400, 22);
+		kryptonProgressBar.StateCommon.Back.Color1 = Color.Green;
+		kryptonProgressBar.StateDisabled.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.StateNormal.Back.ColorStyle = PaletteColorStyle.OneNote;
+		kryptonProgressBar.Values.Text = "";
+		kryptonProgressBar.MouseEnter += Control_Enter;
+		kryptonProgressBar.MouseLeave += Control_Leave;
+		// 
 		// RecordsForm
 		// 
 		AccessibleDescription = "Shows the record values for all orbital elements";
-		AccessibleName = "Record list";
+		AccessibleName = "Records";
 		AccessibleRole = AccessibleRole.Dialog;
 		AutoScaleDimensions = new SizeF(7F, 15F);
 		AutoScaleMode = AutoScaleMode.Font;
-		ClientSize = new Size(700, 560);
-		Controls.Add(kryptonStatusStrip);
-		Controls.Add(kryptonPanelMain);
-		FormBorderStyle = FormBorderStyle.FixedSingle;
+		ClientSize = new Size(542, 445);
+		ControlBox = false;
+		Controls.Add(toolStripContainer);
+		FormBorderStyle = FormBorderStyle.FixedToolWindow;
 		Icon = (Icon)resources.GetObject("$this.Icon");
 		Margin = new Padding(4, 3, 4, 3);
 		MaximizeBox = false;
 		MinimizeBox = false;
 		Name = "RecordsForm";
-		StartPosition = FormStartPosition.CenterParent;
-		Text = "Record list";
+		StartPosition = FormStartPosition.CenterScreen;
+		Text = "Records";
 		Load += RecordsForm_Load;
 		((ISupportInitialize)kryptonPanelMain).EndInit();
 		kryptonPanelMain.ResumeLayout(false);
-		((ISupportInitialize)groupBoxRecordType.Panel).EndInit();
-		groupBoxRecordType.Panel.ResumeLayout(false);
-		((ISupportInitialize)groupBoxRecordType).EndInit();
 		tableLayoutPanel.ResumeLayout(false);
 		tableLayoutPanel.PerformLayout();
+		contextMenuSaveToFile.ResumeLayout(false);
+		contextMenuCopyToClipboard.ResumeLayout(false);
 		kryptonStatusStrip.ResumeLayout(false);
 		kryptonStatusStrip.PerformLayout();
+		toolStripContainer.BottomToolStripPanel.ResumeLayout(false);
+		toolStripContainer.BottomToolStripPanel.PerformLayout();
+		toolStripContainer.ContentPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+		toolStripContainer.TopToolStripPanel.PerformLayout();
+		toolStripContainer.ResumeLayout(false);
+		toolStripContainer.PerformLayout();
+		kryptonToolStripGenerateList.ResumeLayout(false);
+		kryptonToolStripGenerateList.PerformLayout();
+		kryptonToolStripProgress.ResumeLayout(false);
+		kryptonToolStripProgress.PerformLayout();
 		ResumeLayout(false);
-		PerformLayout();
 	}
 
 	#endregion
 
 	private KryptonPanel kryptonPanelMain;
-	private KryptonGroupBox groupBoxRecordType;
-	private KryptonCheckButton checkButtonMax;
-	private KryptonCheckButton checkButtonMin;
 	private KryptonTableLayoutPanel tableLayoutPanel;
 	private KryptonLabel labelElementHeader;
 	private KryptonLabel labelDesignationHeader;
 	private KryptonLabel labelValueHeader;
-	private KryptonLabel labelElement01;
-	private KryptonLabel labelElement02;
-	private KryptonLabel labelElement03;
-	private KryptonLabel labelElement04;
-	private KryptonLabel labelElement05;
-	private KryptonLabel labelElement06;
-	private KryptonLabel labelElement07;
-	private KryptonLabel labelElement08;
-	private KryptonLabel labelElement09;
-	private KryptonLabel labelElement10;
-	private KryptonLabel labelElement11;
-	private KryptonLabel labelElement12;
-	private KryptonLabel labelElement13;
-	private KryptonLabel labelDesignation01;
-	private KryptonLabel labelDesignation02;
-	private KryptonLabel labelDesignation03;
-	private KryptonLabel labelDesignation04;
-	private KryptonLabel labelDesignation05;
-	private KryptonLabel labelDesignation06;
-	private KryptonLabel labelDesignation07;
-	private KryptonLabel labelDesignation08;
-	private KryptonLabel labelDesignation09;
-	private KryptonLabel labelDesignation10;
-	private KryptonLabel labelDesignation11;
-	private KryptonLabel labelDesignation12;
-	private KryptonLabel labelDesignation13;
-	private KryptonLabel labelValue01;
-	private KryptonLabel labelValue02;
-	private KryptonLabel labelValue03;
-	private KryptonLabel labelValue04;
-	private KryptonLabel labelValue05;
-	private KryptonLabel labelValue06;
-	private KryptonLabel labelValue07;
-	private KryptonLabel labelValue08;
-	private KryptonLabel labelValue09;
-	private KryptonLabel labelValue10;
-	private KryptonLabel labelValue11;
-	private KryptonLabel labelValue12;
-	private KryptonLabel labelValue13;
-	private KryptonButton buttonStart;
-	private KryptonButton buttonCancel;
-	private KryptonProgressBar progressBar;
+	private KryptonLabel labelElementMeanAnomalyAtTheEpoch;
+	private KryptonLabel labelElementArgumentOfThePerihelion;
+	private KryptonLabel labelElementLongitudeOfTheAscendingNodeDesc;
+	private KryptonLabel labelElementInclinationToTheEcliptic;
+	private KryptonLabel labelElementOrbitalEccentricity;
+	private KryptonLabel labelElementMeanDailyMotion;
+	private KryptonLabel labelElementSemiMajorAxis;
+	private KryptonLabel labelElementAbsoluteMagnitude;
+	private KryptonLabel labelElementSlopeParameter;
+	private KryptonLabel labelElementNumberOfOppositions;
+	private KryptonLabel labelElementNumberOfObservations;
+	private KryptonLabel labelElementRmsResidual;
+	private KryptonLabel labelDesignationMeanAnomalyAtTheEpoch;
+	private KryptonLabel labelDesignationArgumentOfThePerihelion;
+	private KryptonLabel labelDesignationLongitudeOfTheAscendingNode;
+	private KryptonLabel labelDesignationInclinationToTheEcliptic;
+	private KryptonLabel labelDesignationOrbitalEccentricity;
+	private KryptonLabel labelDesignationMeanDailyMotion;
+	private KryptonLabel labelDesignationSemiMajorAxis;
+	private KryptonLabel labelDesignationAbsoluteMagnitude;
+	private KryptonLabel labelDesignationSlopeParameter;
+	private KryptonLabel labelDesignationNumberOfOppositions;
+	private KryptonLabel labelDesignationNumberOfObservations;
+	private KryptonLabel labelDesignationRmsResidual;
+	private KryptonLabel labelValueMeanAnomalyAtTheEpoch;
+	private KryptonLabel labelValueArgumentOfThePerihelion;
+	private KryptonLabel labelValueLongitudeOfTheAscendingNode;
+	private KryptonLabel labelValueInclinationToTheEcliptic;
+	private KryptonLabel labelValueOrbitalEccentricity;
+	private KryptonLabel labelValueMeanDailyMotion;
+	private KryptonLabel labelValueSemiMajorAxis;
+	private KryptonLabel labelValueAbsoluteMagnitude;
+	private KryptonLabel labelValueSlopeParameter;
+	private KryptonLabel labelValueNumberOfOppositions;
+	private KryptonLabel labelValueNumberOfObservations;
+	private KryptonLabel labelValueRmsResidual;
 	private KryptonStatusStrip kryptonStatusStrip;
 	private ToolStripStatusLabel labelInformation;
 	private KryptonManager kryptonManager;
 	private BackgroundWorker backgroundWorker;
+	private ToolStripContainer toolStripContainer;
+	private KryptonToolStrip kryptonToolStripGenerateList;
+	private ToolStripButton toolStripButtonStart;
+	private ToolStripDropDownButton toolStripDropDownButtonSaveList;
+	private ContextMenuStrip contextMenuSaveToFile;
+	private ToolStripMenuItem toolStripMenuItemTextFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsLatex;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMarkdown;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAsciiDoc;
+	private ToolStripMenuItem toolStripMenuItemSaveAsReStructuredText;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTextile;
+	private ToolStripMenuItem toolStripMenuItemWriterDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWord;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOdt;
+	private ToolStripMenuItem toolStripMenuItemSaveAsRtf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsAbiword;
+	private ToolStripMenuItem toolStripMenuItemSaveAsWps;
+	private ToolStripMenuItem toolStripMenuItemSpreadsheetDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsExcel;
+	private ToolStripMenuItem toolStripMenuItemSaveAsOds;
+	private ToolStripMenuItem toolStripMenuItemSaveAsCsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsTsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPsv;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEt;
+	private ToolStripMenuItem toolStripMenuItemXmlDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsHtml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsDocBook;
+	private ToolStripMenuItem toolStripMenuItemConfigurationFiles;
+	private ToolStripMenuItem toolStripMenuItemSaveAsJson;
+	private ToolStripMenuItem toolStripMenuItemSaveAsToml;
+	private ToolStripMenuItem toolStripMenuItemSaveAsYaml;
+	private ToolStripMenuItem toolStripMenuItemDatabaseScripts;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSql;
+	private ToolStripMenuItem toolStripMenuItemSaveAsSqlite;
+	private ToolStripMenuItem toolStripMenuItemPortableDocuments;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPdf;
+	private ToolStripMenuItem toolStripMenuItemSaveAsPostScript;
+	private ToolStripMenuItem toolStripMenuItemSaveAsEpub;
+	private ToolStripMenuItem toolStripMenuItemSaveAsMobi;
+	private ToolStripMenuItem toolStripMenuItemSaveAsXps;
+	private ToolStripMenuItem toolStripMenuItemSaveAsFictionBook2;
+	private ToolStripMenuItem toolStripMenuItemSaveAsChm;
+	private ToolStripButton toolStripButtonCancel;
+	private ToolStripSeparator toolStripSeparator2;
+	private ToolStripButton toolStripButtonSortOrderAscending;
+	private ToolStripButton toolStripButtonSortOrderDescending;
+	private ToolStripSeparator toolStripSeparator3;
+	private KryptonToolStrip kryptonToolStripProgress;
+	private ToolStripLabel toolStripLabelProgress;
+	private KryptonProgressBarToolStripItem kryptonProgressBar;
+	private ContextMenuStrip contextMenuCopyToClipboard;
+	private ToolStripMenuItem toolStripMenuItemCopyToClipboardInContextMenu;
 }

--- a/Forms/RecordsForm.cs
+++ b/Forms/RecordsForm.cs
@@ -42,15 +42,20 @@ public partial class RecordsForm : BaseKryptonForm
 	private bool isCancelled;
 
 	/// <summary>Stores the current record values for each orbital element (max or min).</summary>
-	/// <remarks>Index corresponds to element: 0=MeanAnomaly, 1=ArgPeri, 2=LongAscNode, 3=Incl, 4=OrbEcc, 5=Motion, 6=SemiMajorAxis, 7=MagAbs, 8=SlopeParam, 9=NumberOpposition, 10=NumberObservation, 11=ObsSpan, 12=RmsResidual.</remarks>
-	private readonly double[] recordValues = new double[13];
+	/// <remarks>Index corresponds to element: 0=MeanAnomaly, 1=ArgPeri, 2=LongAscNode, 3=Incl, 4=OrbEcc, 5=Motion, 6=SemiMajorAxis, 7=MagAbs, 8=SlopeParam, 9=NumberOpposition, 10=NumberObservation, 11=RmsResidual. Note: Observation Span is intentionally skipped.</remarks>
+	private readonly double[] recordValues = new double[12];
+
+	/// <summary>Stores the original string values from the database for each orbital element.</summary>
+	/// <remarks>These string values are displayed in the UI as-is, preserving the original format from the main application.</remarks>
+	private readonly string[] recordStringValues = new string[12];
 
 	/// <summary>Holds a progress update for a single orbital element record, used to marshal label updates from the background thread to the UI thread via <see cref="BackgroundWorker.ReportProgress(int, object)"/>.</summary>
 	/// <param name="ElementIndex">Zero-based index of the orbital element.</param>
-	/// <param name="Value">The new record value.</param>
+	/// <param name="Value">The new record value (as double for comparison).</param>
+	/// <param name="StringValue">The original string value from the database to display in the UI.</param>
 	/// <param name="Designation">The readable designation of the record-holder asteroid.</param>
 	/// <remarks>This struct is used to pass progress updates from the background worker to the UI thread.</remarks>
-	private readonly record struct RecordProgressUpdate(int ElementIndex, double Value, string Designation);
+	private readonly record struct RecordProgressUpdate(int ElementIndex, double Value, string StringValue, string Designation);
 
 	#region constructor
 
@@ -60,7 +65,6 @@ public partial class RecordsForm : BaseKryptonForm
 	{
 		// Initialize the form components
 		InitializeComponent();
-
 		// Enable double buffering for the TableLayoutPanel to prevent flickering
 		try
 		{
@@ -71,11 +75,11 @@ public partial class RecordsForm : BaseKryptonForm
 			MethodInfo? setStyleMethod = typeof(Control).GetMethod(name: "SetStyle", bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance);
 			setStyleMethod?.Invoke(obj: tableLayoutPanel, parameters: [ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true]);
 		}
+		// Catch any exceptions that may occur during reflection and log a warning, but do not prevent the form from functioning without double buffering
 		catch (Exception ex)
 		{
 			logger.Warn(exception: ex, message: "Could not set DoubleBuffered on tableLayoutPanel");
 		}
-
 		// Wire up BackgroundWorker events once at construction time
 #pragma warning disable CS8622
 		backgroundWorker.DoWork += BackgroundWorker_DoWork;
@@ -92,6 +96,60 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <returns>A string representation of the current instance for use in the debugger.</returns>
 	/// <remarks>This method is called to obtain a string representation of the current instance.</remarks>
 	private string GetDebuggerDisplay() => ToString();
+
+	/// <summary>Prepares and displays a save file dialog with a default file name and initial directory set to the user's Documents folder.</summary>
+	/// <remarks>The method sets the dialog's initial directory to the user's Documents folder and generates a default file name based on the current date and time. The dialog is shown modally, and the result indicates whether the user confirmed the selection.</remarks>
+	/// <param name="dialog">The file dialog to configure and display. Must not be null.</param>
+	/// <param name="ext">The file extension to use for the default file name, without the leading period.</param>
+	/// <returns>true if the user selects a file and confirms the dialog; otherwise, false.</returns>
+	private static bool PrepareSaveDialog(FileDialog dialog, string ext)
+	{
+		// Set up the save dialog properties
+		dialog.InitialDirectory = Environment.GetFolderPath(folder: Environment.SpecialFolder.MyDocuments);
+		// Set default file name
+		dialog.FileName = $"Records_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.{ext}";
+		// Show the dialog and return the result
+		return dialog.ShowDialog() == DialogResult.OK;
+	}
+
+	/// <summary>Displays a save dialog and exports the table layout panel contents using the specified export action.</summary>
+	/// <param name="filter">The file type filter for the save dialog.</param>
+	/// <param name="defaultExt">The default file extension.</param>
+	/// <param name="dialogTitle">The title of the save dialog.</param>
+	/// <param name="exportAction">The export action to invoke with the table layout panel, title, and file name.</param>
+	/// <remarks>This method encapsulates the logic for displaying a save dialog and performing the export action based on the user's selection. It handles the preparation of the dialog, execution of the export action, and manages the cursor state during the operation.</remarks>
+	private void PerformSaveExport(string filter, string defaultExt, string dialogTitle, Action<TableLayoutPanel, string, string> exportAction)
+	{
+		// Create and configure the save file dialog with the specified filter, default extension, and title. The dialog allows the user to choose where to save the exported file and what name to give it.
+		using SaveFileDialog saveFileDialog = new()
+		{
+			Filter = filter,
+			DefaultExt = defaultExt,
+			Title = dialogTitle
+		};
+		// Prepare and show the save dialog. If the user cancels the dialog, the method returns without performing any export action.
+		if (!PrepareSaveDialog(dialog: saveFileDialog, ext: defaultExt))
+		{
+			return;
+		}
+		// If the user selects a file and confirms the dialog, set the cursor to a wait cursor to indicate that an operation is in progress, and then invoke the specified export action with the text box containing the output, the title for the export, and the selected file name. After the export action is completed, reset the cursor to the default state.
+		try
+		{
+			Cursor.Current = Cursors.WaitCursor;
+			exportAction(arg1: tableLayoutPanel, arg2: "Records", arg3: saveFileDialog.FileName);
+		}
+		// Handle any exceptions that may occur during the export action
+		catch (Exception ex)
+		{
+			logger.Error(message: $"An error occurred during export: {ex}");
+			ShowErrorMessage(message: $"An error has occurred during export: {ex.Message}");
+		}
+		// In the finally block, ensure that the cursor is reset to the default state regardless of whether the export action succeeds or fails. This ensures that the user interface remains responsive and provides appropriate feedback to the user.
+		finally
+		{
+			Cursor.Current = Cursors.Default;
+		}
+	}
 
 	/// <summary>Fills the internal database list with a copy of the provided planetoid data.</summary>
 	/// <param name="arrTemp">The list of raw planetoid data lines from the main form.</param>
@@ -111,10 +169,11 @@ public partial class RecordsForm : BaseKryptonForm
 			valueLabels[i].Values.Text = "-";
 		}
 		// Reset tracking arrays
-		bool isMax = checkButtonMax.Checked;
+		bool isMax = toolStripButtonSortOrderAscending.Checked;
 		for (int i = 0; i < recordValues.Length; i++)
 		{
 			recordValues[i] = isMax ? double.MinValue : double.MaxValue;
+			recordStringValues[i] = string.Empty;
 		}
 	}
 
@@ -123,10 +182,9 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <remarks>The array is ordered to match the orbital element order used in record tracking.</remarks>
 	private KryptonLabel[] GetDesignationLabels() =>
 	[
-		labelDesignation01, labelDesignation02, labelDesignation03, labelDesignation04,
-		labelDesignation05, labelDesignation06, labelDesignation07, labelDesignation08,
-		labelDesignation09, labelDesignation10, labelDesignation11, labelDesignation12,
-		labelDesignation13
+		labelDesignationMeanAnomalyAtTheEpoch, labelDesignationArgumentOfThePerihelion, labelDesignationLongitudeOfTheAscendingNode, labelDesignationInclinationToTheEcliptic,
+		labelDesignationOrbitalEccentricity, labelDesignationMeanDailyMotion, labelDesignationSemiMajorAxis, labelDesignationAbsoluteMagnitude,
+		labelDesignationSlopeParameter, labelDesignationNumberOfOppositions, labelDesignationNumberOfObservations, labelDesignationRmsResidual
 	];
 
 	/// <summary>Gets the array of value labels in element order.</summary>
@@ -134,38 +192,37 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <remarks>The array is ordered to match the orbital element order used in record tracking.</remarks>
 	private KryptonLabel[] GetValueLabels() =>
 	[
-		labelValue01, labelValue02, labelValue03, labelValue04,
-		labelValue05, labelValue06, labelValue07, labelValue08,
-		labelValue09, labelValue10, labelValue11, labelValue12,
-		labelValue13
+		labelValueMeanAnomalyAtTheEpoch, labelValueArgumentOfThePerihelion, labelValueLongitudeOfTheAscendingNode, labelValueInclinationToTheEcliptic,
+		labelValueOrbitalEccentricity, labelValueMeanDailyMotion, labelValueSemiMajorAxis, labelValueAbsoluteMagnitude,
+		labelValueSlopeParameter, labelValueNumberOfOppositions, labelValueNumberOfObservations, labelValueRmsResidual
 		];
 
 	/// <summary>Checks whether a numeric value beats the current record for the given element index and, if so, fires a <see cref="BackgroundWorker.ReportProgress(int, object)"/> event so the UI labels can be updated safely on the UI thread.</summary>
 	/// <param name="elementIndex">Zero-based index of the orbital element.</param>
 	/// <param name="value">The numeric value to compare against the current record.</param>
+	/// <param name="stringValue">The original string value from the database to display in the UI.</param>
 	/// <param name="designation">The readable designation of the asteroid.</param>
 	/// <param name="isMax">If <c>true</c>, checks for maximum; otherwise checks for minimum.</param>
 	/// <param name="percent">Current scan percentage, forwarded in the progress report.</param>
 	/// <remarks>This method runs on the <see cref="BackgroundWorker"/> DoWork thread. UI updates are performed through the <see cref="BackgroundWorker.ProgressChanged"/> event.</remarks>
-	private void CheckAndReportRecord(int elementIndex, double value, string designation, bool isMax, int percent)
+	private void CheckAndReportRecord(int elementIndex, double value, string stringValue, string designation, bool isMax, int percent)
 	{
 		// Check if this value is a new record
 		bool isNewRecord = isMax
 			? value > recordValues[elementIndex]
 			: value < recordValues[elementIndex];
-
+		// If it's not a new record, simply return without doing anything
 		if (!isNewRecord)
 		{
 			return;
 		}
-
 		// Store the new record value (safe on this thread; only DoWork touches recordValues)
 		recordValues[elementIndex] = value;
-
+		recordStringValues[elementIndex] = stringValue;
 		// Report the update to the UI thread via ProgressChanged
 		backgroundWorker.ReportProgress(
 			percentProgress: percent,
-			userState: new RecordProgressUpdate(ElementIndex: elementIndex, Value: value, Designation: designation));
+			userState: new RecordProgressUpdate(ElementIndex: elementIndex, Value: value, StringValue: stringValue, Designation: designation));
 	}
 
 	/// <summary>Processes a single database entry and checks all orbital element values for records.</summary>
@@ -177,92 +234,75 @@ public partial class RecordsForm : BaseKryptonForm
 	{
 		// Parse the raw line into a PlanetoidRecord
 		PlanetoidRecord record = PlanetoidRecord.Parse(rawLine: rawLine);
-
 		// Skip empty records
 		if (string.IsNullOrWhiteSpace(value: record.DesignationName))
 		{
 			return;
 		}
-
+		// Readable designation for progress reporting
 		string designation = record.DesignationName;
-
+		// Check each orbital element in turn. If parsing succeeds, compare against the current record and report if it's a new record. The element index corresponds to the order defined in the recordValues array and label arrays.		
 		// Mean Anomaly at the Epoch
 		if (double.TryParse(s: record.MeanAnomaly, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double meanAnomaly))
 		{
-			CheckAndReportRecord(elementIndex: 0, value: meanAnomaly, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 0, value: meanAnomaly, stringValue: record.MeanAnomaly, designation: designation, isMax: isMax, percent: percent);
 		}
-
-		// Argument of Perihelion
+		// Argument of the Perihelion
 		if (double.TryParse(s: record.ArgPeri, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double argPeri))
 		{
-			CheckAndReportRecord(elementIndex: 1, value: argPeri, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 1, value: argPeri, stringValue: record.ArgPeri, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Longitude of the Ascending Node
 		if (double.TryParse(s: record.LongAscNode, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double longAscNode))
 		{
-			CheckAndReportRecord(elementIndex: 2, value: longAscNode, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 2, value: longAscNode, stringValue: record.LongAscNode, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Inclination to the Ecliptic
 		if (double.TryParse(s: record.Incl, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double incl))
 		{
-			CheckAndReportRecord(elementIndex: 3, value: incl, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 3, value: incl, stringValue: record.Incl, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Orbital Eccentricity
 		if (double.TryParse(s: record.OrbEcc, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double orbEcc))
 		{
-			CheckAndReportRecord(elementIndex: 4, value: orbEcc, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 4, value: orbEcc, stringValue: record.OrbEcc, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Mean Daily Motion
 		if (double.TryParse(s: record.Motion, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double motion))
 		{
-			CheckAndReportRecord(elementIndex: 5, value: motion, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 5, value: motion, stringValue: record.Motion, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Semi-Major Axis
 		if (double.TryParse(s: record.SemiMajorAxis, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double semiMajorAxis))
 		{
-			CheckAndReportRecord(elementIndex: 6, value: semiMajorAxis, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 6, value: semiMajorAxis, stringValue: record.SemiMajorAxis, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Absolute Magnitude (H)
 		if (double.TryParse(s: record.MagAbs, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double magAbs))
 		{
-			CheckAndReportRecord(elementIndex: 7, value: magAbs, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 7, value: magAbs, stringValue: record.MagAbs, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Slope Parameter (G)
 		if (double.TryParse(s: record.SlopeParam, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double slopeParam))
 		{
-			CheckAndReportRecord(elementIndex: 8, value: slopeParam, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 8, value: slopeParam, stringValue: record.SlopeParam, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Number of Oppositions
 		if (int.TryParse(s: record.NumberOpposition, style: NumberStyles.Integer, provider: CultureInfo.InvariantCulture, result: out int numOpposition))
 		{
-			CheckAndReportRecord(elementIndex: 9, value: numOpposition, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 9, value: numOpposition, stringValue: record.NumberOpposition, designation: designation, isMax: isMax, percent: percent);
 		}
-
 		// Number of Observations
 		if (int.TryParse(s: record.NumberObservation, style: NumberStyles.Integer, provider: CultureInfo.InvariantCulture, result: out int numObservation))
 		{
-			CheckAndReportRecord(elementIndex: 10, value: numObservation, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 10, value: numObservation, stringValue: record.NumberObservation, designation: designation, isMax: isMax, percent: percent);
 		}
-
-		// Observation Span
-		if (int.TryParse(s: record.ObsSpan, style: NumberStyles.Integer, provider: CultureInfo.InvariantCulture, result: out int obsSpan))
-		{
-			CheckAndReportRecord(elementIndex: 11, value: obsSpan, designation: designation, isMax: isMax, percent: percent);
-		}
-
-		// RMS Residual
+		// RMS Residual (Observation Span is intentionally skipped)
 		if (double.TryParse(s: record.RmsResidual, style: NumberStyles.Float, provider: CultureInfo.InvariantCulture, result: out double rmsResidual))
 		{
-			CheckAndReportRecord(elementIndex: 12, value: rmsResidual, designation: designation, isMax: isMax, percent: percent);
+			CheckAndReportRecord(elementIndex: 11, value: rmsResidual, stringValue: record.RmsResidual, designation: designation, isMax: isMax, percent: percent);
 		}
+		// Note: Observation Span is not included in the record tracking since it can vary based on observation history rather than being an intrinsic orbital property.
 	}
 
 	#endregion
@@ -273,7 +313,13 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>Initializes the form by clearing the status bar.</remarks>
-	private void RecordsForm_Load(object sender, EventArgs e) => ClearStatusBar(label: labelInformation);
+	private void RecordsForm_Load(object sender, EventArgs e)
+	{
+		// Clear the status bar when the form loads
+		ClearStatusBar(label: labelInformation);
+		// Ensure the Cancel button is disabled at startup
+		toolStripButtonCancel.Enabled = false;
+	}
 
 	#endregion
 
@@ -292,7 +338,7 @@ public partial class RecordsForm : BaseKryptonForm
 		{
 			return;
 		}
-
+		// Iterate through all entries in the database
 		int lastPercent = -1;
 		for (int i = 0; i < total; i++)
 		{
@@ -302,19 +348,20 @@ public partial class RecordsForm : BaseKryptonForm
 				e.Cancel = true;
 				break;
 			}
-
 			// Process this database entry
 			string rawLine = planetoidsDatabase[index: i];
 			int percent = (int)((i + 1) * 100L / total);
+			// Wrap processing in a try-catch to handle any malformed lines without crashing the entire scan
 			try
 			{
+				// Process the entry and check for records. Any new records will trigger progress reports to update the UI labels.
 				ProcessEntry(rawLine: rawLine, isMax: isMax, percent: percent);
 			}
+			// Catch any exceptions that occur during processing of this entry, log a warning, and continue with the next entry. This ensures that a single bad line does not stop the entire scan.
 			catch (Exception ex)
 			{
 				logger.Warn(exception: ex, message: $"Skipping entry at index {i}: {ex.Message}");
 			}
-
 			// Report plain percentage progress only when the percentage changes
 			if (percent != lastPercent)
 			{
@@ -330,11 +377,12 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <remarks>Called on the UI thread by the BackgroundWorker. When <see cref="ProgressChangedEventArgs.UserState"/> is a <see cref="RecordProgressUpdate"/>, the corresponding designation and value labels are updated.</remarks>
 	private void BackgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
 	{
+		// Update the progress bar value and text if the percentage has changed
 		int percent = e.ProgressPercentage;
-		if (progressBar.Value != percent)
+		if (kryptonProgressBar.Value != percent)
 		{
-			progressBar.Value = percent;
-			progressBar.Text = $"{percent} %";
+			kryptonProgressBar.Value = percent;
+			kryptonProgressBar.Text = $"{percent} %";
 			TaskbarProgress.SetValue(windowHandle: Handle, progressValue: (ulong)percent, progressMax: 100);
 		}
 		// If this progress report carries a record update, apply it to the labels
@@ -342,9 +390,9 @@ public partial class RecordsForm : BaseKryptonForm
 		{
 			KryptonLabel[] designationLabels = GetDesignationLabels();
 			KryptonLabel[] valueLabels = GetValueLabels();
-			string formattedValue = update.Value.ToString(format: "G", provider: CultureInfo.InvariantCulture);
+			// Display the original string value from the database as-is
 			designationLabels[update.ElementIndex].Values.Text = update.Designation;
-			valueLabels[update.ElementIndex].Values.Text = formattedValue;
+			valueLabels[update.ElementIndex].Values.Text = update.StringValue;
 		}
 	}
 
@@ -354,27 +402,28 @@ public partial class RecordsForm : BaseKryptonForm
 	/// <remarks>Called on the UI thread after the BackgroundWorker finishes or is cancelled. Resets the UI state so the user can start a new scan.</remarks>
 	private void BackgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 	{
-		buttonCancel.Enabled = false;
-		progressBar.Enabled = false;
-		buttonStart.Enabled = true;
-		checkButtonMax.Enabled = true;
-		checkButtonMin.Enabled = true;
-		groupBoxRecordType.Enabled = true;
-
+		// Reset UI state to allow starting a new scan
+		toolStripButtonCancel.Enabled = false;
+		toolStripButtonStart.Enabled = true;
+		toolStripButtonSortOrderAscending.Enabled = true;
+		toolStripButtonSortOrderDescending.Enabled = true;
+		toolStripDropDownButtonSaveList.Enabled = true;
+		contextMenuSaveToFile.Enabled = true;
+		// Update the progress bar text based on whether the scan was cancelled, completed with an error, or completed successfully
 		if (e.Cancelled)
 		{
-			progressBar.Text = "Scan cancelled";
+			kryptonProgressBar.Text = "Scan cancelled";
 			ClearStatusBar(label: labelInformation);
 		}
 		else if (e.Error != null)
 		{
 			logger.Error(exception: e.Error, message: e.Error.Message);
-			progressBar.Text = I18nStrings.ErrorCaption;
+			kryptonProgressBar.Text = I18nStrings.ErrorCaption;
 			ClearStatusBar(label: labelInformation);
 		}
 		else
 		{
-			progressBar.Text = "100 %";
+			kryptonProgressBar.Text = "100 %";
 		}
 	}
 
@@ -382,58 +431,284 @@ public partial class RecordsForm : BaseKryptonForm
 
 	#region Click event handlers
 
-	/// <summary>Handles the Click event of the ButtonStart control. Resets results and starts the record detection scan.</summary>
+	/// <summary>Handles the Click event of the ToolStripButtonStart control. Resets results and starts the record detection scan.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>Disables the Start button, enables the Cancel button, resets labels and record arrays, then launches the BackgroundWorker with the selected max/min mode.</remarks>
-	private void ButtonStart_Click(object sender, EventArgs e)
+	private void Start_Click(object sender, EventArgs e)
 	{
+		// Ensure there is data to scan before starting
 		if (planetoidsDatabase.Count == 0)
 		{
 			ShowErrorMessage(message: I18nStrings.MpcorbDatNotFoundText);
 			return;
 		}
-
 		// Reset state
 		isCancelled = false;
 		ResetLabels();
-
 		// Update UI for scan in progress
-		buttonStart.Enabled = false;
-		buttonCancel.Enabled = true;
-		progressBar.Enabled = true;
-		progressBar.Value = 0;
-		progressBar.Text = "0 %";
-		checkButtonMax.Enabled = false;
-		checkButtonMin.Enabled = false;
-		groupBoxRecordType.Enabled = false;
+		toolStripButtonStart.Enabled = false;
+		toolStripButtonCancel.Enabled = true;
+		kryptonProgressBar.Value = 0;
+		kryptonProgressBar.Text = "0 %";
+		toolStripButtonSortOrderAscending.Enabled = false;
+		toolStripButtonSortOrderDescending.Enabled = false;
+		toolStripDropDownButtonSaveList.Enabled = false;
+		contextMenuSaveToFile.Enabled = false;
 
 		// Wire up BackgroundWorker events and start the scan
-		backgroundWorker.RunWorkerAsync(argument: checkButtonMax.Checked);
+		backgroundWorker.RunWorkerAsync(argument: toolStripButtonSortOrderAscending.Checked);
 	}
 
 	/// <summary>Handles the Click event of the ButtonCancel control. Cancels the ongoing record detection scan.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	/// <remarks>Sets the cancellation flag and requests the BackgroundWorker to stop. The UI state will be reset in the <see cref="BackgroundWorker_RunWorkerCompleted"/> handler.</remarks>
-	private void ButtonCancel_Click(object sender, EventArgs e)
+	private void Cancel_Click(object sender, EventArgs e)
 	{
+		// Set the cancellation flag and request the BackgroundWorker to cancel. The actual stopping will be handled cooperatively in the DoWork method, and the UI will be updated in the RunWorkerCompleted handler.
 		isCancelled = true;
 		backgroundWorker.CancelAsync();
-		buttonCancel.Enabled = false;
+		toolStripButtonCancel.Enabled = false;
+		toolStripDropDownButtonSaveList.Enabled = true;
+		contextMenuSaveToFile.Enabled = true;
 	}
 
-	/// <summary>Handles the Click event of the CheckButtonMax control. Selects maximum record mode and deselects minimum mode.</summary>
+	/// <summary>Handles the Click event of the ToolStripButtonSortOrderAscending control. Selects ascending sort order and deselects descending sort order.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>Ensures that exactly one of Max/Min is selected at all times.</remarks>
-	private void CheckButtonMax_Click(object sender, EventArgs e) => checkButtonMin.Checked = !checkButtonMax.Checked;
+	/// <remarks>Ensures that exactly one of Ascending/Descending is selected at all times.</remarks>
+	private void SetAscendingSortOrder_Click(object sender, EventArgs e) => toolStripButtonSortOrderDescending.Checked = !toolStripButtonSortOrderAscending.Checked;
 
-	/// <summary>Handles the Click event of the CheckButtonMin control. Selects minimum record mode and deselects maximum mode.</summary>
+	/// <summary>Handles the Click event of the ToolStripButtonSortOrderDescending control. Selects descending sort order and deselects ascending sort order.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>Ensures that exactly one of Max/Min is selected at all times.</remarks>
-	private void CheckButtonMin_Click(object sender, EventArgs e) => checkButtonMax.Checked = !checkButtonMin.Checked;
+	/// <remarks>Ensures that exactly one of Ascending/Descending is selected at all times.</remarks>
+	private void SetDescendingSortOrder_Click(object sender, EventArgs e) => toolStripButtonSortOrderAscending.Checked = !toolStripButtonSortOrderDescending.Checked;
+
+	/// <summary>Handles the Click event to export the output as a text file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a text file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item for saving as text.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsText_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Text Files (*.txt)|*.txt|All Files (*.*)|*.*", defaultExt: "txt", dialogTitle: "Save as Text", exportAction: TableLayoutPanelExporter.SaveAsText);
+
+	/// <summary>Handles the Click event to export the output as a LaTeX file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a LaTeX file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsLatex_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "LaTeX Files (*.tex)|*.tex|All Files (*.*)|*.*", defaultExt: "tex", dialogTitle: "Save as LaTeX", exportAction: TableLayoutPanelExporter.SaveAsLatex);
+
+	/// <summary>Handles the Click event to export the output as a Markdown file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Markdown file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMarkdown_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Markdown Files (*.md)|*.md|All Files (*.*)|*.*", defaultExt: "md", dialogTitle: "Save as Markdown", exportAction: TableLayoutPanelExporter.SaveAsMarkdown);
+
+	/// <summary>Handles the Click event to export the output as an AsciiDoc file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an AsciiDoc file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAsciiDoc_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "AsciiDoc Files (*.adoc)|*.adoc|All Files (*.*)|*.*", defaultExt: "adoc", dialogTitle: "Save as AsciiDoc", exportAction: TableLayoutPanelExporter.SaveAsAsciiDoc);
+
+	/// <summary>Handles the Click event to export the output as a ReStructuredText file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a ReStructuredText file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsReStructuredText_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "ReStructuredText Files (*.rst)|*.rst|All Files (*.*)|*.*", defaultExt: "rst", dialogTitle: "Save as ReStructuredText", exportAction: TableLayoutPanelExporter.SaveAsReStructuredText);
+
+	/// <summary>Handles the Click event to export the output as a Textile file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Textile file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTextile_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Textile Files (*.textile)|*.textile|All Files (*.*)|*.*", defaultExt: "textile", dialogTitle: "Save as Textile", exportAction: TableLayoutPanelExporter.SaveAsTextile);
+
+	/// <summary>Handles the Click event to export the output as a Word document.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a Word file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWord_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Word Files (*.docx)|*.docx|All Files (*.*)|*.*", defaultExt: "docx", dialogTitle: "Save as Word", exportAction: TableLayoutPanelExporter.SaveAsWord);
+
+	/// <summary>Handles the Click event to export the output as an OpenDocument Text file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ODT file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOdt_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "OpenDocument Text Files (*.odt)|*.odt|All Files (*.*)|*.*", defaultExt: "odt", dialogTitle: "Save as OpenDocument Text", exportAction: TableLayoutPanelExporter.SaveAsOdt);
+
+	/// <summary>Handles the Click event to export the output as an RTF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an RTF file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As RTF menu item.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsRtf_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Rich Text Format Files (*.rtf)|*.rtf|All Files (*.*)|*.*", defaultExt: "rtf", dialogTitle: "Save as RTF", exportAction: TableLayoutPanelExporter.SaveAsRtf);
+
+	/// <summary>Handles the Click event to export the output as an Abiword file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an Abiword file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsAbiword_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Abiword Files (*.abw)|*.abw|All Files (*.*)|*.*", defaultExt: "abw", dialogTitle: "Save as Abiword", exportAction: TableLayoutPanelExporter.SaveAsAbiword);
+
+	/// <summary>Handles the Click event to export the output as a WPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a WPS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As WPS menu item.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsWps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "WPS Files (*.wps)|*.wps|All Files (*.*)|*.*", defaultExt: "wps", dialogTitle: "Save as WPS", exportAction: TableLayoutPanelExporter.SaveAsWps);
+
+	/// <summary>Handles the Click event to export the output as an Excel file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an Excel file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsExcel_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*", defaultExt: "xlsx", dialogTitle: "Save as Excel", exportAction: TableLayoutPanelExporter.SaveAsExcel);
+
+	/// <summary>Handles the Click event to export the output as an ODS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ODS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsOds_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "OpenDocument Spreadsheet Files (*.ods)|*.ods|All Files (*.*)|*.*", defaultExt: "ods", dialogTitle: "Save as ODS", exportAction: TableLayoutPanelExporter.SaveAsOds);
+
+	/// <summary>Handles the Click event to export the output as a CSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a CSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsCsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Comma-Separated Values (*.csv)|*.csv|All Files (*.*)|*.*", defaultExt: "csv", dialogTitle: "Save as CSV", exportAction: TableLayoutPanelExporter.SaveAsCsv);
+
+	/// <summary>Handles the Click event to export the output as a TSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a TSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsTsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Tab-Separated Values (*.tsv)|*.tsv|All Files (*.*)|*.*", defaultExt: "tsv", dialogTitle: "Save as TSV", exportAction: TableLayoutPanelExporter.SaveAsTsv);
+
+	/// <summary>Handles the Click event to export the output as a PSV file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PSV file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPsv_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Pipe-Separated Values (*.psv)|*.psv|All Files (*.*)|*.*", defaultExt: "psv", dialogTitle: "Save as PSV", exportAction: TableLayoutPanelExporter.SaveAsPsv);
+
+	/// <summary>Handles the Click event to export the output as an ET file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an ET file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEt_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "ET Files (*.et)|*.et|All Files (*.*)|*.*", defaultExt: "et", dialogTitle: "Save as ET", exportAction: TableLayoutPanelExporter.SaveAsEt);
+
+	/// <summary>Handles the Click event to export the output as an HTML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an HTML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsHtml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "HTML Files (*.html)|*.html|All Files (*.*)|*.*", defaultExt: "html", dialogTitle: "Save as HTML", exportAction: TableLayoutPanelExporter.SaveAsHtml);
+
+	/// <summary>Handles the Click event to export the output as an XML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an XML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "XML Files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as XML", exportAction: TableLayoutPanelExporter.SaveAsXml);
+
+	/// <summary>Handles the Click event to export the output as a DocBook file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a DocBook file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsDocBook_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "DocBook Files (*.xml)|*.xml|All Files (*.*)|*.*", defaultExt: "xml", dialogTitle: "Save as DocBook", exportAction: TableLayoutPanelExporter.SaveAsDocBook);
+
+	/// <summary>Handles the Click event to export the output as a JSON file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a JSON file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsJson_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "JSON Files (*.json)|*.json|All Files (*.*)|*.*", defaultExt: "json", dialogTitle: "Save as JSON", exportAction: TableLayoutPanelExporter.SaveAsJson);
+
+	/// <summary>Handles the Click event to export the output as a YAML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a YAML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsYaml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "YAML Files (*.yaml)|*.yaml|All Files (*.*)|*.*", defaultExt: "yaml", dialogTitle: "Save as YAML", exportAction: TableLayoutPanelExporter.SaveAsYaml);
+
+	/// <summary>Handles the Click event to export the output as a TOML file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a TOML file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsToml_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "TOML Files (*.toml)|*.toml|All Files (*.*)|*.*", defaultExt: "toml", dialogTitle: "Save as TOML", exportAction: TableLayoutPanelExporter.SaveAsToml);
+
+	/// <summary>Handles the Click event to export the output as a SQL file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a SQL file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As SQL menu item.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSql_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "SQL Files (*.sql)|*.sql|All Files (*.*)|*.*", defaultExt: "sql", dialogTitle: "Save as SQL", exportAction: TableLayoutPanelExporter.SaveAsSql);
+
+	/// <summary>Handles the Click event to export the output as a SQLite file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a SQLite file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsSqlite_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "SQLite Files (*.sqlite)|*.sqlite|All Files (*.*)|*.*", defaultExt: "sqlite", dialogTitle: "Save as SQLite", exportAction: TableLayoutPanelExporter.SaveAsSqlite);
+
+	/// <summary>Handles the Click event to export the output as a PDF file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PDF file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPdf_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "PDF Files (*.pdf)|*.pdf|All Files (*.*)|*.*", defaultExt: "pdf", dialogTitle: "Save as PDF", exportAction: TableLayoutPanelExporter.SaveAsPdf);
+
+	/// <summary>Handles the Click event to export the output as a PostScript file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a PostScript file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As PostScript menu item.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsPostScript_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "PostScript Files (*.ps)|*.ps|All Files (*.*)|*.*", defaultExt: "ps", dialogTitle: "Save as PostScript", exportAction: TableLayoutPanelExporter.SaveAsPostScript);
+
+	/// <summary>Handles the Click event to export the output as an EPUB file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an EPUB file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsEpub_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "EPUB Files (*.epub)|*.epub|All Files (*.*)|*.*", defaultExt: "epub", dialogTitle: "Save as EPUB", exportAction: TableLayoutPanelExporter.SaveAsEpub);
+
+	/// <summary>Handles the Click event to export the output as a MOBI file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a MOBI file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsMobi_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "MOBI Files (*.mobi)|*.mobi|All Files (*.*)|*.*", defaultExt: "mobi", dialogTitle: "Save as MOBI", exportAction: TableLayoutPanelExporter.SaveAsMobi);
+
+	/// <summary>Handles the Click event to export the output as an XPS file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as an XPS file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the Save As XPS menu item.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsXps_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "XPS Files (*.xps)|*.xps|All Files (*.*)|*.*", defaultExt: "xps", dialogTitle: "Save as XPS", exportAction: TableLayoutPanelExporter.SaveAsXps);
+
+	/// <summary>Handles the Click event to export the output as a FictionBook2 file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a FictionBook2 file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsFictionBook2_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "FictionBook2 Files (*.fb2)|*.fb2|All Files (*.*)|*.*", defaultExt: "fb2", dialogTitle: "Save as FictionBook2", exportAction: TableLayoutPanelExporter.SaveAsFictionBook2);
+
+	/// <summary>Handles the Click event to export the output as a CHM file.</summary>
+	/// <remarks>Invokes the PerformSaveExport method with parameters specific to exporting as a CHM file, including the file filter, default extension, dialog title, and export action.</remarks>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <param name="e">The event data associated with the click event.</param>
+	private void ToolStripMenuItemSaveAsChm_Click(object sender, EventArgs e)
+		=> PerformSaveExport(filter: "Compiled HTML Help Files (*.chm)|*.chm|All Files (*.*)|*.*", defaultExt: "chm", dialogTitle: "Save as CHM", exportAction: TableLayoutPanelExporter.SaveAsChm);
 
 	#endregion
 }

--- a/Forms/RecordsForm.cs
+++ b/Forms/RecordsForm.cs
@@ -169,7 +169,7 @@ public partial class RecordsForm : BaseKryptonForm
 			valueLabels[i].Values.Text = "-";
 		}
 		// Reset tracking arrays
-		bool isMax = toolStripButtonSortOrderAscending.Checked;
+		bool isMax = toolStripButtonSortOrderDescending.Checked;
 		for (int i = 0; i < recordValues.Length; i++)
 		{
 			recordValues[i] = isMax ? double.MinValue : double.MaxValue;
@@ -332,7 +332,7 @@ public partial class RecordsForm : BaseKryptonForm
 	private void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e)
 	{
 		// Determine scan mode (max or min) captured before the background thread starts
-		bool isMax = (bool)(e.Argument ?? true);
+		bool isMax = (bool)(e.Argument ?? false);
 		int total = planetoidsDatabase.Count;
 		if (total == 0)
 		{
@@ -457,7 +457,7 @@ public partial class RecordsForm : BaseKryptonForm
 		contextMenuSaveToFile.Enabled = false;
 
 		// Wire up BackgroundWorker events and start the scan
-		backgroundWorker.RunWorkerAsync(argument: toolStripButtonSortOrderAscending.Checked);
+		backgroundWorker.RunWorkerAsync(argument: toolStripButtonSortOrderDescending.Checked);
 	}
 
 	/// <summary>Handles the Click event of the ButtonCancel control. Cancels the ongoing record detection scan.</summary>
@@ -470,8 +470,6 @@ public partial class RecordsForm : BaseKryptonForm
 		isCancelled = true;
 		backgroundWorker.CancelAsync();
 		toolStripButtonCancel.Enabled = false;
-		toolStripDropDownButtonSaveList.Enabled = true;
-		contextMenuSaveToFile.Enabled = true;
 	}
 
 	/// <summary>Handles the Click event of the ToolStripButtonSortOrderAscending control. Selects ascending sort order and deselects descending sort order.</summary>

--- a/Forms/RecordsForm.resx
+++ b/Forms/RecordsForm.resx
@@ -117,17 +117,29 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuSaveToFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>855, 20</value>
+  </metadata>
+  <metadata name="contextMenuCopyToClipboard.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1034, 20</value>
+  </metadata>
   <metadata name="kryptonStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="kryptonManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 17</value>
+    <value>557, 20</value>
   </metadata>
   <metadata name="backgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>235, 17</value>
+    <value>699, 20</value>
+  </metadata>
+  <metadata name="kryptonToolStripGenerateList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>165, 20</value>
+  </metadata>
+  <metadata name="kryptonToolStripProgress.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>371, 20</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>63</value>
+    <value>51</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Redesigns `RecordsForm` to replace the legacy `KryptonGroupBox` + Max/Min check buttons and standalone Start/Cancel/ProgressBar controls with a `ToolStripContainer` layout containing a top toolbar (Start, Cancel, sort-order toggles, Save-list dropdown with many export formats) and a bottom status strip. The form now preserves the original database string values in the result labels (instead of reformatting doubles) and exposes a rich save/export menu reusing `TableLayoutPanelExporter`. The "Observation Span" element is intentionally dropped from the tracked records (12 elements instead of 13).

**Changes:**
- Replaced Max/Min check buttons with Ascending/Descending toolbar toggle buttons and rewired the scan logic to read from them.
- Renamed all element/designation/value labels from numbered (`labelElement01`…) to semantic names (e.g. `labelElementMeanAnomalyAtTheEpoch`) and added a shared copy-to-clipboard context menu plus a large Save-list export menu.
- Stored original database string values alongside parsed doubles so labels display original formatting; removed Observation Span tracking.