### PR TITLE
Updated image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/6a345ee1-90a0-4dcd-bd94-12bdcdc6425a" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/a2333201-eaca-4851-88de-7710fbd9688c" />


### PR DESCRIPTION
Updates the README screenshot reference to point to a new GitHub user-attachment asset.

**Changes:**
- Replaced the README image `src` URL while preserving dimensions and alt text.