### PR TITLE
Added support for AstDyS-2 files

### DIFF
--- a/App.config
+++ b/App.config
@@ -25,13 +25,52 @@
             <setting name="systemFilenameMpcorb" serializeAs="String">
                 <value>mpcorb.dat</value>
             </setting>
+            <setting name="systemFilenameMpcorbDat" serializeAs="String">
+                <value>mpcorb.dat</value>
+            </setting>
             <setting name="systemFilenameMpcorbTemp" serializeAs="String">
+                <value>_</value>
+            </setting>
+            <setting name="systemFilenameMpcorbDatTemp" serializeAs="String">
                 <value>_</value>
             </setting>
             <setting name="systemFilenameAstorb" serializeAs="String">
                 <value>astorb.dat</value>
             </setting>
+            <setting name="systemFilenameAstorbDat" serializeAs="String">
+                <value>astorb.dat</value>
+            </setting>
             <setting name="systemFilenameAstorbTemp" serializeAs="String">
+                <value>_</value>
+            </setting>
+            <setting name="systemFilenameAstorbDatTemp" serializeAs="String">
+                <value>_</value>
+            </setting>
+            <setting name="systemAllnumCatUrl" serializeAs="String">
+                <value>https://newton.spacedys.com/~astdys2/catalogs/allnum.cat</value>
+            </setting>
+            <setting name="systemFilenameAllnumCat" serializeAs="String">
+                <value>allnum.cat</value>
+            </setting>
+            <setting name="systemFilenameAllnumCatTemp" serializeAs="String">
+                <value>_</value>
+            </setting>
+            <setting name="systemUfitobsCatUrl" serializeAs="String">
+                <value>https://newton.spacedys.com/~astdys2/catalogs/ufitobs.cat</value>
+            </setting>
+            <setting name="systemFilenameUfitobsCat" serializeAs="String">
+                <value>ufitobs.cat</value>
+            </setting>
+            <setting name="systemFilenameUfitobsCatTemp" serializeAs="String">
+                <value>_</value>
+            </setting>
+            <setting name="systemSingoppCatUrl" serializeAs="String">
+                <value>https://newton.spacedys.com/~astdys2/catalogs/singopp.cat</value>
+            </setting>
+            <setting name="systemFilenameSingoppCat" serializeAs="String">
+                <value>singopp.cat</value>
+            </setting>
+            <setting name="systemFilenameSingoppCatTemp" serializeAs="String">
                 <value>_</value>
             </setting>
             <setting name="systemHomepage" serializeAs="String">

