### PR TITLE
Updated `System` packages to version 11.0.0-preview.5.26302.115

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -886,12 +886,12 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.150.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="4.150.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="4.150.0-preview.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.5.26302.115" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates several `System.*` NuGet dependencies in the main project file to a newer .NET 11 preview build, keeping the project’s framework-provided components in sync with the intended preview toolchain.

**Changes:**
- Bumped `System.Configuration.ConfigurationManager` to `11.0.0-preview.5.26302.115`.
- Bumped `System.Data.OleDb` to `11.0.0-preview.5.26302.115`.
- Bumped `System.Diagnostics.EventLog`, `System.Diagnostics.PerformanceCounter`, and `System.Security.Cryptography.ProtectedData` to `11.0.0-preview.5.26302.115`.