### PR TITLE
Updated `CHANGELOG` for version 0.9.11.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Planetoid-DB 0.9.11.74
+
+* Updated image source in `README.md` by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/788
+* Updated `CHANGELOG` for version 0.9.10.73 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/789
+* Refactor: consolidate SaveAs click handlers into BaseKryptonForm by @mjohne with @Copilot in https://github.com/mjohne/Planetoid-DB/pull/791
+* Updated to version 0.9.11.74 by @mjohne in https://github.com/mjohne/Planetoid-DB/pull/792
+
+**Full Changelog**: https://github.com/mjohne/Planetoid-DB/compare/0.9.10.73.786.2437...0.9.11.74.792.2446
+
+
 ## Planetoid-DB 0.9.10.73
 
 * Reduce noise from resolved build warnings in exporters and form metadata by @mjohne with @Copilot in https://github.com/mjohne/Planetoid-DB/pull/784


### PR DESCRIPTION
Updates the project’s release notes by adding a new top-of-file changelog entry for version **0.9.11.74**, consistent with the existing release-section format used in `CHANGELOG.md`.

**Changes:**
- Added a new `## Planetoid-DB 0.9.11.74` section at the top of the changelog.
- Included the list of merged PRs for the release and a GitHub compare link for the full changelog.