--- a/Forms/ArchiveMpcorbForm.cs
+++ b/Forms/ArchiveMpcorbForm.cs
@@ -114,7 +114,7 @@ public partial class ArchiveMpcorbForm : BaseKryptonForm
 	private async void ArchiveMpcorbForm_Load(object sender, EventArgs e)
 	{
 		// Set default file path
-		string defaultPath = Settings.Default.systemFilenameMpcorb;
+		string defaultPath = Settings.Default.systemFilenameMpcorbDat;
 		// If the default path exists, set it in the source textbox
 		if (File.Exists(path: defaultPath))
 		{

--- a/Forms/BaseKryptonForm.cs
+++ b/Forms/BaseKryptonForm.cs
@@ -11,10 +11,8 @@ using System.Diagnostics;
 
 namespace Planetoid_DB.Forms;
 
-/// <summary>Base form providing common behaviours for application forms.
-/// Currently: enables <c>KeyPreview</c> and closes the form when the Escape key is pressed.</summary>
-/// <remarks>This class serves as a base form for the application, providing common functionality
-/// and behaviors that can be shared across derived forms.</remarks>
+/// <summary>Base form providing common behaviours for application forms. Currently: enables <c>KeyPreview</c> and closes the form when the Escape key is pressed.</summary>
+/// <remarks>This class serves as a base form for the application, providing common functionality and behaviors that can be shared across derived forms.</remarks>
 // You can customize the debugger display for this class by providing a method that returns a string representation of the instance, which will be shown in the debugger when you inspect an object of this class. In this case, the GetDebuggerDisplay method is used to return a string representation of the instance, and the DebuggerDisplay attribute is applied to the class to specify that this method should be used for the debugger display.
 [DebuggerDisplay(value: "{" + nameof(GetDebuggerDisplay) + "(),nq}")]
 public class BaseKryptonForm : KryptonForm
@@ -50,8 +48,7 @@ public class BaseKryptonForm : KryptonForm
 
 	/// <summary>Copies the specified text to the clipboard and shows a confirmation dialog.</summary>
 	/// <param name="text">The text to copy to the clipboard.</param>
-	/// <remarks>On success an informational dialog is shown. On failure the exception is logged
-	/// and an error dialog is displayed. This method is protected so derived forms can use it directly.</remarks>
+	/// <remarks>On success an informational dialog is shown. On failure the exception is logged and an error dialog is displayed. This method is protected so derived forms can use it directly.</remarks>
 	protected static void CopyToClipboard(string text)
 	{
 		// Try to copy the text to the clipboard
@@ -90,8 +87,7 @@ public class BaseKryptonForm : KryptonForm
 
 	/// <summary>Clears the status bar text and disables the information label.</summary>
 	/// <param name="label">The status label to clear.</param>
-	/// <remarks>Resets the UI state of the status area so that no message is shown.
-	/// Use when there is no status to display or when leaving a control.</remarks>
+	/// <remarks>Resets the UI state of the status area so that no message is shown. Use when there is no status to display or when leaving a control.</remarks>
 	protected static void ClearStatusBar(ToolStripStatusLabel label)
 	{
 		// Check if the label is null
@@ -155,8 +151,7 @@ public class BaseKryptonForm : KryptonForm
 	/// <summary>Handles double-click events on controls and copies their text to the clipboard.</summary>
 	/// <param name="sender">Event source — expected to be a <see cref="Control"/> or <see cref="ToolStripItem"/>.</param>
 	/// <param name="e">Event arguments.</param>
-	/// <remarks>This method extracts text from the sender control or uses the current control's text for ToolStripItems,
-	/// then copies it to the clipboard using the <see cref="CopyToClipboard"/> method.</remarks>
+	/// <remarks>This method extracts text from the sender control or uses the current control's text for ToolStripItems, then copies it to the clipboard using the <see cref="CopyToClipboard"/> method.</remarks>
 	protected void CopyToClipboard_DoubleClick(object sender, EventArgs e)
 	{
 		// Check if the sender is null
@@ -214,9 +209,8 @@ public class BaseKryptonForm : KryptonForm
 	}
 
 	/// <summary>Opens the specified website URL in the default web browser.</summary>
-	/// <remarks>If the operation fails or the input is invalid, an error message is displayed and the exception or error is logged.
-	/// The method uses the system's default browser to open the URL.</remarks>
 	/// <param name="fileName">The URL or file name to open in the default browser. If null, empty, or whitespace, an error is logged and shown.</param>
+	/// <remarks>If the operation fails or the input is invalid, an error message is displayed and the exception or error is logged. The method uses the system's default browser to open the URL.</remarks>
 	protected static void OpenWebsite(string fileName)
 	{
 		if (string.IsNullOrWhiteSpace(value: fileName))

--- a/Forms/DatabaseDifferencesForm.cs
+++ b/Forms/DatabaseDifferencesForm.cs
@@ -288,7 +288,7 @@ public partial class DatabaseDifferencesForm : BaseKryptonForm
 	private void DatabaseDifferencesForm_Load(object sender, EventArgs e)
 	{
 		// Default to the currently configured MPCORB file
-		pathFile1 = Settings.Default.systemFilenameMpcorb;
+		pathFile1 = Settings.Default.systemFilenameMpcorbDat;
 		// Check if the default file exists and update the label accordingly
 		if (!File.Exists(path: pathFile1))
 		{

--- a/Forms/DatabaseDownloaderForm.cs
+++ b/Forms/DatabaseDownloaderForm.cs
@@ -112,6 +112,28 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 	/// <remarks>This method is used to provide a visual representation of the object in the debugger.</remarks>
 	private string GetDebuggerDisplay() => ToString();
 
+	/// <summary>Extracts the filename from the given URL and returns the full destination path within the temporary file directory.</summary>
+	/// <param name="url">The absolute URL from which to extract the filename.</param>
+	/// <returns>The full destination path combining the temporary file directory and the filename from the URL, or <see langword="null"/> if the URL is invalid or contains no filename.</returns>
+	/// <remarks>Uses <see cref="Uri.LocalPath"/> to extract the filename. The result is combined with the directory of <see cref="_filenameTemp"/>.</remarks>
+	private string? GetFileFromUrl(string url)
+	{
+		// Validate the URL and extract the filename
+		if (!Uri.TryCreate(uriString: url, uriKind: UriKind.Absolute, result: out Uri? parsedUri))
+		{
+			return null;
+		}
+		// Extract the filename from the URL's local path
+		string fileName = Path.GetFileName(path: parsedUri.LocalPath);
+		// If the filename is null or whitespace, return null
+		if (string.IsNullOrWhiteSpace(value: fileName))
+		{
+			return null;
+		}
+		// Combine the filename with the directory of the temporary file and return the full path
+		return Path.Combine(path1: Path.GetDirectoryName(path: _filenameTemp) ?? string.Empty, path2: fileName);
+	}
+
 	/// <summary>Extracts a GZIP-compressed file to the specified output file.</summary>
 	/// <param name="gzipFilePath">Full path to the source .gz file.</param>
 	/// <param name="outputFilePath">Full path where the decompressed file will be written.</param>
@@ -146,14 +168,15 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			using HttpRequestMessage request = new(method: HttpMethod.Head, requestUri: url);
 			// Timeout 5 seconds
 			using CancellationTokenSource cts = new(delay: TimeSpan.FromSeconds(seconds: 5));
-
+			// Send the request and get the response
 			using HttpResponseMessage response = await client.SendAsync(
-				request,
+				request: request,
 				completionOption: HttpCompletionOption.ResponseHeadersRead,
 				cancellationToken: cts.Token);
-
+			// Return true if the response status code indicates success (2xx); otherwise, return false
 			return response.IsSuccessStatusCode;
 		}
+		// If any exception occurs (e.g., HttpRequestException, TaskCanceledException), return false
 		catch
 		{
 			return false;
@@ -269,10 +292,20 @@ public partial class DatabaseDownloaderForm : BaseKryptonForm
 			CancellationToken token = cancellationTokenSource.Token;
 			// Start downloading the file asynchronously
 			await DownloadFileAsync(fileUrl: url, destinationPath: _filenameTemp, token: token);
-			// Extract the downloaded GZIP file
-			labelStatusValue.Text = "Extracting...";
-			kryptonProgressBarDownload.Style = ProgressBarStyle.Marquee;
-			await ExtractGzipFileAsync(gzipFilePath: _filenameTemp, outputFilePath: extractFilePath, token: token);
+			// If the downloaded file is a GZIP archive, extract it
+			if (Path.GetExtension(path: url).Equals(value: ".gz", comparisonType: StringComparison.OrdinalIgnoreCase))
+			{
+				// Extract the downloaded GZIP file
+				labelStatusValue.Text = "Extracting...";
+				kryptonProgressBarDownload.Style = ProgressBarStyle.Marquee;
+				await ExtractGzipFileAsync(gzipFilePath: _filenameTemp, outputFilePath: extractFilePath, token: token);
+			}
+			else
+			{
+				string destFilePath = GetFileFromUrl(url) ?? _filenameTemp;
+				// If it's not a GZIP file, just move it to the destFilePath
+				File.Move(sourceFileName: _filenameTemp, destFileName: destFilePath, overwrite: true);
+			}
 			// Notify the user of successful completion
 			labelStatusValue.Text = "Download completed";
 			_ = KryptonMessageBox.Show(text: "Download completed successfully!", caption: "Finished", buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);

--- a/Forms/DatabaseInformationForm.cs
+++ b/Forms/DatabaseInformationForm.cs
@@ -108,7 +108,7 @@ public partial class DatabaseInformationForm : BaseKryptonForm
 	private void DatabaseInformationForm_Load(object sender, EventArgs e)
 	{
 		// Path to the database file
-		FileInfo fileInfo = new(fileName: Settings.Default.systemFilenameMpcorb);
+		FileInfo fileInfo = new(fileName: Settings.Default.systemFilenameMpcorbDat);
 		// Check if the file exists
 		if (!File.Exists(path: fileInfo.FullName))
 		{

--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -165,6 +165,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTableMode = new ToolStripMenuItem();
 		toolStripMenuItemScatterPlots = new ToolStripMenuItem();
 		toolStripMenuItemAverageAsteroid = new ToolStripMenuItem();
+		toolStripMenuItemAEIDiagram3D = new ToolStripMenuItem();
 		toolStripMenuItemGroupOrbitalAnalysis = new ToolStripMenuItem();
 		toolStripMenuItemFilter = new ToolStripMenuItem();
 		toolStripMenuItemFilterEdit = new ToolStripMenuItem();
@@ -2493,7 +2494,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemGroupDataAndStatistics.AccessibleName = "Data & Statistics";
 		toolStripMenuItemGroupDataAndStatistics.AccessibleRole = AccessibleRole.MenuPopup;
 		toolStripMenuItemGroupDataAndStatistics.AutoToolTip = true;
-		toolStripMenuItemGroupDataAndStatistics.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemDatabaseInformation, toolStripMenuItemTableMode, toolStripMenuItemRecords, toolStripMenuItemDistribution, toolStripMenuItemScatterPlots, toolStripMenuItemAverageAsteroid });
+		toolStripMenuItemGroupDataAndStatistics.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemDatabaseInformation, toolStripMenuItemTableMode, toolStripMenuItemRecords, toolStripMenuItemDistribution, toolStripMenuItemScatterPlots, toolStripMenuItemAverageAsteroid, toolStripMenuItemAEIDiagram3D });
 		toolStripMenuItemGroupDataAndStatistics.Name = "toolStripMenuItemGroupDataAndStatistics";
 		toolStripMenuItemGroupDataAndStatistics.Size = new Size(183, 22);
 		toolStripMenuItemGroupDataAndStatistics.Text = "Data && &Statistics";
@@ -2558,6 +2559,19 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAverageAsteroid.Click += AverageAsteroid_Click;
 		toolStripMenuItemAverageAsteroid.MouseEnter += Control_Enter;
 		toolStripMenuItemAverageAsteroid.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemAEIDiagram3D
+		// 
+		toolStripMenuItemAEIDiagram3D.AccessibleDescription = "Shows the 3D a/e/i diagram for all planetoids";
+		toolStripMenuItemAEIDiagram3D.AccessibleName = "a/e/i 3D diagram";
+		toolStripMenuItemAEIDiagram3D.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemAEIDiagram3D.AutoToolTip = true;
+		toolStripMenuItemAEIDiagram3D.Name = "toolStripMenuItemAEIDiagram3D";
+		toolStripMenuItemAEIDiagram3D.Size = new Size(227, 22);
+		toolStripMenuItemAEIDiagram3D.Text = "a/&e/i 3D diagram";
+		toolStripMenuItemAEIDiagram3D.Click += AEIDiagram3D_Click;
+		toolStripMenuItemAEIDiagram3D.MouseEnter += Control_Enter;
+		toolStripMenuItemAEIDiagram3D.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemGroupOrbitalAnalysis
 		// 
@@ -4902,6 +4916,7 @@ partial class PlanetoidDbForm
 	private ToolStripMenuItem toolStripMenuItemOrbit3DView;
 	private ToolStripMenuItem toolStripMenuItemScatterPlots;
 	private ToolStripMenuItem toolStripMenuItemAverageAsteroid;
+	private ToolStripMenuItem toolStripMenuItemAEIDiagram3D;
 	private ToolStripMenuItem toolStripMenuItemOrbit;
 	private ToolStripMenuItem toolStripMenuItemShowAllnumCatUpdateIsAvailable;
 	private ToolStripSeparator toolStripSeparator18;

--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -165,7 +165,6 @@ partial class PlanetoidDbForm
 		toolStripMenuItemTableMode = new ToolStripMenuItem();
 		toolStripMenuItemScatterPlots = new ToolStripMenuItem();
 		toolStripMenuItemAverageAsteroid = new ToolStripMenuItem();
-		toolStripMenuItemAEIDiagram3D = new ToolStripMenuItem();
 		toolStripMenuItemGroupOrbitalAnalysis = new ToolStripMenuItem();
 		toolStripMenuItemFilter = new ToolStripMenuItem();
 		toolStripMenuItemFilterEdit = new ToolStripMenuItem();
@@ -213,12 +212,25 @@ partial class PlanetoidDbForm
 		toolStripMenuItemUpdate = new ToolStripMenuItem();
 		toolStripMenuItemShowMpcorbDatUpdateIsAvailable = new ToolStripMenuItem();
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable = new ToolStripMenuItem();
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable = new ToolStripMenuItem();
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable = new ToolStripMenuItem();
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable = new ToolStripMenuItem();
 		toolStripSeparator19 = new ToolStripSeparator();
 		toolStripMenuItemCheckMpcorbDatUpdate = new ToolStripMenuItem();
 		toolStripMenuItemDownloadMpcorbDat = new ToolStripMenuItem();
 		toolStripSeparator2 = new ToolStripSeparator();
 		toolStripMenuItemCheckAstorbDatUpdate = new ToolStripMenuItem();
 		toolStripMenuItemDownloadAstorbDat = new ToolStripMenuItem();
+		toolStripSeparator18 = new ToolStripSeparator();
+		toolStripMenuItemAstdys2File = new ToolStripMenuItem();
+		toolStripMenuItemCheckAllnumCatUpdate = new ToolStripMenuItem();
+		toolStripMenuItemDownloadAllnumCat = new ToolStripMenuItem();
+		toolStripSeparator20 = new ToolStripSeparator();
+		toolStripMenuItemCheckUfitobsCatUpdate = new ToolStripMenuItem();
+		toolStripMenuItemDownloadUfitobsCat = new ToolStripMenuItem();
+		toolStripSeparator21 = new ToolStripSeparator();
+		toolStripMenuItemCheckSingoppCatUpdate = new ToolStripMenuItem();
+		toolStripMenuItemDownloadSingoppCat = new ToolStripMenuItem();
 		toolStripMenuItemOptions = new ToolStripMenuItem();
 		toolStripMenuItemSettings = new ToolStripMenuItem();
 		toolStripMenuItemStyle = new ToolStripMenuItem();
@@ -236,6 +248,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenWebsitePDB = new ToolStripMenuItem();
 		toolStripMenuItemOpenWebsiteMPC = new ToolStripMenuItem();
 		toolStripMenuItemOpenMPCORBWebsite = new ToolStripMenuItem();
+		toolStripDropDownButtonOrbit = new ToolStripDropDownButton();
 		toolStripSeparator10 = new ToolStripSeparator();
 		toolStripSeparator16 = new ToolStripSeparator();
 		toolStripSeparator12 = new ToolStripSeparator();
@@ -263,7 +276,6 @@ partial class PlanetoidDbForm
 		toolStripSeparator3 = new ToolStripSeparator();
 		toolStripButtonHistogram = new ToolStripButton();
 		toolStripButtonScatterPlot = new ToolStripButton();
-		toolStripDropDownButtonOrbit = new ToolStripDropDownButton();
 		toolStripSeparator5 = new ToolStripSeparator();
 		toolStripButtonCheckMpcorbDatUpdate = new ToolStripButton();
 		toolStripButtonDownloadMpcorbDat = new ToolStripButton();
@@ -2481,7 +2493,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemGroupDataAndStatistics.AccessibleName = "Data & Statistics";
 		toolStripMenuItemGroupDataAndStatistics.AccessibleRole = AccessibleRole.MenuPopup;
 		toolStripMenuItemGroupDataAndStatistics.AutoToolTip = true;
-		toolStripMenuItemGroupDataAndStatistics.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemDatabaseInformation, toolStripMenuItemTableMode, toolStripMenuItemRecords, toolStripMenuItemDistribution, toolStripMenuItemScatterPlots, toolStripMenuItemAverageAsteroid, toolStripMenuItemAEIDiagram3D });
+		toolStripMenuItemGroupDataAndStatistics.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemDatabaseInformation, toolStripMenuItemTableMode, toolStripMenuItemRecords, toolStripMenuItemDistribution, toolStripMenuItemScatterPlots, toolStripMenuItemAverageAsteroid });
 		toolStripMenuItemGroupDataAndStatistics.Name = "toolStripMenuItemGroupDataAndStatistics";
 		toolStripMenuItemGroupDataAndStatistics.Size = new Size(183, 22);
 		toolStripMenuItemGroupDataAndStatistics.Text = "Data && &Statistics";
@@ -2546,19 +2558,6 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAverageAsteroid.Click += AverageAsteroid_Click;
 		toolStripMenuItemAverageAsteroid.MouseEnter += Control_Enter;
 		toolStripMenuItemAverageAsteroid.MouseLeave += Control_Leave;
-		// 
-		// toolStripMenuItemAEIDiagram3D
-		// 
-		toolStripMenuItemAEIDiagram3D.AccessibleDescription = "Shows the 3D a/e/i diagram for all planetoids";
-		toolStripMenuItemAEIDiagram3D.AccessibleName = "a/e/i 3D diagram";
-		toolStripMenuItemAEIDiagram3D.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemAEIDiagram3D.AutoToolTip = true;
-		toolStripMenuItemAEIDiagram3D.Name = "toolStripMenuItemAEIDiagram3D";
-		toolStripMenuItemAEIDiagram3D.Size = new Size(227, 22);
-		toolStripMenuItemAEIDiagram3D.Text = "a/&e/i 3D diagram";
-		toolStripMenuItemAEIDiagram3D.Click += AEIDiagram3D_Click;
-		toolStripMenuItemAEIDiagram3D.MouseEnter += Control_Enter;
-		toolStripMenuItemAEIDiagram3D.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemGroupOrbitalAnalysis
 		// 
@@ -3162,7 +3161,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemUpdate.AccessibleName = "Update";
 		toolStripMenuItemUpdate.AccessibleRole = AccessibleRole.MenuPopup;
 		toolStripMenuItemUpdate.AutoToolTip = true;
-		toolStripMenuItemUpdate.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemShowMpcorbDatUpdateIsAvailable, toolStripMenuItemShowAstorbDatUpdateIsAvailable, toolStripSeparator19, toolStripMenuItemCheckMpcorbDatUpdate, toolStripMenuItemDownloadMpcorbDat, toolStripSeparator2, toolStripMenuItemCheckAstorbDatUpdate, toolStripMenuItemDownloadAstorbDat });
+		toolStripMenuItemUpdate.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemShowMpcorbDatUpdateIsAvailable, toolStripMenuItemShowAstorbDatUpdateIsAvailable, toolStripMenuItemShowAllnumCatUpdateIsAvailable, toolStripMenuItemShowUfitobsCatUpdateIsAvailable, toolStripMenuItemShowSingoppCatUpdateIsAvailable, toolStripSeparator19, toolStripMenuItemCheckMpcorbDatUpdate, toolStripMenuItemDownloadMpcorbDat, toolStripSeparator2, toolStripMenuItemCheckAstorbDatUpdate, toolStripMenuItemDownloadAstorbDat, toolStripSeparator18, toolStripMenuItemAstdys2File });
 		toolStripMenuItemUpdate.Name = "toolStripMenuItemUpdate";
 		toolStripMenuItemUpdate.Size = new Size(57, 24);
 		toolStripMenuItemUpdate.Text = "&Update";
