### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/4758d404-b482-4614-b0cc-8563b073a96c" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/318b64fe-5ef8-48c1-b173-afd4fce5936d" />


### PR DESCRIPTION
Updates the README’s embedded UI screenshot link to point to a new GitHub user-attachments asset, keeping the project’s documentation visuals current.

**Changes:**
- Replaced the `src` URL of the screenshot `<img>` in `README.md` with a new user-attachments asset link.