### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/8860979b-6207-4ef7-b4a2-b36992c415a7" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/fc57e217-7fe8-4d8e-b3a7-42519c129fc6" />


### PR DESCRIPTION
Updates the README documentation to point to the current hosted screenshot for Planetoid-DB, keeping the project overview accurate and visually up to date.

**Changes:**
- Updated the screenshot image URL in `README.md` to a new `github.com/user-attachments/assets/...` link.