@@ -3199,6 +3198,45 @@ partial class PlanetoidDbForm
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.MouseEnter += Control_Enter;
 		toolStripMenuItemShowAstorbDatUpdateIsAvailable.MouseLeave += Control_Leave;
 		// 
+		// toolStripMenuItemShowAllnumCatUpdateIsAvailable
+		// 
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.AccessibleDescription = "Shows whether an ALLNUM.CAT update is available";
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.AccessibleName = "ALLNUM.CAT update available";
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.AutoToolTip = true;
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Enabled = false;
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Image = FatcowIcons16px.fatcow_new_16px;
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Name = "toolStripMenuItemShowAllnumCatUpdateIsAvailable";
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Size = new Size(236, 22);
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Text = "ALLNUM.CAT update available";
+		toolStripMenuItemShowAllnumCatUpdateIsAvailable.Click += DownloadAllnumCat_Click;
+		// 
+		// toolStripMenuItemShowUfitobsCatUpdateIsAvailable
+		// 
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.AccessibleDescription = "Shows whether an UFITOBS.CAT update is available";
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.AccessibleName = "UFITOBS.CAT update available";
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.AutoToolTip = true;
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Enabled = false;
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Image = FatcowIcons16px.fatcow_new_16px;
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Name = "toolStripMenuItemShowUfitobsCatUpdateIsAvailable";
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Size = new Size(236, 22);
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Text = "UFITOBS.CAT update available";
+		toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Click += DownloadUfitobsCat_Click;
+		// 
+		// toolStripMenuItemShowSingoppCatUpdateIsAvailable
+		// 
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.AccessibleDescription = "Shows whether an SINGOPP.CAT update is available";
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.AccessibleName = "SINGOPP.CAT update available";
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.AutoToolTip = true;
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Enabled = false;
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Image = FatcowIcons16px.fatcow_new_16px;
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Name = "toolStripMenuItemShowSingoppCatUpdateIsAvailable";
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Size = new Size(236, 22);
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Text = "SINGOPP.CAT update available";
+		toolStripMenuItemShowSingoppCatUpdateIsAvailable.Click += DownloadSingoppCat_Click;
+		// 
 		// toolStripSeparator19
 		// 
 		toolStripSeparator19.AccessibleDescription = "Just a separator";
@@ -3206,6 +3244,7 @@ partial class PlanetoidDbForm
 		toolStripSeparator19.AccessibleRole = AccessibleRole.Separator;
 		toolStripSeparator19.Name = "toolStripSeparator19";
 		toolStripSeparator19.Size = new Size(233, 6);
+		toolStripSeparator19.Text = "Just a separator";
 		toolStripSeparator19.Click += AsteroidGame_Click;
 		toolStripSeparator19.MouseEnter += Control_Enter;
 		toolStripSeparator19.MouseLeave += Control_Leave;
