### PR TITLE
Updated package version numbers

### DIFF
--- a/Forms/AppInfoForm.Designer.cs
+++ b/Forms/AppInfoForm.Designer.cs
@@ -1057,7 +1057,7 @@ partial class AppInfoForm
 		kryptonLabelVersionKryptonSuite.ToolTipValues.EnableToolTips = true;
 		kryptonLabelVersionKryptonSuite.ToolTipValues.Heading = "Krypton Suite version";
 		kryptonLabelVersionKryptonSuite.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		kryptonLabelVersionKryptonSuite.Values.Text = "Version: 100.26.1.19";
+		kryptonLabelVersionKryptonSuite.Values.Text = "Version: 105.26.7.201";
 		kryptonLabelVersionKryptonSuite.DoubleClick += CopyToClipboard_DoubleClick;
 		kryptonLabelVersionKryptonSuite.Enter += Control_Enter;
 		kryptonLabelVersionKryptonSuite.Leave += Control_Leave;

--- a/Forms/AppInfoForm.cs
+++ b/Forms/AppInfoForm.cs
@@ -308,7 +308,7 @@ public partial class AppInfoForm : BaseKryptonForm
 
 		try
 		{
-			await ApplyZoomAndPixelateAsync(pictureBoxBanner);
+			await ApplyZoomAndPixelateAsync(pictureBox: pictureBoxBanner);
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Updates the AppInfo UI to reflect the current Krypton Suite package version and makes a small call-site adjustment in the banner click handler.

**Changes:**
- Updated the displayed Krypton Suite version text in `AppInfoForm` designer.
- Switched the `ApplyZoomAndPixelateAsync` call to use a named argument in the banner click handler.
