### PR TITLE
Updated `NLog` package to version 6.1.4

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -864,7 +864,7 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="Krypton.Toolkit" Version="105.26.4.110" />
     <PackageReference Include="Krypton.Toolkit.Suite.Extended.Ultimate" Version="95.25.5.145" />
     <PackageReference Include="Krypton.Workspace" Version="105.26.4.110" />
-    <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="NLog" Version="6.1.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="OpenTK.Audio" Version="5.0.0-pre.16" />
     <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />


### PR DESCRIPTION
Updates the Planetoid-DB project’s NuGet dependency on `NLog` to the next patch release, keeping logging dependencies current.

**Changes:**
- Bumped `NLog` package reference from `6.1.3` to `6.1.4` in the main project file.