@@ -3276,6 +3315,136 @@ partial class PlanetoidDbForm
 		toolStripMenuItemDownloadAstorbDat.Click += DownloadAstorbDat_Click;
 		toolStripMenuItemDownloadAstorbDat.MouseEnter += Control_Enter;
 		toolStripMenuItemDownloadAstorbDat.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator18
+		// 
+		toolStripSeparator18.AccessibleDescription = "Just a separator";
+		toolStripSeparator18.AccessibleName = "Just a separator";
+		toolStripSeparator18.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator18.Name = "toolStripSeparator18";
+		toolStripSeparator18.Size = new Size(233, 6);
+		toolStripSeparator18.Text = "Just a separator";
+		toolStripSeparator18.MouseEnter += Control_Enter;
+		toolStripSeparator18.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemAstdys2File
+		// 
+		toolStripMenuItemAstdys2File.AccessibleDescription = "Shows the AstDyS-2 files";
+		toolStripMenuItemAstdys2File.AccessibleName = "AstDyS-2 files";
+		toolStripMenuItemAstdys2File.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemAstdys2File.AutoToolTip = true;
+		toolStripMenuItemAstdys2File.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemCheckAllnumCatUpdate, toolStripMenuItemDownloadAllnumCat, toolStripSeparator20, toolStripMenuItemCheckUfitobsCatUpdate, toolStripMenuItemDownloadUfitobsCat, toolStripSeparator21, toolStripMenuItemCheckSingoppCatUpdate, toolStripMenuItemDownloadSingoppCat });
+		toolStripMenuItemAstdys2File.Name = "toolStripMenuItemAstdys2File";
+		toolStripMenuItemAstdys2File.Size = new Size(236, 22);
+		toolStripMenuItemAstdys2File.Text = "AstDyS-2 files";
+		toolStripMenuItemAstdys2File.MouseEnter += Control_Enter;
+		toolStripMenuItemAstdys2File.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemCheckAllnumCatUpdate
+		// 
+		toolStripMenuItemCheckAllnumCatUpdate.AccessibleDescription = "Checks for updates of the database ALLNUM.CAT";
+		toolStripMenuItemCheckAllnumCatUpdate.AccessibleName = "Check ALLNUM.CAT";
+		toolStripMenuItemCheckAllnumCatUpdate.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemCheckAllnumCatUpdate.AutoToolTip = true;
+		toolStripMenuItemCheckAllnumCatUpdate.Image = FatcowIcons16px.fatcow_database_lightning_16px;
+		toolStripMenuItemCheckAllnumCatUpdate.Name = "toolStripMenuItemCheckAllnumCatUpdate";
+		toolStripMenuItemCheckAllnumCatUpdate.Size = new Size(204, 22);
+		toolStripMenuItemCheckAllnumCatUpdate.Text = "Check ALLNUM.CAT";
+		toolStripMenuItemCheckAllnumCatUpdate.Click += CheckAllnumCatUpdate_Click;
+		toolStripMenuItemCheckAllnumCatUpdate.MouseEnter += Control_Enter;
+		toolStripMenuItemCheckAllnumCatUpdate.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDownloadAllnumCat
+		// 
+		toolStripMenuItemDownloadAllnumCat.AccessibleDescription = "Downloads the database ALLNUM.CAT";
+		toolStripMenuItemDownloadAllnumCat.AccessibleName = "Download ALLNUM.CAT";
+		toolStripMenuItemDownloadAllnumCat.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDownloadAllnumCat.AutoToolTip = true;
+		toolStripMenuItemDownloadAllnumCat.Image = FatcowIcons16px.fatcow_package_go_16px;
+		toolStripMenuItemDownloadAllnumCat.Name = "toolStripMenuItemDownloadAllnumCat";
+		toolStripMenuItemDownloadAllnumCat.Size = new Size(204, 22);
+		toolStripMenuItemDownloadAllnumCat.Text = "Download ALLNUM.CAT";
+		toolStripMenuItemDownloadAllnumCat.Click += DownloadAllnumCat_Click;
+		toolStripMenuItemDownloadAllnumCat.MouseEnter += Control_Enter;
+		toolStripMenuItemDownloadAllnumCat.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator20
+		// 
+		toolStripSeparator20.AccessibleDescription = "Just a separator";
+		toolStripSeparator20.AccessibleName = "Just a separator";
+		toolStripSeparator20.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator20.Name = "toolStripSeparator20";
+		toolStripSeparator20.Size = new Size(201, 6);
+		toolStripSeparator20.Text = "Just a separator";
+		toolStripSeparator20.MouseEnter += Control_Enter;
+		toolStripSeparator20.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemCheckUfitobsCatUpdate
+		// 
+		toolStripMenuItemCheckUfitobsCatUpdate.AccessibleDescription = "Checks for updates of the database UFITOBS.CAT";
+		toolStripMenuItemCheckUfitobsCatUpdate.AccessibleName = "Check UFITOBS.CAT";
+		toolStripMenuItemCheckUfitobsCatUpdate.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemCheckUfitobsCatUpdate.AutoToolTip = true;
+		toolStripMenuItemCheckUfitobsCatUpdate.Image = FatcowIcons16px.fatcow_database_lightning_16px;
+		toolStripMenuItemCheckUfitobsCatUpdate.Name = "toolStripMenuItemCheckUfitobsCatUpdate";
+		toolStripMenuItemCheckUfitobsCatUpdate.Size = new Size(204, 22);
+		toolStripMenuItemCheckUfitobsCatUpdate.Text = "Check UFITOBS.CAT";
+		toolStripMenuItemCheckUfitobsCatUpdate.Click += CheckUfitobsCatUpdate_Click;
+		toolStripMenuItemCheckUfitobsCatUpdate.MouseEnter += Control_Enter;
+		toolStripMenuItemCheckUfitobsCatUpdate.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDownloadUfitobsCat
+		// 
+		toolStripMenuItemDownloadUfitobsCat.AccessibleDescription = "Downloads the database UFITOBS.CAT";
+		toolStripMenuItemDownloadUfitobsCat.AccessibleName = "Download UFITOBS.CAT";
+		toolStripMenuItemDownloadUfitobsCat.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDownloadUfitobsCat.AutoToolTip = true;
+		toolStripMenuItemDownloadUfitobsCat.Image = FatcowIcons16px.fatcow_package_go_16px;
+		toolStripMenuItemDownloadUfitobsCat.Name = "toolStripMenuItemDownloadUfitobsCat";
+		toolStripMenuItemDownloadUfitobsCat.Size = new Size(204, 22);
+		toolStripMenuItemDownloadUfitobsCat.Text = "Download UFITOBS.CAT";
+		toolStripMenuItemDownloadUfitobsCat.Click += DownloadUfitobsCat_Click;
+		toolStripMenuItemDownloadUfitobsCat.MouseEnter += Control_Enter;
+		toolStripMenuItemDownloadUfitobsCat.MouseLeave += Control_Leave;
+		// 
+		// toolStripSeparator21
+		// 
+		toolStripSeparator21.AccessibleDescription = "Just a separator";
+		toolStripSeparator21.AccessibleName = "Just a separator";
+		toolStripSeparator21.AccessibleRole = AccessibleRole.Separator;
+		toolStripSeparator21.Name = "toolStripSeparator21";
+		toolStripSeparator21.Size = new Size(201, 6);
+		toolStripSeparator21.Text = "Just a separator";
+		toolStripSeparator21.MouseEnter += Control_Enter;
+		toolStripSeparator21.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemCheckSingoppCatUpdate
+		// 
+		toolStripMenuItemCheckSingoppCatUpdate.AccessibleDescription = "Checks for updates of the database SINGOPP.CAT";
+		toolStripMenuItemCheckSingoppCatUpdate.AccessibleName = "Check SINGOPP.CAT";
+		toolStripMenuItemCheckSingoppCatUpdate.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemCheckSingoppCatUpdate.AutoToolTip = true;
+		toolStripMenuItemCheckSingoppCatUpdate.Image = FatcowIcons16px.fatcow_database_lightning_16px;
+		toolStripMenuItemCheckSingoppCatUpdate.Name = "toolStripMenuItemCheckSingoppCatUpdate";
+		toolStripMenuItemCheckSingoppCatUpdate.Size = new Size(204, 22);
+		toolStripMenuItemCheckSingoppCatUpdate.Text = "Check SINGOPP.CAT";
+		toolStripMenuItemCheckSingoppCatUpdate.Click += CheckSingoppCatUpdate_Click;
+		toolStripMenuItemCheckSingoppCatUpdate.MouseEnter += Control_Enter;
+		toolStripMenuItemCheckSingoppCatUpdate.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemDownloadSingoppCat
+		// 
+		toolStripMenuItemDownloadSingoppCat.AccessibleDescription = "Downloads the database SINGOPP.CAT";
+		toolStripMenuItemDownloadSingoppCat.AccessibleName = "Download SINGOPP.CAT";
+		toolStripMenuItemDownloadSingoppCat.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemDownloadSingoppCat.AutoToolTip = true;
+		toolStripMenuItemDownloadSingoppCat.Image = FatcowIcons16px.fatcow_package_go_16px;
+		toolStripMenuItemDownloadSingoppCat.Name = "toolStripMenuItemDownloadSingoppCat";
+		toolStripMenuItemDownloadSingoppCat.Size = new Size(204, 22);
+		toolStripMenuItemDownloadSingoppCat.Text = "Download SINGOPP.CAT";
+		toolStripMenuItemDownloadSingoppCat.Click += DownloadSingoppCat_Click;
+		toolStripMenuItemDownloadSingoppCat.MouseEnter += Control_Enter;
+		toolStripMenuItemDownloadSingoppCat.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemOptions
 		// 
