### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/99a0b8a7-bab6-4c76-98fb-a40d52b349df" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/4802b5c8-7f85-4680-9db1-8b961cd12b3d" />


### PR DESCRIPTION
Updates the README’s embedded screenshot to point to a new GitHub user-attachments image, keeping the documentation in sync with the current UI presentation.

**Changes:**
- Replaced the `<img>` `src` URL in `README.md` with a new user-attachments asset link.