### PR TITLE
Updated to version 0.9.14.77

### DIFF
--- a/App.config
+++ b/App.config
@@ -34,15 +34,6 @@
             <setting name="systemFilenameAstorbDatTemp" serializeAs="String">
                 <value>_</value>
             </setting>
-            <setting name="systemHomepage" serializeAs="String">
-                <value>https://planetoid-db.de</value>
-            </setting>
-            <setting name="systemHomepageMailExtern" serializeAs="String">
-                <value>info@planetoid-db.de</value>
-            </setting>
-            <setting name="systemHomepageMailIntern" serializeAs="String">
-                <value>mailto:info@planetoid-db.de</value>
-            </setting>
             <setting name="systemWebsiteMpc" serializeAs="String">
                 <value>http://www.minorplanetcenter.org/iau/mpc.html</value>
             </setting>
@@ -72,6 +63,15 @@
             </setting>
             <setting name="systemFilenameSingoppCatTemp" serializeAs="String">
                 <value>_</value>
+            </setting>
+            <setting name="systemHomepage" serializeAs="String">
+                <value>https://mjohne.github.io/Planetoid-DB/</value>
+            </setting>
+            <setting name="systemHomepageMailExtern" serializeAs="String">
+                <value>mj-programming@gmx.de</value>
+            </setting>
+            <setting name="systemHomepageMailIntern" serializeAs="String">
+                <value>mailto:mj-programming@gmx.de</value>
             </setting>
         </Planetoid_DB.Properties.Settings>
     </applicationSettings>

--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -10,7 +10,7 @@
     <StartupObject>Planetoid_DB.Program</StartupObject>
     <ApplicationIcon>Resources\Planetoid-DB-3.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.9.13.76</Version>
+    <Version>0.9.14.77</Version>
     <Company>Mijo Software</Company>
     <Description>Viewer for the MPC Orbit (MPCORB) Database</Description>
     <Copyright>2010-2026 Michael Johne</Copyright>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Planetoid_DB.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -140,33 +140,6 @@ namespace Planetoid_DB.Properties {
         public string systemFilenameAstorbDatTemp {
             get {
                 return ((string)(this["systemFilenameAstorbDatTemp"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://planetoid-db.de")]
-        public string systemHomepage {
-            get {
-                return ((string)(this["systemHomepage"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("info@planetoid-db.de")]
-        public string systemHomepageMailExtern {
-            get {
-                return ((string)(this["systemHomepageMailExtern"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("mailto:info@planetoid-db.de")]
-        public string systemHomepageMailIntern {
-            get {
-                return ((string)(this["systemHomepageMailIntern"]));
             }
         }
         
@@ -317,6 +290,33 @@ namespace Planetoid_DB.Properties {
         public string systemFilenameSingoppCatTemp {
             get {
                 return ((string)(this["systemFilenameSingoppCatTemp"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://mjohne.github.io/Planetoid-DB/")]
+        public string systemHomepage {
+            get {
+                return ((string)(this["systemHomepage"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("mj-programming@gmx.de")]
+        public string systemHomepageMailExtern {
+            get {
+                return ((string)(this["systemHomepageMailExtern"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("mailto:mj-programming@gmx.de")]
+        public string systemHomepageMailIntern {
+            get {
+                return ((string)(this["systemHomepageMailIntern"]));
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -38,15 +38,6 @@
     <Setting Name="systemFilenameAstorbDatTemp" Type="System.String" Scope="Application">
       <Value Profile="(Default)">_</Value>
     </Setting>
-    <Setting Name="systemHomepage" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">https://mjohne.github.io/Planetoid-DB/</Value>
-    </Setting>
-    <Setting Name="systemHomepageMailExtern" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">mailto:mj-programming@gmx.de</Value>
-    </Setting>
-    <Setting Name="systemHomepageMailIntern" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">mailto:mj-programming@gmx.de</Value>
-    </Setting>
     <Setting Name="systemWebsiteMpc" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/mpc.html</Value>
     </Setting>
@@ -91,6 +82,15 @@
     </Setting>
     <Setting Name="systemFilenameSingoppCatTemp" Type="System.String" Scope="Application">
       <Value Profile="(Default)">_</Value>
+    </Setting>
+    <Setting Name="systemHomepage" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://mjohne.github.io/Planetoid-DB/</Value>
+    </Setting>
+    <Setting Name="systemHomepageMailExtern" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">mj-programming@gmx.de</Value>
+    </Setting>
+    <Setting Name="systemHomepageMailIntern" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">mailto:mj-programming@gmx.de</Value>
     </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Updates Planetoid-DB’s application metadata and default configuration values as part of the 0.9.14.77 version bump.

**Changes:**
- Bumped `<Version>` in `Planetoid-DB.csproj` to `0.9.14.77`.
- Updated default homepage/contact settings in app configuration (`App.config` and `Properties/Settings.settings`).
- Regenerated `Properties/Settings.Designer.cs` to reflect settings changes (including updated generator version string).