@@ -3525,6 +3694,22 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOpenMPCORBWebsite.Click += OpenMpcorbDatWebsite_Click;
 		toolStripMenuItemOpenMPCORBWebsite.MouseEnter += Control_Enter;
 		toolStripMenuItemOpenMPCORBWebsite.MouseLeave += Control_Leave;
+		// 
+		// toolStripDropDownButtonOrbit
+		// 
+		toolStripDropDownButtonOrbit.AccessibleDescription = "Shows orbit visualization";
+		toolStripDropDownButtonOrbit.AccessibleName = "Scatter plots";
+		toolStripDropDownButtonOrbit.AccessibleRole = AccessibleRole.PushButton;
+		toolStripDropDownButtonOrbit.DisplayStyle = ToolStripItemDisplayStyle.Image;
+		toolStripDropDownButtonOrbit.DropDown = contextMenuOrbit;
+		toolStripDropDownButtonOrbit.Enabled = false;
+		toolStripDropDownButtonOrbit.Image = FatcowIcons16px.fatcow_orbit_16px;
+		toolStripDropDownButtonOrbit.ImageTransparentColor = Color.Magenta;
+		toolStripDropDownButtonOrbit.Name = "toolStripDropDownButtonOrbit";
+		toolStripDropDownButtonOrbit.Size = new Size(29, 22);
+		toolStripDropDownButtonOrbit.Text = "Orbit visualization";
+		toolStripDropDownButtonOrbit.MouseEnter += Control_Enter;
+		toolStripDropDownButtonOrbit.MouseLeave += Control_Leave;
 		// 
 		// toolStripSeparator10
 		// 
@@ -4018,22 +4203,6 @@ partial class PlanetoidDbForm
 		toolStripButtonScatterPlot.Click += ScatterPlots_Click;
 		toolStripButtonScatterPlot.MouseEnter += Control_Enter;
 		toolStripButtonScatterPlot.MouseLeave += Control_Leave;
-		// 
-		// toolStripDropDownButtonOrbit
-		// 
-		toolStripDropDownButtonOrbit.AccessibleDescription = "Shows orbit visualization";
-		toolStripDropDownButtonOrbit.AccessibleName = "Scatter plots";
-		toolStripDropDownButtonOrbit.AccessibleRole = AccessibleRole.PushButton;
-		toolStripDropDownButtonOrbit.DisplayStyle = ToolStripItemDisplayStyle.Image;
-		toolStripDropDownButtonOrbit.DropDown = contextMenuOrbit;
-		toolStripDropDownButtonOrbit.Enabled = false;
-		toolStripDropDownButtonOrbit.Image = FatcowIcons16px.fatcow_orbit_16px;
-		toolStripDropDownButtonOrbit.ImageTransparentColor = Color.Magenta;
-		toolStripDropDownButtonOrbit.Name = "toolStripDropDownButtonOrbit";
-		toolStripDropDownButtonOrbit.Size = new Size(29, 22);
-		toolStripDropDownButtonOrbit.Text = "Orbit visualization";
-		toolStripDropDownButtonOrbit.MouseEnter += Control_Enter;
-		toolStripDropDownButtonOrbit.MouseLeave += Control_Leave;
 		// 
 		// toolStripSeparator5
 		// 
@@ -4733,6 +4902,18 @@ partial class PlanetoidDbForm
 	private ToolStripMenuItem toolStripMenuItemOrbit3DView;
 	private ToolStripMenuItem toolStripMenuItemScatterPlots;
 	private ToolStripMenuItem toolStripMenuItemAverageAsteroid;
-	private ToolStripMenuItem toolStripMenuItemAEIDiagram3D;
 	private ToolStripMenuItem toolStripMenuItemOrbit;
+	private ToolStripMenuItem toolStripMenuItemShowAllnumCatUpdateIsAvailable;
+	private ToolStripSeparator toolStripSeparator18;
+	private ToolStripMenuItem toolStripMenuItemAstdys2File;
+	private ToolStripMenuItem toolStripMenuItemCheckAllnumCatUpdate;
+	private ToolStripMenuItem toolStripMenuItemDownloadAllnumCat;
+	private ToolStripSeparator toolStripSeparator20;
+	private ToolStripMenuItem toolStripMenuItemCheckUfitobsCatUpdate;
+	private ToolStripMenuItem toolStripMenuItemDownloadUfitobsCat;
+	private ToolStripSeparator toolStripSeparator21;
+	private ToolStripMenuItem toolStripMenuItemCheckSingoppCatUpdate;
+	private ToolStripMenuItem toolStripMenuItemDownloadSingoppCat;
+	private ToolStripMenuItem toolStripMenuItemShowUfitobsCatUpdateIsAvailable;
+	private ToolStripMenuItem toolStripMenuItemShowSingoppCatUpdateIsAvailable;
 }

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -60,21 +60,48 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 	/// <summary>Filenames for the MPCORB database.</summary>
 	/// <remarks>These strings are used to store the filenames for the MPCORB database.</remarks>
-	private readonly string filenameMpcorb = Settings.Default.systemFilenameMpcorb;
-	private readonly string filenameMpcorbTemp = Settings.Default.systemFilenameMpcorbTemp;
+	private readonly string filenameMpcorbDat = Settings.Default.systemFilenameMpcorbDat;
+	private readonly string filenameMpcorbTemp = Settings.Default.systemFilenameMpcorbDatTemp;
 
 	/// <summary>Filenames for the ASTORB database.</summary>
 	/// <remarks>These strings are used to store the filenames for the ASTORB database.</remarks>
-	private readonly string filenameAstorb = Settings.Default.systemFilenameAstorb;
-	private readonly string filenameAstorbTemp = Settings.Default.systemFilenameAstorbTemp;
+	private readonly string filenameAstorbDat = Settings.Default.systemFilenameAstorbDat;
+	private readonly string filenameAstorbTemp = Settings.Default.systemFilenameAstorbDatTemp;
+
+	/// <summary>Filenames for the ALLNUMCAT database.</summary>
+	/// <remarks>These strings are used to store the filenames for the ALLNUMCAT database.</remarks>
+	private readonly string filenameAllnumCat = Settings.Default.systemFilenameAllnumCat;
+	private readonly string filenameAllnumCatTemp = Settings.Default.systemFilenameAllnumCatTemp;
+
+	/// <summary>Filenames for the UFITOBS database.</summary>
+	/// <remarks>These strings are used to store the filenames for the UFITOBS database.</remarks>
+	private readonly string filenameUfitobsCat = Settings.Default.systemFilenameUfitobsCat;
+	private readonly string filenameUfitobsCatTemp = Settings.Default.systemFilenameUfitobsCatTemp;
+
+	/// <summary>Filenames for the SINGOPP database.</summary>
+	/// <remarks>These strings are used to store the filenames for the SINGOPP database.</remarks>
+	private readonly string filenameSingoppCat = Settings.Default.systemFilenameSingoppCat;
+	private readonly string filenameSingoppCatTemp = Settings.Default.systemFilenameSingoppCatTemp;
 
 	/// <summary>URI for the MPCORB database.</summary>
 	/// <remarks>This URI is used to access the MPCORB database.</remarks>
-	private readonly Uri uriMpcorb = new(uriString: Settings.Default.systemMpcorbDatGzUrl);
+	private readonly Uri uriMpcorbDat = new(uriString: Settings.Default.systemMpcorbDatGzUrl);
 
 	/// <summary>URI for the ASTORB database.</summary>
 	/// <remarks>This URI is used to access the ASTORB database.</remarks>
