### PR TITLE
Updated to version 0.9.18.81

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -10,7 +10,7 @@
     <StartupObject>Planetoid_DB.Program</StartupObject>
     <ApplicationIcon>Resources\Planetoid-DB-3.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.9.17.80</Version>
+    <Version>0.9.18.81</Version>
     <Company>Mijo Software</Company>
     <Description>Viewer for the MPC Orbit (MPCORB) Database</Description>
     <Copyright>2010-2026 Michael Johne</Copyright>

--- a/Planetoid-DB.csproj.user
+++ b/Planetoid-DB.csproj.user
@@ -112,6 +112,18 @@
     <Compile Update="Forms\PlanetoidDBForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.DatabaseUpdates.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.Decoders.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.EventHandlers.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.Helpers.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Forms\PreloadForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Updates the Planetoid-DB application/package version to `0.9.18.81` and includes a small Visual Studio project user-metadata adjustment related to the `PlanetoidDBForm` partial-class split.

**Changes:**
- Bumped `<Version>` in `Planetoid-DB.csproj` to `0.9.18.81`.
- Added additional `<Compile Update=...><SubType>Form</SubType></Compile>` entries in `Planetoid-DB.csproj.user` for `PlanetoidDBForm.*.cs` partial files.