### PR TITLE
Updated package version numbers

### DIFF
--- a/Forms/AppInfoForm.Designer.cs
+++ b/Forms/AppInfoForm.Designer.cs
@@ -1843,7 +1843,7 @@ partial class AppInfoForm
 		kryptonLabelVersionSkiaSharp.ToolTipValues.EnableToolTips = true;
 		kryptonLabelVersionSkiaSharp.ToolTipValues.Heading = "SkiaSharp version";
 		kryptonLabelVersionSkiaSharp.ToolTipValues.Image = FatcowIcons16px.fatcow_information_16px;
-		kryptonLabelVersionSkiaSharp.Values.Text = "Version: 4.151.0-preview.2.1";
+		kryptonLabelVersionSkiaSharp.Values.Text = "Version: 4.151.0-rc.1.1";
 		kryptonLabelVersionSkiaSharp.DoubleClick += CopyToClipboard_DoubleClick;
 		kryptonLabelVersionSkiaSharp.Enter += Control_Enter;
 		kryptonLabelVersionSkiaSharp.Leave += Control_Leave;


### PR DESCRIPTION
Updates the SkiaSharp version string displayed in the “App Info” UI so it matches the currently referenced `SkiaSharp` package version.

Changes:
- Updated the SkiaSharp version label text from `4.151.0-preview.2.1` to `4.151.0-rc.1.1`.