-	private readonly Uri uriAstorb = new(uriString: Settings.Default.systemAstorbDatGzUrl);
+	private readonly Uri uriAstorbDat = new(uriString: Settings.Default.systemAstorbDatGzUrl);
+
+	/// <summary>URI for the ALLNUMCAT database.</summary>
+	/// <remarks>This URI is used to access the ALLNUMCAT database.</remarks>
+	private readonly Uri uriAllnumCat = new(uriString: Settings.Default.systemAllnumCatUrl);
+
+	/// <summary>URI for the UFITOBS database.</summary>
+	/// <remarks>This URI is used to access the UFITOBS database.</remarks>
+	private readonly Uri uriUfitobsCat = new(uriString: Settings.Default.systemUfitobsCatUrl);
+
+	/// <summary>URI for the SINGOPP database.</summary>
+	/// <remarks>This URI is used to access the SINGOPP database.</remarks>
+	private readonly Uri uriSingoppCat = new(uriString: Settings.Default.systemSingoppCatUrl);
 
 	/*
 	private readonly IProgress<int>? downloadProgress;
@@ -426,20 +453,20 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	private bool IsMpcorbDatUpdateAvailable()
 	{
 		// Check if the file exists before attempting to delete it
-		if (!File.Exists(path: filenameMpcorb))
+		if (!File.Exists(path: filenameMpcorbDat))
 		{
 			return true; // If the file does not exist, return true (update available)
 		}
 		// Get the file information for the local file
-		FileInfo fileInfo = new(fileName: filenameMpcorb);
+		FileInfo fileInfo = new(fileName: filenameMpcorbDat);
 		// Get the last modified date of the local file
 		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
 		try
 		{
 			// Get the last modified date of the online file
-			DateTime datetimeFileOnline = GetLastModified(uri: uriMpcorb);
+			DateTime datetimeFileOnline = GetLastModified(uri: uriMpcorbDat);
 			// Get the content length of the online file
-			_ = GetContentLength(uri: uriMpcorb);
+			_ = GetContentLength(uri: uriMpcorbDat);
 			// Get the content length of the local file
 			_ = fileInfo.Length;
 			// Check if the online file is larger than the local file
@@ -463,18 +490,123 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	private bool IsAstorbDatUpdateAvailable()
 	{
 		// Check if the file exists before attempting to delete it
-		if (!File.Exists(path: filenameAstorb))
+		if (!File.Exists(path: filenameAstorbDat))
 		{
 			return true; // If the file does not exist, return true (update available)
 		}
 		// Get the file information for the local file
-		FileInfo fileInfo = new(fileName: filenameAstorb);
+		FileInfo fileInfo = new(fileName: filenameAstorbDat);
 		// Get the last modified date of the local file
 		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
 		try
 		{
 			// Get the last modified date of the online file
-			DateTime datetimeFileOnline = GetLastModified(uri: uriAstorb);
+			DateTime datetimeFileOnline = GetLastModified(uri: uriAstorbDat);
+			// Get the content length of the local file
+			_ = fileInfo.Length;
+			// Check if the online file is larger than the local file
+			// If it greater, return true (update available)
+			// Otherwise, return false (no update available)
+			return datetimeFileOnline > datetimeFileLocal;
+		}
+		catch (WebException)
+		{
+			return false;
+		}
+		catch (IOException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>Checks if an update for the ALLNUMCAT database is available.</summary>
+	/// <returns>true if an update is available, otherwise false.</returns>
+	/// <remarks>This method is used to check if an update for the ALLNUMCAT database is available.</remarks>
+	private bool IsAllnumCatUpdateAvailable()
+	{
+		// Check if the file exists before attempting to delete it
+		if (!File.Exists(path: filenameAllnumCat))
+		{
+			return true; // If the file does not exist, return true (update available)
+		}
+		// Get the file information for the local file
+		FileInfo fileInfo = new(fileName: filenameAllnumCat);
+		// Get the last modified date of the local file
+		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
+		try
+		{
+			// Get the last modified date of the online file
+			DateTime datetimeFileOnline = GetLastModified(uri: uriAllnumCat);
+			// Get the content length of the local file
+			_ = fileInfo.Length;
+			// Check if the online file is larger than the local file
+			// If it greater, return true (update available)
+			// Otherwise, return false (no update available)
+			return datetimeFileOnline > datetimeFileLocal;
+		}
+		catch (WebException)
+		{
+			return false;
+		}
+		catch (IOException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>Checks if an update for the UFITOBSCAT database is available.</summary>
+	/// <returns>true if an update is available, otherwise false.</returns>
+	/// <remarks>This method is used to check if an update for the UFITOBSCAT database is available.</remarks>
+	private bool IsUfitobsCatUpdateAvailable()
+	{
+		// Check if the file exists before attempting to delete it
+		if (!File.Exists(path: filenameUfitobsCat))
+		{
+			return true; // If the file does not exist, return true (update available)
+		}
+		// Get the file information for the local file
+		FileInfo fileInfo = new(fileName: filenameUfitobsCat);
+		// Get the last modified date of the local file
+		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
+		try
+		{
+			// Get the last modified date of the online file
+			DateTime datetimeFileOnline = GetLastModified(uri: uriUfitobsCat);
+			// Get the content length of the local file
+			_ = fileInfo.Length;
+			// Check if the online file is larger than the local file
+			// If it greater, return true (update available)
+			// Otherwise, return false (no update available)
+			return datetimeFileOnline > datetimeFileLocal;
+		}
+		catch (WebException)
+		{
+			return false;
+		}
+		catch (IOException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>Checks if an update for the SINGOPP database is available.</summary>
+	/// <returns>true if an update is available, otherwise false.</returns>
+	/// <remarks>This method is used to check if an update for the SINGOPP database is available.</remarks>
+	private bool IsSingoppCatUpdateAvailable()
+	{
+		// Check if the file exists before attempting to delete it
+		if (!File.Exists(path: filenameSingoppCat))
+		{
+			return true; // If the file does not exist, return true (update available)
+		}
+		// Get the file information for the local file
+		FileInfo fileInfo = new(fileName: filenameSingoppCat);
+		// Get the last modified date of the local file
+		DateTime datetimeFileLocal = fileInfo.LastWriteTime;
+		try
+		{
+			// Get the last modified date of the online file
+			DateTime datetimeFileOnline = GetLastModified(uri: uriSingoppCat);
 			// Get the content length of the local file
 			_ = fileInfo.Length;
 			// Check if the online file is larger than the local file
@@ -1214,7 +1346,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		else
 		{
 			// Create and show the MPCORB data check form
-			using CheckDatabaseForm formCheckMpcorbDat = new(url: Settings.Default.systemMpcorbDatUrl, localFilePath: Settings.Default.systemFilenameMpcorb, databaseName: "MPCORB.DAT");
+			using CheckDatabaseForm formCheckMpcorbDat = new(url: Settings.Default.systemMpcorbDatUrl, localFilePath: Settings.Default.systemFilenameMpcorbDat, databaseName: "MPCORB.DAT");
 			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			formCheckMpcorbDat.TopMost = TopMost;
 			// Show the MPCORB data check form as a modal dialog
@@ -1235,11 +1367,74 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		else
 		{
 			// Create and show the ASTORB data check form
-			using CheckDatabaseForm formCheckAstorbDat = new(url: Settings.Default.systemAstorbDatUrl, localFilePath: Settings.Default.systemFilenameAstorb, databaseName: "ASTORB.DAT");
+			using CheckDatabaseForm formCheckAstorbDat = new(url: Settings.Default.systemAstorbDatUrl, localFilePath: Settings.Default.systemFilenameAstorbDat, databaseName: "ASTORB.DAT");
 			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
 			formCheckAstorbDat.TopMost = TopMost;
 			// Show the ASTORB data check form as a modal dialog
 			_ = formCheckAstorbDat.ShowDialog();
+		}
+	}
+
+	/// <summary>Shows the ALLNUM.CAT data check form.</summary>
+	/// <remarks>This method is used to check the ALLNUM.CAT data for updates.</remarks>
+	private void ShowAllnumCatUpdateCheck()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the ALLNUM.CAT data check form
+			using CheckDatabaseForm formCheckAllnumCat = new(url: Settings.Default.systemAllnumCatUrl, localFilePath: Settings.Default.systemFilenameAllnumCat, databaseName: "allnum.cat");
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			formCheckAllnumCat.TopMost = TopMost;
+			// Show the ALLNUM.CAT data check form as a modal dialog
+			_ = formCheckAllnumCat.ShowDialog();
+		}
+	}
+
+	/// <summary>Shows the UFITOBS.CAT data check form.</summary>
+	/// <remarks>This method is used to check the UFITOBS.CAT data for updates.</remarks>
+	private void ShowUfitobsCatUpdateCheck()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the UFITOBS.CAT data check form
+			using CheckDatabaseForm formCheckUfitobsCat = new(url: Settings.Default.systemUfitobsCatUrl, localFilePath: Settings.Default.systemFilenameUfitobsCat, databaseName: "ufitobs.cat");
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			formCheckUfitobsCat.TopMost = TopMost;
+			// Show the UFITOBS.CAT data check form as a modal dialog
+			_ = formCheckUfitobsCat.ShowDialog();
+		}
+	}
+
+	/// <summary>Shows the SINGOPP.CAT data check form.</summary>
+	/// <remarks>This method is used to check the SINGOPP.CAT data for updates.</remarks>
+	private void ShowSingoppCatUpdateCheck()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the SINGOPP.CAT data check form
+			using CheckDatabaseForm formCheckSingoppCat = new(url: Settings.Default.systemSingoppCatUrl, localFilePath: Settings.Default.systemFilenameSingoppCat, databaseName: "singopp.cat");
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			formCheckSingoppCat.TopMost = TopMost;
+			// Show the SINGOPP.CAT data check form as a modal dialog
+			_ = formCheckSingoppCat.ShowDialog();
 		}
 	}
 
@@ -1303,6 +1498,96 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		}
 	}
 
+	/// <summary>Shows the downloader form for the ALLNUM.CAT database.</summary>
+	/// <remarks>This method is used to show the downloader form for the ALLNUM.CAT database.</remarks>
+	private void ShowAllnumCatDownloader()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Disable the menu item for showing updates is available
+			toolStripMenuItemShowAllnumCatUpdateIsAvailable.Enabled = false;
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the downloader form for the ALLNUM.CAT database
+			using DatabaseDownloaderForm downloaderForm = new(url: Settings.Default.systemAllnumCatUrl);
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			downloaderForm.TopMost = TopMost;
+			// Show the downloader form as a modal dialog
+			if (downloaderForm.ShowDialog() == DialogResult.OK)
+			{
+				// Disable the menu item and the status label for showing updates is available
+				toolStripMenuItemShowAllnumCatUpdateIsAvailable.Enabled = false;
+				//toolStripStatusLabelAllnumCatUpdate.Enabled = false;
+				// Ask the user if they want to restart the application after downloading the database
+				AskForRestartAfterDownloadingDatabase();
+			}
+		}
+	}
+
+	/// <summary>Shows the downloader form for the UFITOBS.CAT database.</summary>
+	/// <remarks>This method is used to show the downloader form for the UFITOBS.CAT database.</remarks>
+	private void ShowUfitobsCatDownloader()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Disable the menu item for showing updates is available
+			toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Enabled = false;
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the downloader form for the UFITOBS.CAT database
+			using DatabaseDownloaderForm downloaderForm = new(url: Settings.Default.systemUfitobsCatUrl);
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			downloaderForm.TopMost = TopMost;
+			// Show the downloader form as a modal dialog
+			if (downloaderForm.ShowDialog() == DialogResult.OK)
+			{
+				// Disable the menu item and the status label for showing updates is available
+				toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Enabled = false;
+				//toolStripStatusLabelUfitobsCatUpdate.Enabled = false;
+				// Ask the user if they want to restart the application after downloading the database
+				AskForRestartAfterDownloadingDatabase();
+			}
+		}
+	}
+
+	/// <summary>Shows the downloader form for the SINGOPP.CAT database.</summary>
+	/// <remarks>This method is used to show the downloader form for the SINGOPP.CAT database.</remarks>
+	private void ShowSingoppCatDownloader()
+	{
+		// Check if the network is available before proceeding with the download
+		if (!NetworkInterface.GetIsNetworkAvailable())
+		{
+			// Disable the menu item for showing updates is available
+			toolStripMenuItemShowSingoppCatUpdateIsAvailable.Enabled = false;
+			// Display an error message if the network is not available
+			ShowErrorMessage(message: I18nStrings.NoInternetConnectionText);
+		}
+		else
+		{
+			// Create and show the downloader form for the SINGOPP.CAT database
+			using DatabaseDownloaderForm downloaderForm = new(url: Settings.Default.systemSingoppCatUrl);
+			// Set the TopMost property to match the current form's TopMost value to maintain consistent window layering
+			downloaderForm.TopMost = TopMost;
+			// Show the downloader form as a modal dialog
+			if (downloaderForm.ShowDialog() == DialogResult.OK)
+			{
+				// Disable the menu item and the status label for showing updates is available
+				toolStripMenuItemShowSingoppCatUpdateIsAvailable.Enabled = false;
+				//toolStripStatusLabelSingoppCatUpdate.Enabled = false;
+				// Ask the user if they want to restart the application after downloading the database
+				AskForRestartAfterDownloadingDatabase();
+			}
+		}
+	}
+
 	/// <summary>Shows the database information form.</summary>
 	/// <remarks>This method is used to show the database information form.</remarks>
 	private void ShowDatabaseInformation()
@@ -1326,22 +1611,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 		_ = formSearch.ShowDialog();
 
-		/*
-		// Fill the form with the planetoids database
-		formSearch.FillArray(arrTemp: planetoidsDatabase);
-		// Set the maximum index for the search form
-		formSearch.SetMaxIndex(maxIndex: planetoidsDatabase.Count);
-		// Show the search form as a modal dialog
-		_ = formSearch.ShowDialog();
-		// Check if the dialog result is OK and the selected index is greater than 0
-		_ = KryptonMessageBox.Show(text: formSearch.GetSelectedIndex().ToString());
-		// If so, navigate to the current position in the database
-		if (formSearch.DialogResult == DialogResult.OK && formSearch.GetSelectedIndex() > 0)
-		{
-			// Navigate to the current position in the database
-			GotoCurrentPosition(position: formSearch.GetSelectedIndex());
-		}
-		*/
 	}
 
 	/// <summary>Shows the filter form.</summary>
