### PR TITLE
Updated image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/96968f0e-143b-4ea2-a8de-7a8f178b66d0" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/955e6313-24c2-457a-a9bd-356b727b74f3" />


### PR DESCRIPTION
Updates the README screenshot reference so the project documentation displays the correct/most recent UI image for Planetoid-DB.

**Changes:**
- Replaced the `<img>` `src` URL in `README.md` to point to a new GitHub user-attachments asset.