### PR TITLE
Updated website url and email adress

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -10,12 +10,12 @@
     <StartupObject>Planetoid_DB.Program</StartupObject>
     <ApplicationIcon>Resources\Planetoid-DB-3.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.9.12.75</Version>
+    <Version>0.9.13.76</Version>
     <Company>Mijo Software</Company>
     <Description>Viewer for the MPC Orbit (MPCORB) Database</Description>
     <Copyright>2010-2026 Michael Johne</Copyright>
     <PackageIcon>PlanetoidDB3.png</PackageIcon>
-    <PackageProjectUrl>https://planetoid-db.de</PackageProjectUrl>
+    <PackageProjectUrl>https://mjohne.github.io/Planetoid-DB/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Mijo-Software/Planetoid-DB</RepositoryUrl>
     <PackageTags>csharp;astronomy;mpc;minor-planets;planetoid;minor-planet-center</PackageTags>

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -39,13 +39,13 @@
       <Value Profile="(Default)">_</Value>
     </Setting>
     <Setting Name="systemHomepage" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">https://planetoid-db.de</Value>
+      <Value Profile="(Default)">https://mjohne.github.io/Planetoid-DB/</Value>
     </Setting>
     <Setting Name="systemHomepageMailExtern" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">info@planetoid-db.de</Value>
+      <Value Profile="(Default)">mailto:mj-programming@gmx.de</Value>
     </Setting>
     <Setting Name="systemHomepageMailIntern" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">mailto:info@planetoid-db.de</Value>
+      <Value Profile="(Default)">mailto:mj-programming@gmx.de</Value>
     </Setting>
     <Setting Name="systemWebsiteMpc" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/mpc.html</Value>


### PR DESCRIPTION
This PR updates application/package metadata to point to the new project website and support email, along with a version bump.

**Changes:**
- Updated application settings defaults for homepage URL and support email.
- Bumped the project version and updated NuGet `PackageProjectUrl` to the new website.