@@ -2019,7 +2288,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		// Show the splash screen while loading the database
 		formSplashScreen.Show();
 		// Attempt to get the last modified date of the MPCORB.DAT file and display it in the tab text
-		string resolvedMpcOrbDatFilePath = string.IsNullOrWhiteSpace(value: MpcOrbDatFilePath) ? filenameMpcorb : MpcOrbDatFilePath;
+		string resolvedMpcOrbDatFilePath = string.IsNullOrWhiteSpace(value: MpcOrbDatFilePath) ? filenameMpcorbDat : MpcOrbDatFilePath;
 		if (!string.IsNullOrWhiteSpace(value: resolvedMpcOrbDatFilePath))
 		{
 			// Use a try-catch block to handle potential exceptions when accessing the file information
@@ -2084,6 +2353,42 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 			toolStripStatusLabelAstorbDatUpdate.Enabled = false;
 			toolStripStatusLabelAstorbDatUpdate.Visible = false;
 		}
+		// Check if an update is available for the ALLNUM.CAT database and enable the timer for blinking the update label
+		if (IsAllnumCatUpdateAvailable())
+		{
+			toolStripMenuItemShowAllnumCatUpdateIsAvailable.Enabled = true;
+			//toolStripStatusLabelAllnumCatUpdate.Enabled = true;
+		}
+		// Otherwise, disable and hide the update label
+		else
+		{
+			//toolStripStatusLabelAllnumCatUpdate.Enabled = false;
+			//toolStripStatusLabelAllnumCatUpdate.Visible = false;
+		}
+		// Check if an update is available for the UFITOBS.CAT database and enable the timer for blinking the update label
+		if (IsUfitobsCatUpdateAvailable())
+		{
+			toolStripMenuItemShowUfitobsCatUpdateIsAvailable.Enabled = true;
+			//toolStripStatusLabelUfitobsCatUpdate.Enabled = true;
+		}
+		// Otherwise, disable and hide the update label
+		else
+		{
+			//toolStripStatusLabelUfitobsCatUpdate.Enabled = false;
+			//toolStripStatusLabelUfitobsCatUpdate.Visible = false;
+		}
+		// Check if an update is available for the SINGOPP.CAT database and enable the timer for blinking the update label
+		if (IsSingoppCatUpdateAvailable())
+		{
+			toolStripMenuItemShowSingoppCatUpdateIsAvailable.Enabled = true;
+			//toolStripStatusLabelSingoppCatUpdate.Enabled = true;
+		}
+		// Otherwise, disable and hide the update label
+		else
+		{
+			//toolStripStatusLabelSingoppCatUpdate.Enabled = false;
+			//toolStripStatusLabelSingoppCatUpdate.Visible = false;
+		}
 		// Check if the form should stay on top of other windows
 		CheckStayOnTop();
 	}
