### PR TITLE
Updated `HarfBuzzSharp`packages to version 14.2.1-rc.1.1

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -854,10 +854,10 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.0" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.0" />
+    <PackageReference Include="HarfBuzzSharp" Version="14.2.1-rc.1.1" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1-rc.1.1" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.1-rc.1.1" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.1-rc.1.1" />
     <PackageReference Include="Krypton.Docking" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Navigator" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Ribbon" Version="105.26.4.110" />


### PR DESCRIPTION
Updates the project’s HarfBuzzSharp dependencies to a newer pre-release version to pick up upstream changes/fixes.

**Changes:**
- Bumped `HarfBuzzSharp` and platform-specific `HarfBuzzSharp.NativeAssets.*` package references from `14.2.0` to `14.2.1-rc.1.1`.