### PR TITLE
Updated to version 0.9.6.69

### DIFF
--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -642,7 +642,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			38 => TerminologyElement.StandardGravitationalParameter,
 			_ => TerminologyElement.IndexNumber,
 		};
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formTerminology.TopMost = TopMost;
 		// Show the terminology form as a modal dialog
 		_ = formTerminology.ShowDialog();
@@ -654,7 +654,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the TableModeForm
 		using TableModeForm formTableMode = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formTableMode.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		formTableMode.FillArray(arrTemp: planetoidsDatabase);
@@ -667,7 +667,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	private void ShowOrbitalResonances()
 	{
 		// Try to parse the semi-major axis from the label text using invariant culture to ensure consistent parsing regardless of the user's locale settings
-		IFormatProvider provider = CultureInfo.CreateSpecificCulture(name: "en");
+		IFormatProvider provider = CultureInfo.InvariantCulture;
 		// If parsing fails, log an error and show an error message to the user, then return early to avoid opening the form with invalid data
 		if (!double.TryParse(s: labelSemiMajorAxisData.Text, style: NumberStyles.Any, provider: provider, result: out double semiMajorAxis))
 		{
@@ -677,7 +677,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the OrbitalResonancesOfOneMinorPlanetForm
 		using OrbitalResonancesOfOneMinorPlanetForm formOrbitalResonances = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formOrbitalResonances.TopMost = TopMost;
 		// Pass the parsed semi-major axis to the form so it can calculate and display the relevant orbital resonances for the current planetoid
 		formOrbitalResonances.SetSemiMajorAxis(semiMajorAxis: semiMajorAxis);
@@ -698,7 +698,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the ObservationsForm
 		using ObservationsForm formObservations = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formObservations.TopMost = TopMost;
 		// Pass the index data label text to the observations form so it can use it to fetch and display the relevant observations for the current planetoid
 		formObservations.SetIndexData(indexData: labelIndexData.Text);
@@ -706,13 +706,13 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		_ = formObservations.ShowDialog();
 	}
 
-	/// <summary>Shows the orbital resonances form for the current planetoid.</summary>
-	/// <remarks>Parses the semi-major axis from the UI label and opens the <see cref="OrbitalResonancesOfOneMinorPlanetForm"/>.</remarks>
+	/// <summary>Shows the orbit elements grouping form.</summary>
+	/// <remarks>Passes the full planetoids database to the <see cref="OrbitElementsGroupingForm"/> and shows it as a modal dialog.</remarks>
 	private void ShowOrbitElementsGrouping()
 	{
-		// Create a new instance of the OrbitElementsGroupingForm and pass the planeto
+		// Create a new instance of the OrbitElementsGroupingForm and pass the planetoids database to it
 		using OrbitElementsGroupingForm formOrbitElementsGrouping = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formOrbitElementsGrouping.TopMost = TopMost;
 		// Show the orbit elements grouping form as a modal dialog
 		_ = formOrbitElementsGrouping.ShowDialog();
@@ -724,7 +724,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the AsteroidFamiliesForm and pass the planetoids database to it
 		using AsteroidFamiliesForm formAsteroidFamilies = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formAsteroidFamilies.TopMost = TopMost;
 		// Show the asteroid families form as a modal dialog
 		_ = formAsteroidFamilies.ShowDialog(owner: this);
@@ -736,7 +736,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the OrbitalResonancesOfAllMinorPlanetsForm
 		using OrbitalResonancesOfAllMinorPlanetsForm formOrbitalResonances = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formOrbitalResonances.TopMost = TopMost;
 		// Show the orbital resonances form as a modal dialog
 		_ = formOrbitalResonances.ShowDialog(owner: this);
@@ -815,7 +815,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the MoidsOfOneMinorPlanetForm
 		using MoidsOfOneMinorPlanetForm formMoids = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formMoids.TopMost = TopMost;
 		// Pass the parsed orbital elements to the form
 		formMoids.SetOrbitalElements(
@@ -844,7 +844,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the MaxoidsOfOneMinorPlanetForm
 		using MaxoidsOfOneMinorPlanetForm formMaxoids = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formMaxoids.TopMost = TopMost;
 		// Pass the parsed orbital elements to the form
 		formMaxoids.SetOrbitalElements(
@@ -873,7 +873,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the MoidsAndMaxoidsOfOneMinorPlanetForm
 		using MoidsAndMaxoidsOfOneMinorPlanetForm formMoidsAndMaxoids = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formMoidsAndMaxoids.TopMost = TopMost;
 		// Pass the parsed orbital elements to the form
 		formMoidsAndMaxoids.SetOrbitalElements(
@@ -892,7 +892,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the MoidsOfAllMinorPlanetsForm
 		using MoidsOfAllMinorPlanetsForm formMoidsOfAll = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formMoidsOfAll.TopMost = TopMost;
 		// Show the MOIDs of all minor planets form as a modal dialog
 		_ = formMoidsOfAll.ShowDialog(owner: this);
@@ -904,7 +904,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the MaxoidsOfAllMinorPlanetsForm
 		using MaxoidsOfAllMinorPlanetsForm formMaxoidsOfAll = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formMaxoidsOfAll.TopMost = TopMost;
 		// Show the MAXOIDs of all minor planets form as a modal dialog
 		_ = formMaxoidsOfAll.ShowDialog(owner: this);
@@ -916,7 +916,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the HistogramsForm
 		using HistogramsForm formHistogram = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formHistogram.TopMost = TopMost;
 		// Show the histogram form as a modal dialog
 		_ = formHistogram.ShowDialog(owner: this);
@@ -928,7 +928,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the ScatterplotsForm
 		using ScatterplotsForm formScatterplot = new(planetoids: planetoidsDatabase);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formScatterplot.TopMost = TopMost;
 		// Show the scatterplots form as a modal dialog
 		_ = formScatterplot.ShowDialog(owner: this);
@@ -1001,7 +1001,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			return;
 		}
 		// Parse the mean anomaly at the epoch from the corresponding label on the form
-		IFormatProvider provider = CultureInfo.CreateSpecificCulture(name: "en");
+		IFormatProvider provider = CultureInfo.InvariantCulture;
 		// If parsing fails, log the error and show an error message to the user, then return early to avoid opening the form with invalid data
 		if (!double.TryParse(s: labelMeanAnomalyAtTheEpochData.Text, style: NumberStyles.Any, provider: provider, result: out double meanAnomalyDeg))
 		{
@@ -1023,7 +1023,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			argumentPerihelionDeg: argumentPerihelionDeg,
 			meanAnomalyDeg: meanAnomalyDeg,
 			epochMpcorb: epochMpcorb);
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formOrbit3D.TopMost = TopMost;
 		// Show the 3D orbit visualization form as a modal dialog
 		_ = formOrbit3D.ShowDialog();
@@ -1061,7 +1061,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 		// Create a new instance of the TisserandParameterOfOneMinorPlanetForm
 		using TisserandParameterOfOneMinorPlanetForm formTisserand = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formTisserand.TopMost = TopMost;
 		// Pass the parsed orbital elements to the form
 		formTisserand.SetOrbitalElements(semiMajorAxis: semiMajorAxis, eccentricity: eccentricity, inclinationDeg: inclinationDeg);
@@ -1121,7 +1121,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the AppInfoForm
 		using AppInfoForm formAppInfo = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formAppInfo.TopMost = TopMost;
 		// Show the application information form as a modal dialog
 		_ = formAppInfo.ShowDialog();
@@ -1133,7 +1133,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the ArchiveMpcorbForm
 		using ArchiveMpcorbForm formArchive = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formArchive.TopMost = TopMost;
 		// Show the archive form as a modal dialog
 		_ = formArchive.ShowDialog();
@@ -1145,7 +1145,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the DatabaseDifferencesForm
 		using DatabaseDifferencesForm formDataDifferences = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formDataDifferences.TopMost = TopMost;
 		// Show the archive form as a modal dialog
 		_ = formDataDifferences.ShowDialog();
@@ -1157,7 +1157,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the LicenseForm
 		using LicenseForm formLicense = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formLicense.TopMost = TopMost;
 		// Show the application information form as a modal dialog
 		_ = formLicense.ShowDialog();
@@ -1206,7 +1206,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		{
 			// Create and show the MPCORB data check form
 			using CheckDatabaseForm formCheckMpcorbDat = new(url: Settings.Default.systemMpcorbDatUrl, localFilePath: Settings.Default.systemFilenameMpcorb, databaseName: "MPCORB.DAT");
-			// Set the TopMost property to true to keep the form on top of other windows
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			formCheckMpcorbDat.TopMost = TopMost;
 			// Show the MPCORB data check form as a modal dialog
 			_ = formCheckMpcorbDat.ShowDialog();
@@ -1227,7 +1227,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		{
 			// Create and show the ASTORB data check form
 			using CheckDatabaseForm formCheckAstorbDat = new(url: Settings.Default.systemAstorbDatUrl, localFilePath: Settings.Default.systemFilenameAstorb, databaseName: "ASTORB.DAT");
-			// Set the TopMost property to true to keep the form on top of other windows
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			formCheckAstorbDat.TopMost = TopMost;
 			// Show the ASTORB data check form as a modal dialog
 			_ = formCheckAstorbDat.ShowDialog();
@@ -1250,7 +1250,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		{
 			// Create and show the downloader form for the MPCORB database
 			using DatabaseDownloaderForm downloaderForm = new(url: Settings.Default.systemMpcorbDatGzUrl);
-			// Set the TopMost property to true to keep the form on top of other windows
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			downloaderForm.TopMost = TopMost;
 			// Show the downloader form as a modal dialog
 			if (downloaderForm.ShowDialog() == DialogResult.OK)
@@ -1280,7 +1280,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		{
 			// Create and show the downloader form for the ASTORB database
 			using DatabaseDownloaderForm downloaderForm = new(url: Settings.Default.systemAstorbDatGzUrl);
-			// Set the TopMost property to true to keep the form on top of other windows
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			downloaderForm.TopMost = TopMost;
 			// Show the downloader form as a modal dialog
 			if (downloaderForm.ShowDialog() == DialogResult.OK)
@@ -1300,7 +1300,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the DatabaseInformationForm
 		using DatabaseInformationForm formDatabaseInformation = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formDatabaseInformation.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		_ = formDatabaseInformation.ShowDialog();
@@ -1312,7 +1312,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the SearchForm
 		using SearchForm formSearch = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formSearch.TopMost = TopMost;
 
 		_ = formSearch.ShowDialog();
@@ -1341,7 +1341,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the FilterForm
 		using FilterForm formFilter = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formFilter.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		_ = formFilter.ShowDialog();
@@ -1353,7 +1353,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the SettingsForm
 		using SettingsForm formSettings = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formSettings.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		_ = formSettings.ShowDialog();
@@ -1365,7 +1365,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the ListReadableDesignationsForm
 		using ListReadableDesignationsForm formListReadableDesignations = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formListReadableDesignations.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		formListReadableDesignations.FillArray(arrTemp: planetoidsDatabase);
@@ -1435,7 +1435,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		orbitalElements.Add(item: DerivedElements.CalculateStandardGravitationalParameter(semiMajorAxis: semiMajorAxis).ToString(provider: provider));
 		// Create a new instance of the ExportDataSheetForm
 		using ExportDataSheetForm formExportDataSheet = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formExportDataSheet.TopMost = TopMost;
 		// Fill the form with the orbital elements
 		formExportDataSheet.SetDatabase(list: [.. orbitalElements.Cast<string>()]);
@@ -1498,7 +1498,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 		// Create a new instance of the PrintDataSheetForm
 		using PrintDataSheetForm formPrintDataSheet = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formPrintDataSheet.TopMost = TopMost;
 		// Fill the form with the planetoids database
 		formPrintDataSheet.SetDatabase(db: [.. orbitalElements]);
@@ -1572,7 +1572,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 		// Create a new instance of the DerivedOrbitElementsForm
 		using DerivedOrbitElementsForm formDerivedOrbitElements = new();
-		// Set the TopMost property to true to keep the form on top of other windows
+		// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 		formDerivedOrbitElements.TopMost = TopMost;
 		// Fill the form with the derived orbit elements
 		formDerivedOrbitElements.SetDatabase(list: [.. derivedOrbitElements.Cast<object>()]);

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -666,16 +666,22 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the semi-major axis from the UI label and opens the <see cref="OrbitalResonancesOfOneMinorPlanetForm"/>.</remarks>
 	private void ShowOrbitalResonances()
 	{
+		// Try to parse the semi-major axis from the label text using invariant culture to ensure consistent parsing regardless of the user's locale settings
 		IFormatProvider provider = CultureInfo.CreateSpecificCulture(name: "en");
+		// If parsing fails, log an error and show an error message to the user, then return early to avoid opening the form with invalid data
 		if (!double.TryParse(s: labelSemiMajorAxisData.Text, style: NumberStyles.Any, provider: provider, result: out double semiMajorAxis))
 		{
 			logger.Error(message: $"Failed to parse semi-major axis: '{labelSemiMajorAxisData.Text}'");
 			ShowErrorMessage(message: $"Could not parse semi-major axis value: '{labelSemiMajorAxisData.Text}'");
 			return;
 		}
+		// Create a new instance of the OrbitalResonancesOfOneMinorPlanetForm
 		using OrbitalResonancesOfOneMinorPlanetForm formOrbitalResonances = new();
+		// Set the TopMost property to true to keep the form on top of other windows
 		formOrbitalResonances.TopMost = TopMost;
+		// Pass the parsed semi-major axis to the form so it can calculate and display the relevant orbital resonances for the current planetoid
 		formOrbitalResonances.SetSemiMajorAxis(semiMajorAxis: semiMajorAxis);
+		// Show the orbital resonances form as a modal dialog
 		_ = formOrbitalResonances.ShowDialog();
 	}
 
@@ -683,14 +689,20 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Passes the index data label text to the <see cref="ObservationsForm"/> and shows it as a modal dialog.</remarks>
 	private void ShowObservations()
 	{
+		// Check if the network is available before attempting to show the observations form
 		if (!NetworkInterface.GetIsNetworkAvailable())
 		{
+			// If the network is not available, show an error message to the user and return early
 			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
 			return;
 		}
+		// Create a new instance of the ObservationsForm
 		using ObservationsForm formObservations = new();
+		// Set the TopMost property to true to keep the form on top of other windows
 		formObservations.TopMost = TopMost;
+		// Pass the index data label text to the observations form so it can use it to fetch and display the relevant observations for the current planetoid
 		formObservations.SetIndexData(indexData: labelIndexData.Text);
+		// Show the observations form as a modal dialog
 		_ = formObservations.ShowDialog();
 	}
 
@@ -698,8 +710,11 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the semi-major axis from the UI label and opens the <see cref="OrbitalResonancesOfOneMinorPlanetForm"/>.</remarks>
 	private void ShowOrbitElementsGrouping()
 	{
+		// Create a new instance of the OrbitElementsGroupingForm and pass the planeto
 		using OrbitElementsGroupingForm formOrbitElementsGrouping = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formOrbitElementsGrouping.TopMost = TopMost;
+		// Show the orbit elements grouping form as a modal dialog
 		_ = formOrbitElementsGrouping.ShowDialog();
 	}
 
@@ -707,8 +722,11 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Passes the full planetoids database to the form so it can display asteroid families.</remarks>
 	private void ShowAsteroidFamiliesDetection()
 	{
+		// Create a new instance of the AsteroidFamiliesForm and pass the planetoids database to it
 		using AsteroidFamiliesForm formAsteroidFamilies = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formAsteroidFamilies.TopMost = TopMost;
+		// Show the asteroid families form as a modal dialog
 		_ = formAsteroidFamilies.ShowDialog(owner: this);
 	}
 
@@ -718,7 +736,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the OrbitalResonancesOfAllMinorPlanetsForm
 		using OrbitalResonancesOfAllMinorPlanetsForm formOrbitalResonances = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formOrbitalResonances.TopMost = TopMost;
+		// Show the orbital resonances form as a modal dialog
 		_ = formOrbitalResonances.ShowDialog(owner: this);
 	}
 
@@ -729,6 +749,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <param name="longitudeAscendingNodeDeg">When this method returns, contains the parsed longitude of ascending node in degrees.</param>
 	/// <param name="argumentPerihelionDeg">When this method returns, contains the parsed argument of perihelion in degrees.</param>
 	/// <returns><see langword="true"/> if all orbital elements were parsed successfully; otherwise, <see langword="false"/>.</returns>
+	/// <remarks>This method uses the <see cref="labelSemiMajorAxisData"/>, <see cref="labelOrbitalEccentricityData"/>, <see cref="labelInclinationToTheEclipticData"/>, <see cref="labelLongitudeOfTheAscendingNodeData"/>, and <see cref="labelArgumentOfThePerihelionData"/> labels to parse the orbital elements.</remarks>
 	private bool TryParseCurrentOrbitalElements(
 		out double semiMajorAxis,
 		out double eccentricity,
@@ -736,12 +757,15 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		out double longitudeAscendingNodeDeg,
 		out double argumentPerihelionDeg)
 	{
+		// Initialize output parameters
 		semiMajorAxis = default;
 		eccentricity = default;
 		inclinationDeg = default;
 		longitudeAscendingNodeDeg = default;
 		argumentPerihelionDeg = default;
+		// Use a consistent culture for parsing to ensure that decimal separators are handled correctly
 		IFormatProvider provider = CultureInfo.CreateSpecificCulture(name: "en");
+		// Try to parse each orbital element from the corresponding label
 		if (!double.TryParse(s: labelSemiMajorAxisData.Text, style: NumberStyles.Any, provider: provider, result: out semiMajorAxis))
 		{
 			logger.Error(message: $"Failed to parse semi-major axis: '{labelSemiMajorAxisData.Text}'");
@@ -779,6 +803,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the orbital elements from the UI labels and opens the <see cref="MoidsOfOneMinorPlanetForm"/>.</remarks>
 	private void ShowMoids()
 	{
+		// Try to parse the current orbital elements from the UI labels
 		if (!TryParseCurrentOrbitalElements(
 			semiMajorAxis: out double semiMajorAxis,
 			eccentricity: out double eccentricity,
@@ -807,6 +832,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the orbital elements from the UI labels and opens the <see cref="MaxoidsOfOneMinorPlanetForm"/>.</remarks>
 	private void ShowMaxoids()
 	{
+		// Try to parse the current orbital elements from the UI labels
 		if (!TryParseCurrentOrbitalElements(
 			semiMajorAxis: out double semiMajorAxis,
 			eccentricity: out double eccentricity,
@@ -835,6 +861,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the orbital elements from the UI labels and opens the <see cref="MoidsAndMaxoidsOfOneMinorPlanetForm"/>.</remarks>
 	private void ShowMoidsAndMaxoids()
 	{
+		// Try to parse the current orbital elements from the UI labels
 		if (!TryParseCurrentOrbitalElements(
 			semiMajorAxis: out double semiMajorAxis,
 			eccentricity: out double eccentricity,
@@ -865,7 +892,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the MoidsOfAllMinorPlanetsForm
 		using MoidsOfAllMinorPlanetsForm formMoidsOfAll = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formMoidsOfAll.TopMost = TopMost;
+		// Show the MOIDs of all minor planets form as a modal dialog
 		_ = formMoidsOfAll.ShowDialog(owner: this);
 	}
 
@@ -875,7 +904,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the MaxoidsOfAllMinorPlanetsForm
 		using MaxoidsOfAllMinorPlanetsForm formMaxoidsOfAll = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formMaxoidsOfAll.TopMost = TopMost;
+		// Show the MAXOIDs of all minor planets form as a modal dialog
 		_ = formMaxoidsOfAll.ShowDialog(owner: this);
 	}
 
@@ -885,7 +916,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the HistogramsForm
 		using HistogramsForm formHistogram = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formHistogram.TopMost = TopMost;
+		// Show the histogram form as a modal dialog
 		_ = formHistogram.ShowDialog(owner: this);
 	}
 
@@ -895,7 +928,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		// Create a new instance of the ScatterplotsForm
 		using ScatterplotsForm formScatterplot = new(planetoids: planetoidsDatabase);
+		// Set the TopMost property to true to keep the form on top of other windows
 		formScatterplot.TopMost = TopMost;
+		// Show the scatterplots form as a modal dialog
 		_ = formScatterplot.ShowDialog(owner: this);
 	}
 
@@ -903,6 +938,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the semi-major axis, eccentricity, and argument of perihelion from the UI labels and opens the <see cref="Orbit2DTopViewForm"/>.</remarks>
 	private void ShowOrbit2DTopView()
 	{
+		// Use the TryParseCurrentOrbitalElements method to parse the necessary orbital elements from the UI labels.
 		if (!TryParseCurrentOrbitalElements(
 			semiMajorAxis: out double semiMajorAxis,
 			eccentricity: out double eccentricity,
@@ -928,6 +964,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>Parses the semi-major axis, eccentricity, and inclination from the UI labels and opens the <see cref="Orbit2DSideViewForm"/>.</remarks>
 	private void ShowOrbit2DSideView()
 	{
+		// Use the TryParseCurrentOrbitalElements method to parse the necessary orbital elements from the UI labels.
 		if (!TryParseCurrentOrbitalElements(
 			semiMajorAxis: out double semiMajorAxis,
 			eccentricity: out double eccentricity,
@@ -937,7 +974,9 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		{
 			return;
 		}
+		// Use the readable designation as the planetoid label in the diagram title.
 		string planetoidName = labelReadableDesignationData.Text;
+		// Create a new instance of the Orbit2DSideViewForm and show it as a modal dialog.
 		using Orbit2DSideViewForm formOrbit2DSideView = new(
 			planetoidName: planetoidName,
 			semiMajorAxis: semiMajorAxis,
@@ -945,6 +984,49 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			inclinationDeg: inclinationDeg);
 		formOrbit2DSideView.TopMost = TopMost;
 		_ = formOrbit2DSideView.ShowDialog();
+	}
+
+	/// <summary>Shows the 3D orbit visualization for the current planetoid.</summary>
+	/// <remarks>Parses all six Keplerian orbital elements plus the mean anomaly and the MPCORB epoch from the UI labels and opens the <see cref="Orbit3DForm"/>.</remarks>
+	private void ShowOrbit3D()
+	{
+		// Use the TryParseCurrentOrbitalElements method to parse the necessary orbital elements from the UI labels.
+		if (!TryParseCurrentOrbitalElements(
+			semiMajorAxis: out double semiMajorAxis,
+			eccentricity: out double eccentricity,
+			inclinationDeg: out double inclinationDeg,
+			longitudeAscendingNodeDeg: out double longitudeAscendingNodeDeg,
+			argumentPerihelionDeg: out double argumentPerihelionDeg))
+		{
+			return;
+		}
+		// Parse the mean anomaly at the epoch from the corresponding label on the form
+		IFormatProvider provider = CultureInfo.CreateSpecificCulture(name: "en");
+		// If parsing fails, log the error and show an error message to the user, then return early to avoid opening the form with invalid data
+		if (!double.TryParse(s: labelMeanAnomalyAtTheEpochData.Text, style: NumberStyles.Any, provider: provider, result: out double meanAnomalyDeg))
+		{
+			logger.Error(message: $"Failed to parse mean anomaly: '{labelMeanAnomalyAtTheEpochData.Text}'");
+			ShowErrorMessage(message: $"Could not parse mean anomaly value: '{labelMeanAnomalyAtTheEpochData.Text}'");
+			return;
+		}
+		// Use the readable designation as the planetoid label in the diagram title.
+		string planetoidName = labelReadableDesignationData.Text;
+		// Parse the epoch from the corresponding label on the form
+		string epochMpcorb = labelEpochData.Text;
+		// Create a new instance of the Orbit3DForm and show it as a modal dialog.
+		using Orbit3DForm formOrbit3D = new(
+			planetoidName: planetoidName,
+			semiMajorAxis: semiMajorAxis,
+			eccentricity: eccentricity,
+			inclinationDeg: inclinationDeg,
+			longitudeAscendingNodeDeg: longitudeAscendingNodeDeg,
+			argumentPerihelionDeg: argumentPerihelionDeg,
+			meanAnomalyDeg: meanAnomalyDeg,
+			epochMpcorb: epochMpcorb);
+		// Set the TopMost property to true to keep the form on top of other windows
+		formOrbit3D.TopMost = TopMost;
+		// Show the 3D orbit visualization form as a modal dialog
+		_ = formOrbit3D.ShowDialog();
 	}
 
 	/// <summary>Shows the Tisserand parameters form for the current planetoid.</summary>

--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -10,7 +10,7 @@
     <StartupObject>Planetoid_DB.Program</StartupObject>
     <ApplicationIcon>Resources\Planetoid-DB-3.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.9.5.68</Version>
+    <Version>0.9.6.69</Version>
     <Company>Mijo Software</Company>
     <Description>Viewer for the MPC Orbit (MPCORB) Database</Description>
     <Copyright>2010-2026 Michael Johne</Copyright>
@@ -854,6 +854,10 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HarfBuzzSharp" Version="8.3.1.3" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.3" />
     <PackageReference Include="Krypton.Docking" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Navigator" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Ribbon" Version="105.26.4.110" />
@@ -861,10 +865,33 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="Krypton.Toolkit.Suite.Extended.Ultimate" Version="95.25.5.145" />
     <PackageReference Include="Krypton.Workspace" Version="105.26.4.110" />
     <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="OpenTK" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Compute" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Core" Version="4.9.4" />
+    <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Input" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.9.4" />
+    <PackageReference Include="OpenTK.redist.glfw" Version="3.4.0.47" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.9.4" />
     <PackageReference Include="ScottPlot" Version="5.1.58" />
     <PackageReference Include="ScottPlot.WinForms" Version="5.1.58" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="3.119.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.2.26159.112" />
     <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.2.26159.112" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.2.26159.112" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Planetoid-DB.csproj.user
+++ b/Planetoid-DB.csproj.user
@@ -82,6 +82,9 @@
     <Compile Update="Forms\ObservatoryCodesForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="Forms\Orbit3DForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Forms\OrbitalResonancesOfOneMinorPlanetForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Updates Planetoid-DB to version `0.9.6.69`, adds new graphics/text-rendering dependencies, and extends the main UI to support additional dialogs (including a new 3D orbit visualization) with more robust parsing and error handling.

**Changes:**
- Bumped application/package version to `0.9.6.69`.
- Added NuGet dependencies for OpenTK (3D), SkiaSharp/HarfBuzz (rendering), and additional System.* packages.
- Extended `PlanetoidDBForm` to open more forms as `TopMost`-consistent modal dialogs and added `ShowOrbit3D()` with parsing/logging.