@@ -2114,7 +2419,7 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	{
 		Enabled = false; // Disable the form while loading the database
 		int lineNum = 0; // Variable to store the line number being read
-		string filename = !string.IsNullOrEmpty(value: MpcOrbDatFilePath) ? MpcOrbDatFilePath : filenameMpcorb; // Get the file name from the path
+		string filename = !string.IsNullOrEmpty(value: MpcOrbDatFilePath) ? MpcOrbDatFilePath : filenameMpcorbDat; // Get the file name from the path
 		FileInfo fileInfo = new(fileName: filename);
 		long fileSize = fileInfo.Length, fileSizeRead = 0; // Get the size of the file in bytes
 														   // Open the file stream for reading
@@ -2405,11 +2710,23 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	/// <remarks>This method is used to show the downloader form for the ASTORB database.</remarks>
 	private void DownloadAstorbDat_Click(object sender, EventArgs e) => ShowAstorbDatDownloader();
 
-	/// <summary>Handles the click event for the ToolStripMenuItemCheckAstorbDat. Shows the ASTORB data check form.</summary>
+	/// <summary>Handles the click event for the ToolStripMenuItemDownloadAllnumCat. Shows the downloader form for the ALLNUMCAT database.</summary>
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
-	/// <remarks>This method is used to show the ASTORB data check form.</remarks>
-	private void CheckAstorbDatUpdate_Click(object sender, EventArgs e) => ShowAstorbDatUpdateCheck();
+	/// <remarks>This method is used to show the downloader form for the ALLNUMCAT database.</remarks>
+	private void DownloadAllnumCat_Click(object sender, EventArgs e) => ShowAllnumCatDownloader();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemDownloadUfitobsCat. Shows the downloader form for the UFITOBS database.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the downloader form for the UFITOBS database.</remarks>
+	private void DownloadUfitobsCat_Click(object sender, EventArgs e) => ShowUfitobsCatDownloader();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemDownloadSingoppCat. Shows the downloader form for the SINGOPP database.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the downloader form for the SINGOPP database.</remarks>
+	private void DownloadSingoppCat_Click(object sender, EventArgs e) => ShowSingoppCatDownloader();
 
 	/// <summary>Handles the click event for the ToolStripButtonCheckMpcorbDatUpdate. Shows the MPCORB data check form.</summary>
 	/// <param name="sender">The event source.</param>
@@ -2417,6 +2734,30 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 	///	<remarks>
 	///	This method is used to show the MPCORB data check form.</remarks>
 	private void CheckMpcorbDatUpdate_Click(object sender, EventArgs e) => ShowMpcorbDatUpdateCheck();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemCheckAstorbDat. Shows the ASTORB data check form.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the ASTORB data check form.</remarks>
+	private void CheckAstorbDatUpdate_Click(object sender, EventArgs e) => ShowAstorbDatUpdateCheck();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemCheckAllnumCat. Shows the ALLNUMCAT data check form.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the ALLNUMCAT data check form.</remarks>
+	private void CheckAllnumCatUpdate_Click(object sender, EventArgs e) => ShowAllnumCatUpdateCheck();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemCheckUfitobsCat. Shows the UFITOBS data check form.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the UFITOBS data check form.</remarks>
+	private void CheckUfitobsCatUpdate_Click(object sender, EventArgs e) => ShowUfitobsCatUpdateCheck();
+
+	/// <summary>Handles the click event for the ToolStripMenuItemCheckSingoppCat. Shows the SINGOPP data check form.</summary>
+	/// <param name="sender">The event source.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
+	/// <remarks>This method is used to show the SINGOPP data check form.</remarks>
+	private void CheckSingoppCatUpdate_Click(object sender, EventArgs e) => ShowSingoppCatUpdateCheck();
 
 	/// <summary>Handles the click event for the ToolStripButtonAbout. Shows the application information form.</summary>
 	/// <param name="sender">The event source.</param>

--- a/Forms/PreloadForm.cs
+++ b/Forms/PreloadForm.cs
@@ -123,7 +123,7 @@ public partial class PreloadForm : BaseKryptonForm
 			if (formDownloaderForMpcorbDat.ShowDialog() == DialogResult.OK)
 			{
 				// Set the file path to the downloaded MPCORB.DAT file
-				_ = MpcOrbDatFilePath = Settings.Default.systemFilenameMpcorb;
+				_ = MpcOrbDatFilePath = Settings.Default.systemFilenameMpcorbDat;
 				// Set the dialog result to OK
 				DialogResult = DialogResult.OK;
 			}

--- a/Forms/SearchForm.cs
+++ b/Forms/SearchForm.cs
@@ -270,7 +270,7 @@ public partial class SearchForm : BaseKryptonForm
 			return;
 		}
 		// Get the file path of the planetoid database from the application settings. If the file does not exist at the specified path, show an error message to the user and return without performing any search.
-		string filePath = Settings.Default.systemFilenameMpcorb;
+		string filePath = Settings.Default.systemFilenameMpcorbDat;
 		if (!File.Exists(path: filePath))
 		{
 			// Show an error message indicating that the database file could not be found at the specified path. This is a critical error that prevents the search operation from proceeding, as the search relies on reading data from the database file.

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -118,10 +118,28 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("mpcorb.dat")]
+        public string systemFilenameMpcorbDat {
+            get {
+                return ((string)(this["systemFilenameMpcorbDat"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("_")]
         public string systemFilenameMpcorbTemp {
             get {
                 return ((string)(this["systemFilenameMpcorbTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("_")]
+        public string systemFilenameMpcorbDatTemp {
+            get {
+                return ((string)(this["systemFilenameMpcorbDatTemp"]));
             }
         }
         
@@ -136,10 +154,109 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("astorb.dat")]
+        public string systemFilenameAstorbDat {
+            get {
+                return ((string)(this["systemFilenameAstorbDat"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("_")]
         public string systemFilenameAstorbTemp {
             get {
                 return ((string)(this["systemFilenameAstorbTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("_")]
+        public string systemFilenameAstorbDatTemp {
+            get {
+                return ((string)(this["systemFilenameAstorbDatTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://newton.spacedys.com/~astdys2/catalogs/allnum.cat")]
+        public string systemAllnumCatUrl {
+            get {
+                return ((string)(this["systemAllnumCatUrl"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("allnum.cat")]
+        public string systemFilenameAllnumCat {
+            get {
+                return ((string)(this["systemFilenameAllnumCat"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("_")]
+        public string systemFilenameAllnumCatTemp {
+            get {
+                return ((string)(this["systemFilenameAllnumCatTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://newton.spacedys.com/~astdys2/catalogs/ufitobs.cat")]
+        public string systemUfitobsCatUrl {
+            get {
+                return ((string)(this["systemUfitobsCatUrl"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("ufitobs.cat")]
+        public string systemFilenameUfitobsCat {
+            get {
+                return ((string)(this["systemFilenameUfitobsCat"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("_")]
+        public string systemFilenameUfitobsCatTemp {
+            get {
+                return ((string)(this["systemFilenameUfitobsCatTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://newton.spacedys.com/~astdys2/catalogs/singopp.cat")]
+        public string systemSingoppCatUrl {
+            get {
+                return ((string)(this["systemSingoppCatUrl"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("singopp.cat")]
+        public string systemFilenameSingoppCat {
+            get {
+                return ((string)(this["systemFilenameSingoppCat"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("_")]
+        public string systemFilenameSingoppCatTemp {
+            get {
+                return ((string)(this["systemFilenameSingoppCatTemp"]));
             }
         }
         

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -29,13 +29,52 @@
     <Setting Name="systemFilenameMpcorb" Type="System.String" Scope="Application">
       <Value Profile="(Default)">mpcorb.dat</Value>
     </Setting>
+    <Setting Name="systemFilenameMpcorbDat" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">mpcorb.dat</Value>
+    </Setting>
     <Setting Name="systemFilenameMpcorbTemp" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemFilenameMpcorbDatTemp" Type="System.String" Scope="Application">
       <Value Profile="(Default)">_</Value>
     </Setting>
     <Setting Name="systemFilenameAstorb" Type="System.String" Scope="Application">
       <Value Profile="(Default)">astorb.dat</Value>
     </Setting>
+    <Setting Name="systemFilenameAstorbDat" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">astorb.dat</Value>
+    </Setting>
     <Setting Name="systemFilenameAstorbTemp" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemFilenameAstorbDatTemp" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemAllnumCatUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://newton.spacedys.com/~astdys2/catalogs/allnum.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameAllnumCat" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">allnum.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameAllnumCatTemp" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemUfitobsCatUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://newton.spacedys.com/~astdys2/catalogs/ufitobs.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameUfitobsCat" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">ufitobs.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameUfitobsCatTemp" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemSingoppCatUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://newton.spacedys.com/~astdys2/catalogs/singopp.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameSingoppCat" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">singopp.cat</Value>
+    </Setting>
+    <Setting Name="systemFilenameSingoppCatTemp" Type="System.String" Scope="Application">
       <Value Profile="(Default)">_</Value>
     </Setting>
     <Setting Name="systemHomepage" Type="System.String" Scope="Application">


### PR DESCRIPTION
This PR aims to extend Planetoid-DB’s update/download workflow beyond MPCORB/ASTORB by adding UI and logic hooks for AstDyS-2 catalog files (ALLNUM.CAT, UFITOBS.CAT, SINGOPP.CAT), while also updating several call sites to use renamed “*...Dat” settings keys.

**Changes:**
- Added Update-menu entries and corresponding handlers to check/download AstDyS-2 catalog files.
- Updated multiple forms to reference renamed settings keys (e.g., `systemFilenameMpcorbDat`).
- Enhanced `DatabaseDownloaderForm` to handle non-`.gz` downloads by moving the downloaded file instead of attempting extraction.