### PR TITLE
Updated `HarfBuzzSharp` packages to version 14.2.0-rc.1.2

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -854,10 +854,10 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="8.3.1.5" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.5" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.5" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.5" />
+    <PackageReference Include="HarfBuzzSharp" Version="14.2.0-rc.1.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0-rc.1.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.0-rc.1.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.0-rc.1.2" />
     <PackageReference Include="Krypton.Docking" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Navigator" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Ribbon" Version="105.26.4.110" />


### PR DESCRIPTION
This PR updates the NuGet package references for `HarfBuzzSharp` and its platform native-asset packages in `Planetoid-DB.csproj`.

**Changes:**
- Bumped `HarfBuzzSharp` from `8.3.1.5` to `14.2.0-rc.1.2`.
- Bumped `HarfBuzzSharp.NativeAssets.*` package references to `14.2.0-rc.1.2`.