### PR TITLE
Updated internal url of `MPCORB.DAT`

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("http://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT.gz")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT.gz")]
         public string systemMpcorbDatGzUrl {
             get {
                 return ((string)(this["systemMpcorbDatGzUrl"]));
@@ -46,7 +46,7 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("http://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT")]
         public string systemMpcorbDatUrl {
             get {
                 return ((string)(this["systemMpcorbDatUrl"]));
@@ -145,7 +145,7 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("http://www.minorplanetcenter.org/iau/mpc.html")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://www.minorplanetcenter.org/iau/mpc.html")]
         public string systemWebsiteMpc {
             get {
                 return ((string)(this["systemWebsiteMpc"]));
@@ -154,7 +154,7 @@ namespace Planetoid_DB.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("http://www.minorplanetcenter.org/iau/MPCORB.html")]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://www.minorplanetcenter.org/iau/MPCORB.html")]
         public string systemWebsiteMpcorb {
             get {
                 return ((string)(this["systemWebsiteMpcorb"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -3,13 +3,13 @@
   <Profiles />
   <Settings>
     <Setting Name="systemMpcorbDatGzUrl" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT.gz</Value>
+      <Value Profile="(Default)">https://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT.gz</Value>
     </Setting>
     <Setting Name="userMpcorbDatGzUrl" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="systemMpcorbDatUrl" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT</Value>
+      <Value Profile="(Default)">https://www.minorplanetcenter.org/iau/MPCORB/MPCORB.DAT</Value>
     </Setting>
     <Setting Name="userMpcorbDatUrl" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
@@ -39,10 +39,10 @@
       <Value Profile="(Default)">_</Value>
     </Setting>
     <Setting Name="systemWebsiteMpc" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/mpc.html</Value>
+      <Value Profile="(Default)">https://www.minorplanetcenter.org/iau/mpc.html</Value>
     </Setting>
     <Setting Name="systemWebsiteMpcorb" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">http://www.minorplanetcenter.org/iau/MPCORB.html</Value>
+      <Value Profile="(Default)">https://www.minorplanetcenter.org/iau/MPCORB.html</Value>
     </Setting>
     <Setting Name="systemFilenameTemp" Type="System.String" Scope="Application">
       <Value Profile="(Default)">_</Value>


### PR DESCRIPTION
Updates the application’s default Minor Planet Center (MPC) endpoints to use HTTPS instead of HTTP, aligning built-in URLs with modern transport security expectations.

**Changes:**
- Switched default `MPCORB.DAT` and `MPCORB.DAT.gz` URLs from `http://` to `https://` in application settings.
- Switched default MPC website URLs from `http://` to `https://` in application settings.
