### PR TITLE
Updated `OpenTK` packages to version 5.0.0-pre.16

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -865,18 +865,18 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="Krypton.Toolkit.Suite.Extended.Ultimate" Version="95.25.5.145" />
     <PackageReference Include="Krypton.Workspace" Version="105.26.4.110" />
     <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Compute" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Core" Version="4.9.4" />
+    <PackageReference Include="OpenTK" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Audio" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Compute" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Core" Version="5.0.0-pre.16" />
     <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
-    <PackageReference Include="OpenTK.Graphics" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Input" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Graphics" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Input" Version="5.0.0-pre.15" />
+    <PackageReference Include="OpenTK.Mathematics" Version="5.0.0-pre.16" />
     <PackageReference Include="OpenTK.redist.glfw" Version="3.4.0.47" />
-    <PackageReference Include="OpenTK.Windowing.Common" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.4" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="5.0.0-pre.16" />
     <PackageReference Include="ScottPlot" Version="5.1.59" />
     <PackageReference Include="ScottPlot.WinForms" Version="5.1.59" />
     <PackageReference Include="SkiaSharp" Version="4.150.0-preview.1.1" />
@@ -886,12 +886,12 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.150.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="4.150.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="4.150.0-preview.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.5.26302.115" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.2.26159.112" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.2.26159.112" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates NuGet package references in `Planetoid-DB.csproj`, primarily moving most OpenTK dependencies from 4.9.4 to 5.0.0 pre-release versions (and also bumping several `System.*` preview packages). This affects the project’s 3D/OpenGL-related WinForms features which currently rely on `OpenTK.GLControl`.

**Changes:**
- Updated OpenTK package references to `5.0.0-pre.16` (with `OpenTK.Input` set to `5.0.0-pre.15`).
- Replaced `OpenTK.Audio.OpenAL` with `OpenTK.Audio`.
- Bumped several `System.*` package references from `11.0.0-preview.2.*` to `11.0.0-preview.5.*`.