### PR TITLE
Changed default branch from 'master' to 'main'

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Updates the GitHub Pages deployment workflow to track the repository’s default branch rename from `master` to `main`, ensuring deployments continue to run on pushes to the default branch.

**Changes:**
- Changed the workflow trigger branch from `master` to `main` in the Pages deploy workflow.