### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/318b64fe-5ef8-48c1-b173-afd4fce5936d" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/fe654c1b-fdaa-44f8-a87a-6d9ebd921d98" />


### PR DESCRIPTION
Updates the README documentation to point to a new hosted screenshot asset, keeping the project’s visual example current.

**Changes:**
- Replaced the `<img>` tag `src` URL in `README.md` to reference an updated GitHub user-attachments asset.