### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/cac8f904-a693-426d-9946-98102493707e" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/1691894a-ad5d-457e-a946-8717e4f1b85e" />


### PR DESCRIPTION
Updates the README’s embedded screenshot link so the documentation displays the current UI image for Planetoid-DB’s MPCORB.DAT tabular view.

**Changes:**
- Replaced the `src` URL of the README screenshot image to point to a new `user-attachments` asset.