### PR TITLE
Updated `System` packages to version 11.0.0-preview.6.26359.118

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -887,12 +887,12 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.151.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="4.151.0-preview.1.1" />
     <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="4.151.0-preview.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.5.26302.115" />
-    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.6.26359.118" />
+    <PackageReference Include="System.Data.OleDb" Version="11.0.0-preview.6.26359.118" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.5.26302.115" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.5.26302.115" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.6.26359.118" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.6.26359.118" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the project’s NuGet dependencies for several `System.*` packages to the newer **11.0.0-preview.6.26359.118** versions, keeping the package set aligned on the same preview release.

**Changes:**
- Bumped `System.Configuration.ConfigurationManager` to `11.0.0-preview.6.26359.118`.
- Bumped `System.Data.OleDb` to `11.0.0-preview.6.26359.118`.
- Bumped `System.Diagnostics.EventLog`, `System.Diagnostics.PerformanceCounter`, and `System.Security.Cryptography.ProtectedData` to `11.0.0-preview.6.26359.118`.