### PR TITLE
Updated `HarfBuzzSharp` packages to version 14.2.0

### DIFF
--- a/Forms/AppInfoForm.Designer.cs
+++ b/Forms/AppInfoForm.Designer.cs
@@ -1687,7 +1687,7 @@ partial class AppInfoForm
 		kryptonLabelVersionHarfBuzzSharp.ToolTipValues.EnableToolTips = true;
 		kryptonLabelVersionHarfBuzzSharp.ToolTipValues.Heading = "HarfBuzzSharp version";
 		kryptonLabelVersionHarfBuzzSharp.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		kryptonLabelVersionHarfBuzzSharp.Values.Text = "Version: 14.2.0-rc.1.2";
+		kryptonLabelVersionHarfBuzzSharp.Values.Text = "Version: 14.2.0";
 		kryptonLabelVersionHarfBuzzSharp.DoubleClick += CopyToClipboard_DoubleClick;
 		kryptonLabelVersionHarfBuzzSharp.Enter += Control_Enter;
 		kryptonLabelVersionHarfBuzzSharp.Leave += Control_Leave;

--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -854,10 +854,10 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="14.2.0-rc.1.2" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0-rc.1.2" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.0-rc.1.2" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.0-rc.1.2" />
+    <PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.0" />
     <PackageReference Include="Krypton.Docking" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Navigator" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Ribbon" Version="105.26.4.110" />
@@ -867,6 +867,8 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="NLog" Version="6.1.3" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="OpenTK.Audio" Version="5.0.0-pre.16" />
+    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
+    <PackageReference Include="OpenTK.Compute" Version="4.9.4" />
     <PackageReference Include="OpenTK.Core" Version="5.0.0-pre.16" />
     <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
     <PackageReference Include="OpenTK.Graphics" Version="4.9.4" />


### PR DESCRIPTION
Updates dependency metadata for HarfBuzzSharp (moving from an RC to the stable 14.2.0 release) and refreshes the in-app “About/App Info” version display accordingly. The PR also introduces two additional OpenTK package references, expanding the dependency surface beyond what the PR title indicates.

**Changes:**
- Bump HarfBuzzSharp + native asset packages from `14.2.0-rc.1.2` to `14.2.0`.
- Update AppInfoForm’s HarfBuzzSharp version label text to match `14.2.0`.
- Add `OpenTK.Audio.OpenAL` and `OpenTK.Compute` package references.