### PR TITLE
Refactored `ExportEscapeHelper.cs`

### DIFF
--- a/Helpers/ExportEscapeHelper.cs
+++ b/Helpers/ExportEscapeHelper.cs
@@ -1,6 +1,7 @@
-using Krypton.Toolkit;
-
-using NLog;
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
 
 using System.Text;
 
@@ -46,21 +47,20 @@ public static class ExportEscapeHelper
 	}
 
 	/// <summary>Escapes Markdown table cell characters.</summary>
-	/// <param name="value">The raw cell value.</param>
+	/// <param name="input">The raw cell value.</param>
 	/// <returns>The escaped string suitable for Markdown table output.</returns>
 	/// <remarks>In Markdown tables, the pipe character '|' is used as a column separator, so it must be escaped if it appears in cell content. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it replaces all occurrences of '|' with '\|', which is the standard way to escape a pipe character in Markdown.</remarks>
-	public static string EscapeMarkdownCell(string? value)
+	public static string EscapeMarkdownCell(string? input)
 	{
 		// In Markdown tables, the pipe character '|' is used as a column separator, so it must be escaped if it appears in cell content.
-		return string.IsNullOrEmpty(value: value) ? string.Empty : value.Replace(oldValue: "|", newValue: "\\|");
+		return string.IsNullOrEmpty(value: input) ? string.Empty : input.Replace(oldValue: "|", newValue: "\\|");
 	}
 
 	/// <summary>Escapes Typst table cell characters.</summary>
-	/// <param name="value">The raw cell value.</param>
+	/// <param name="input">The raw cell value.</param>
 	/// <returns>The escaped string suitable for Typst table output.</returns>
 	/// <remarks>In Typst tables, the pipe character '|' is used as a column separator, so it must be escaped if it appears in cell content. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it replaces all occurrences of '|' with '\|'.</remarks>
-public static string EscapeTypstCell(string? value)
-		=> EscapeMarkdownCell(value);
+	public static string EscapeTypstCell(string? input) => EscapeMarkdownCell(input: input);
 
 	/// <summary>Escapes PostScript string literal characters.</summary>
 	/// <param name="input">The raw input string.</param>
@@ -68,28 +68,44 @@ public static string EscapeTypstCell(string? value)
 	/// <remarks>In PostScript string literals, the backslash, parentheses, and control characters need to be escaped. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it replaces backslashes with double backslashes and parentheses with escaped versions to ensure that the resulting string can be safely included in a PostScript string literal.</remarks>
 	public static string EscapePostScript(string? input)
 	{
-		// In PostScript string literals, the backslash, parentheses, and control characters need to be escaped.
-		return string.IsNullOrEmpty(value: input)
-			? string.Empty
-			: input.Replace(oldValue: "\\", newValue: "\\\\")
-				   .Replace(oldValue: "(", newValue: "\\(")
-				   .Replace(oldValue: ")", newValue: "\\)");
+		// If the input string is null or empty, return an empty string to avoid processing.
+		if (string.IsNullOrEmpty(value: input))
+		{
+			return string.Empty;
+		}
+		// Initialize a StringBuilder with an estimated capacity to reduce memory allocations.
+		StringBuilder builder = new(input.Length + 5);
+		// Iterate through each character in the input string and escape special characters as needed.
+		foreach (char ch in input)
+		{
+			// Escape backslash and parentheses with a backslash. For other characters, append them as-is.
+			switch (ch)
+			{
+				case '\\': builder.Append(value: "\\\\"); break;
+				case '(': builder.Append(value: "\\("); break;
+				case ')': builder.Append(value: "\\)"); break;
+				default: builder.Append(value: ch); break;
+			}
+		}
+		// Return the fully escaped string.
+		return builder.ToString();
+
 	}
 
 	/// <summary>Escapes PDF string literal characters.</summary>
-	/// <param name="text">The raw input string.</param>
+	/// <param name="input">The raw input string.</param>
 	/// <returns>The escaped string suitable for PDF output.</returns>
 	/// <remarks>In PDF string literals, the backslash, parentheses, and control characters need to be escaped. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it iterates through each character in the input string and appends either the escaped version or the original character to a StringBuilder, which is then returned as the fully escaped string. Control characters are escaped using backslash followed by a letter (e.g. \n for newline), while other non-printable characters are escaped using octal escape sequences.</remarks>
-	public static string EscapePdf(string? text)
+	public static string EscapePdf(string? input)
 	{
 		// In PDF string literals, the backslash, parentheses, and control characters need to be escaped.
-		if (string.IsNullOrEmpty(value: text))
+		if (string.IsNullOrEmpty(value: input))
 		{
 			return string.Empty;
 		}
 		// Use a StringBuilder for efficient string concatenation when escaping characters.
-		StringBuilder builder = new(capacity: text.Length);
-		foreach (char ch in text)
+		StringBuilder builder = new(capacity: input.Length + 10);
+		foreach (char ch in input)
 		{
 			// Escape backslash, parentheses, and control characters with a backslash. For other non-printable characters, use octal escape sequences.
 			switch (ch)
@@ -124,13 +140,13 @@ public static string EscapeTypstCell(string? value)
 	/// <remarks>In RTF, the backslash, braces, and control characters need to be escaped. Non-ASCII characters can be represented using Unicode escape sequences. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it iterates through each character in the input string and appends either the escaped version or the original character to a StringBuilder, which is then returned as the fully escaped string. Backslashes and braces are escaped with a preceding backslash, newlines are replaced with the \par control word, and non-ASCII characters are represented using \uN? where N is the Unicode code point of the character.</remarks>
 	public static string EscapeRtf(string? input)
 	{
-		// In RTF, the backslash, braces, and control characters need to be escaped. Non-ASCII characters can be represented using Unicode escape sequences.
+		// If the input string is null or empty, return an empty string to avoid processing.
 		if (string.IsNullOrEmpty(value: input))
 		{
 			return string.Empty;
 		}
 		// Use a StringBuilder for efficient string concatenation when escaping characters.
-		StringBuilder builder = new(capacity: input.Length);
+		StringBuilder builder = new(capacity: input.Length + 10);
 		foreach (char ch in input)
 		{
 			// Escape backslash and braces with a backslash. For newlines, use the \par control word. For other non-ASCII characters, use Unicode escape sequences.
@@ -139,6 +155,8 @@ public static string EscapeTypstCell(string? value)
 				case '\\': builder.Append(value: "\\\\"); break;
 				case '{': builder.Append(value: "\\{"); break;
 				case '}': builder.Append(value: "\\}"); break;
+				// Ignore carriage return characters, as they are handled by the newline case; Bugfix: Prevents \r\par with Windows line breaks.
+				case '\r': break;
 				case '\n': builder.Append(value: "\\par "); break;
 				default:
 					if (ch > 127)
@@ -157,54 +175,45 @@ public static string EscapeTypstCell(string? value)
 	}
 
 	/// <summary>Escapes a CSV field by doubling internal quotes and wrapping in double quotes.</summary>
-	/// <param name="field">The raw field value.</param>
+	/// <param name="input">The raw field value.</param>
 	/// <returns>The escaped CSV field suitable for CSV output.</returns>
 	/// <remarks>In CSV, fields that contain commas, quotes, or newlines must be enclosed in double quotes, and internal double quotes are escaped by doubling them. This method first checks if the input field is null and treats it as an empty string; then it replaces any internal double quotes with two double quotes to escape them, and finally wraps the entire field in double quotes to ensure it is treated as a single field in the CSV output.</remarks>
-	public static string EscapeCsvField(string? field)
+	public static string EscapeCsvField(string? input)
 	{
-		// In CSV, fields that contain commas, quotes, or newlines must be enclosed in double quotes, and internal double quotes are escaped by doubling them.
-		string safeField = field ?? string.Empty;
-		// First, double any internal double quotes to escape them.
-		safeField = safeField.Replace(oldValue: "\"", newValue: "\"\"");
-		return $"\"{safeField}\"";
+		// If the input string is null or empty, return an empty string to avoid processing.
+		if (string.IsNullOrEmpty(value: input))
+		{
+			return string.Empty;
+		}
+		// Replace any internal double quotes with two double quotes to escape them, and wrap the entire field in double quotes.
+		return $"\"{input.Replace("\"", "\"\"")}\"";
+
 	}
 
 	/// <summary>Escapes a TOML string value.</summary>
-	/// <param name="value">The raw value.</param>
+	/// <param name="input">The raw input string.</param>
 	/// <returns>The escaped TOML string value suitable for TOML output.</returns>
-	/// <remarks>In TOML, basic string values are enclosed in double quotes, and backslashes and double quotes within the string must be escaped with a backslash. This method checks if the input value is null or empty and returns an empty string in that case; otherwise, it replaces backslashes with double backslashes and double quotes with escaped double quotes to ensure that the resulting string can be safely included as a basic string value in a TOML document.</remarks>
-	public static string EscapeToml(string? value)
+	/// <remarks>In TOML, basic string values are enclosed in double quotes, and backslashes and double quotes within the string must be escaped with a backslash. This method checks if the input string is null or empty and returns an empty string in that case; otherwise, it replaces backslashes with double backslashes and double quotes with escaped double quotes to ensure that the resulting string can be safely included as a basic string value in a TOML document.</remarks>
+	public static string EscapeToml(string? input)
 	{
-		// In TOML, basic string values are enclosed in double quotes, and backslashes and double quotes within the string must be escaped with a backslash.
-		return string.IsNullOrEmpty(value: value)
-			? string.Empty
-			: value.Replace(oldValue: "\\", newValue: "\\\\")
-				   .Replace(oldValue: "\"", newValue: "\\\"");
-	}
-
-	/// <summary>NLog logger for logging export-related messages and errors.</summary>
-	/// <remarks>This logger captures error and info messages during export operations.</remarks>
-	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-
-	/// <summary>Displays an error message box to the user.</summary>
-	/// <param name="message">The error message to display.</param>
-	/// <remarks>This method is used by exporter classes to display error messages to the user when an export operation fails.</remarks>
-	internal static void ShowErrorMessage(string message) =>
-		_ = KryptonMessageBox.Show(text: message, caption: I18nStrings.ErrorCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Error);
-
-	/// <summary>Shows a success message box after a file has been saved successfully.</summary>
-	/// <remarks>Displays a message box to the user confirming the file was saved successfully.</remarks>
-	internal static void ShowSuccess() =>
-		_ = KryptonMessageBox.Show(text: I18nStrings.FileSavedSuccessfully, caption: I18nStrings.InformationCaption, buttons: KryptonMessageBoxButtons.OK, icon: KryptonMessageBoxIcon.Information);
-
-	/// <summary>Logs and shows an error that occurred while saving a file.</summary>
-	/// <param name="ex">The exception that occurred.</param>
-	/// <param name="format">A label identifying the file format (e.g. "Text", "LaTeX").</param>
-	/// <param name="filePath">The target file path.</param>
-	/// <remarks>Logs the error with details about the format and file path, and displays an error message box to the user.</remarks>
-	internal static void ShowError(Exception ex, string format, string filePath)
-	{
-		logger.Error(exception: ex, message: "Error saving as {Format} to '{FilePath}'.", args: [format, filePath]);
-		ShowErrorMessage(message: $"Error saving as {format}: {ex.Message}");
+		// If the input string is null or empty, return an empty string to avoid processing.
+		if (string.IsNullOrEmpty(value: input))
+		{
+			return string.Empty;
+		}
+		// Use a StringBuilder for efficient string concatenation when escaping characters.
+		StringBuilder builder = new(input.Length + 5);
+		// Iterate through each character in the input string and escape backslashes and double quotes with a backslash. For other characters, append them as-is.
+		foreach (char ch in input)
+		{
+			switch (ch)
+			{
+				case '\\': builder.Append(value: "\\\\"); break;
+				case '\"': builder.Append(value: "\\\""); break;
+				default: builder.Append(value: ch); break;
+			}
+		}
+		// Return the fully escaped string.
+		return builder.ToString();
 	}
 }

--- a/Helpers/ExportFeedbackHelper.cs
+++ b/Helpers/ExportFeedbackHelper.cs
@@ -1,0 +1,53 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using Krypton.Toolkit;
+
+using NLog;
+
+namespace Planetoid_DB.Helpers;
+
+/// <summary>Handles UI feedback and logging during export operations.</summary>
+/// <remarks>This static class provides methods for displaying success and error messages to the user, as well as logging errors that occur during file export operations.</remarks>
+public static class ExportFeedbackHelper
+{
+	/// <summary>NLog logger for logging export-related messages and errors.</summary>
+	/// <remarks>This logger captures error and info messages during export operations.</remarks>
+	private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+	/// <summary>Displays an error message box to the user.</summary>
+	/// <param name="message">The error message to display.</param>
+	/// <remarks>This method is used by exporter classes to display error messages to the user when an export operation fails.</remarks>
+	public static void ShowErrorMessage(string message)
+	{
+		_ = KryptonMessageBox.Show(
+			text: message,
+			caption: I18nStrings.ErrorCaption,
+			buttons: KryptonMessageBoxButtons.OK,
+			icon: KryptonMessageBoxIcon.Error);
+	}
+
+	/// <summary>Shows a success message box after a file has been saved successfully.</summary>
+	/// <remarks>Displays a message box to the user confirming the file was saved successfully.</remarks>
+	public static void ShowSuccess()
+	{
+		_ = KryptonMessageBox.Show(
+			text: I18nStrings.FileSavedSuccessfully,
+			caption: I18nStrings.InformationCaption,
+			buttons: KryptonMessageBoxButtons.OK,
+			icon: KryptonMessageBoxIcon.Information);
+	}
+
+	/// <summary>Logs and shows an error that occurred while saving a file.</summary>
+	/// <param name="ex">The exception that occurred.</param>
+	/// <param name="format">A label identifying the file format (e.g. "Text", "LaTeX").</param>
+	/// <param name="filePath">The target file path.</param>
+	/// <remarks>Logs the error with details about the format and file path, and displays an error message box to the user.</remarks>
+	public static void ShowError(Exception ex, string format, string filePath)
+	{
+		logger.Error(exception: ex, message: $"Error saving as {format} to '{filePath}'.");
+		ShowErrorMessage(message: $"Error saving as {format}: {ex.Message}");
+	}
+}

--- a/Helpers/ListViewExporter.cs
+++ b/Helpers/ListViewExporter.cs
@@ -92,12 +92,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: string.Join(separator: " ", values: row));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
 		}
 	}
 
@@ -139,12 +139,12 @@ public static partial class ListViewExporter
 			writer.WriteLine(value: "\\end{table}");
 			writer.WriteLine(value: "\\end{document}");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
 		}
 	}
 
@@ -174,12 +174,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "| " + string.Join(separator: " | ", values: row.Select(selector: ExportEscapeHelper.EscapeMarkdownCell)) + " |");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
 		}
 	}
 
@@ -212,12 +212,12 @@ public static partial class ListViewExporter
 			}
 			writer.WriteLine(value: "|===");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
 		}
 	}
 
@@ -285,12 +285,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: separator);
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
 		}
 	}
 
@@ -320,12 +320,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "| " + string.Join(separator: " | ", values: escaped) + " |");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
 		}
 	}
 
@@ -362,12 +362,12 @@ public static partial class ListViewExporter
 			writer.WriteLine(value: "  ]");
 			writer.WriteLine(value: ")");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
 		}
 	}
 
@@ -441,12 +441,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "</w:document>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
 		}
 	}
 
@@ -516,12 +516,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
 		}
 	}
 
@@ -567,12 +567,12 @@ public static partial class ListViewExporter
 			}
 			writer.WriteLine(value: "}");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
 		}
 	}
 
@@ -625,12 +625,12 @@ public static partial class ListViewExporter
 			writer.WriteLine(value: "  </section>");
 			writer.WriteLine(value: "</abiword>");
 			//
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
 		}
 	}
 
@@ -675,12 +675,12 @@ public static partial class ListViewExporter
 			}
 			writer.WriteLine(value: "</table></body></html>");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
 		}
 	}
 
@@ -768,12 +768,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "</worksheet>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
 		}
 	}
 
@@ -842,12 +842,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
 		}
 	}
 
@@ -873,16 +873,16 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: string.Join(separator: ";", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c =>
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					return ExportEscapeHelper.EscapeCsvField(field: cell);
+					return ExportEscapeHelper.EscapeCsvField(input: cell);
 				})));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
 		}
 	}
 
@@ -908,12 +908,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: string.Join(separator: "\t", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c => c < row.Length ? row[c] : string.Empty)));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
 		}
 	}
 
@@ -939,12 +939,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: string.Join(separator: "|", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c => c < row.Length ? row[c] : string.Empty)));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
 		}
 	}
 
@@ -970,16 +970,16 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: string.Join(separator: ";", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c =>
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					return ExportEscapeHelper.EscapeCsvField(field: cell);
+					return ExportEscapeHelper.EscapeCsvField(input: cell);
 				})));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
 		}
 	}
 
@@ -1023,12 +1023,12 @@ public static partial class ListViewExporter
 			}
 			writer.WriteLine(value: "</tbody></table></body></html>");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
 		}
 	}
 
@@ -1069,12 +1069,12 @@ public static partial class ListViewExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
 		}
 	}
 
@@ -1138,12 +1138,12 @@ public static partial class ListViewExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
 		}
 	}
 
@@ -1177,12 +1177,12 @@ public static partial class ListViewExporter
 			string json = JsonSerializer.Serialize(value: doc, options: jsonSerializerOptions);
 			File.WriteAllText(path: fileName, contents: json);
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
 		}
 	}
 
@@ -1212,17 +1212,17 @@ public static partial class ListViewExporter
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(value: headers[c])} = \"{ExportEscapeHelper.EscapeToml(value: cell)}\"");
+					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(input: headers[c])} = \"{ExportEscapeHelper.EscapeToml(input: cell)}\"");
 				}
 				writer.WriteLine();
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
 		}
 	}
 
@@ -1241,7 +1241,7 @@ public static partial class ListViewExporter
 			string[] headers = GetHeaders(listView: listView);
 			// Use a StreamWriter to write the output file in TOML format with UTF-8 encoding. The 'append: false' parameter ensures that the file is overwritten if it already exists. The TOML document has a "title" key at the top of the file and a list of tables for each row in the ListView. Each table is represented as a TOML array of tables with keys corresponding to the column headers. Special characters in the headers and cell data are escaped by replacing double quotes with escaped double quotes to ensure that the TOML document is well-formed.
 			using StreamWriter writer = new(path: fileName, append: false, encoding: Encoding.UTF8);
-			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(value: title)}\"");
+			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(input: title)}\"");
 			writer.WriteLine(value: $"created_at = {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
 			writer.WriteLine();
 			foreach (string[] row in GetRows(listView: listView, virtualRowProvider: virtualRowProvider))
@@ -1251,17 +1251,17 @@ public static partial class ListViewExporter
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(value: headers[c])} = \"{ExportEscapeHelper.EscapeToml(value: cell)}\"");
+					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(input: headers[c])} = \"{ExportEscapeHelper.EscapeToml(input: cell)}\"");
 				}
 				writer.WriteLine();
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
 		}
 	}
 
@@ -1307,12 +1307,12 @@ public static partial class ListViewExporter
 			}
 			writer.WriteLine(value: "COMMIT;");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
 		}
 	}
 
@@ -1371,12 +1371,12 @@ public static partial class ListViewExporter
 			transaction.Commit();
 			connection.Close();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
 		}
 	}
 
@@ -1424,11 +1424,11 @@ public static partial class ListViewExporter
 			pageContentObjIds.Add(item: currentContentObjId);
 			writer.WriteLine(value: "<< >> stream");
 			writer.WriteLine(value: "BT /F1 10 Tf");
-			writer.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(text: title)}) Tj");
+			writer.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(input: title)}) Tj");
 			for (int c = 0; c < headers.Length; c++)
 			{
 				// Write the column headers on the PDF page. Each header is positioned based on the calculated column X coordinates and a fixed Y coordinate near the top of the page. The headers are repeated on each new page to maintain context for the data rows.
-				writer.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(text: headers[c])}) Tj");
+				writer.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(input: headers[c])}) Tj");
 			}
 			currentY = startY - 30;
 			foreach (string[] row in GetRows(listView: listView, virtualRowProvider: virtualRowProvider))
@@ -1443,10 +1443,10 @@ public static partial class ListViewExporter
 					pageContentObjIds.Add(item: currentContentObjId);
 					writer.WriteLine(value: "<< >> stream");
 					writer.WriteLine(value: "BT /F1 10 Tf");
-					writer.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(text: title)} - Cont.) Tj");
+					writer.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(input: title)} - Cont.) Tj");
 					for (int c = 0; c < headers.Length; c++)
 					{
-						writer.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(text: headers[c])}) Tj");
+						writer.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(input: headers[c])}) Tj");
 					}
 					currentY = startY - 30;
 				}
@@ -1454,7 +1454,7 @@ public static partial class ListViewExporter
 				{
 					// Write each cell in the current row. If a row has fewer cells than headers, the missing cells are treated as empty strings.
 					string cell = c < row.Length ? row[c] : string.Empty;
-					writer.WriteLine(value: $"1 0 0 1 {colX[c]} {currentY} Tm ({ExportEscapeHelper.EscapePdf(text: cell)}) Tj");
+					writer.WriteLine(value: $"1 0 0 1 {colX[c]} {currentY} Tm ({ExportEscapeHelper.EscapePdf(input: cell)}) Tj");
 				}
 				currentY -= lineHeight;
 			}
@@ -1528,12 +1528,12 @@ public static partial class ListViewExporter
 			writer.WriteLine(value: xrefOffset);
 			writer.WriteLine(value: "%%EOF");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
 		}
 	}
 
@@ -1679,12 +1679,12 @@ public static partial class ListViewExporter
 			writer.WriteLine(value: xrefOffset);
 			writer.WriteLine(value: "%%EOF");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
 		}
 	}
 
@@ -1782,12 +1782,12 @@ public static partial class ListViewExporter
 				writer.WriteLine(value: "</tbody></table></body></html>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
 		}
 	}
 
@@ -1806,27 +1806,27 @@ public static partial class ListViewExporter
 			string[] headers = GetHeaders(listView: listView);
 			// Build the HTML content for the MOBI file. The HTML includes a title, a heading with the title, and a table with the column headers and data rows. Special characters in the title, headers, and cell data are encoded using HTML encoding to ensure that the resulting HTML is well-formed and can be rendered correctly by e-book readers that support the MOBI format.
 			StringBuilder html = new();
-			html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{System.Net.WebUtility.HtmlEncode(value: title)}</title></head><body>");
-			html.Append(value: $"<h1>{System.Net.WebUtility.HtmlEncode(value: title)}</h1>");
-			html.Append(value: "<table><tr>");
+			_ = html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{System.Net.WebUtility.HtmlEncode(value: title)}</title></head><body>");
+			_ = html.Append(value: $"<h1>{System.Net.WebUtility.HtmlEncode(value: title)}</h1>");
+			_ = html.Append(value: "<table><tr>");
 			foreach (string h in headers)
 			{
 				// Write the column headers in the HTML table. Each header is encoded using HTML encoding to ensure that special characters are properly handled in the resulting HTML content.
-				html.Append(value: $"<th>{System.Net.WebUtility.HtmlEncode(value: h)}</th>");
+				_ = html.Append(value: $"<th>{System.Net.WebUtility.HtmlEncode(value: h)}</th>");
 			}
-			html.Append(value: "</tr>");
+			_ = html.Append(value: "</tr>");
 			foreach (string[] row in GetRows(listView: listView, virtualRowProvider: virtualRowProvider))
 			{
 				// Write each data row in the HTML table. Each cell is encoded using HTML encoding to ensure that special characters are properly handled. If a row has fewer cells than headers, the missing cells are treated as empty strings.
-				html.Append(value: "<tr>");
+				_ = html.Append(value: "<tr>");
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					html.Append(value: $"<td>{System.Net.WebUtility.HtmlEncode(value: cell)}</td>");
+					_ = html.Append(value: $"<td>{System.Net.WebUtility.HtmlEncode(value: cell)}</td>");
 				}
-				html.Append(value: "</tr>");
+				_ = html.Append(value: "</tr>");
 			}
-			html.Append(value: "</table></body></html>");
+			_ = html.Append(value: "</table></body></html>");
 			byte[] bodyData = Encoding.UTF8.GetBytes(s: html.ToString());
 			List<byte[]> textRecords = [];
 			for (int i = 0; i < bodyData.Length; i += 4096)
@@ -1903,12 +1903,12 @@ public static partial class ListViewExporter
 			}
 			w.Write(buffer: eofRecord);
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
 		}
 	}
 
@@ -1985,12 +1985,12 @@ public static partial class ListViewExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO and unauthorized access exceptions and show an error message.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
 		}
 	}
 
@@ -2009,7 +2009,7 @@ public static partial class ListViewExporter
 			path2: @"HTML Help Workshop\hhc.exe");
 		if (!File.Exists(path: hhcPath))
 		{
-			ExportEscapeHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
+			ExportFeedbackHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
 			return;
 		}
 		// Create a temporary directory to store the intermediate files needed for CHM compilation. The directory is created in the system's temporary path with a unique name generated using a GUID. After the compilation process, the temporary directory and its contents will be deleted to clean up any intermediate files.
@@ -2088,18 +2088,18 @@ public static partial class ListViewExporter
 			{
 				File.Copy(sourceFileName: chmTempPath, destFileName: fileName, overwrite: true);
 				// Show a success message after the CHM file has been successfully created.
-				ExportEscapeHelper.ShowSuccess();
+				ExportFeedbackHelper.ShowSuccess();
 			}
 			else
 			{
 				// If the CHM file was not created, show an error message to the user.
-				ExportEscapeHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
+				ExportFeedbackHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
 			}
 		}
 		// Catch any exceptions that occur during the file generation and compilation process, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
 		}
 		// Finally, clean up the temporary directory used for intermediate files.
 		finally
@@ -2176,24 +2176,24 @@ public static partial class ListViewExporter
 			void StartNewPage()
 			{
 				currentPageBuilder.Clear();
-				currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-				currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
+				_ = currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+				_ = currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
 				string safeTitle = System.Security.SecurityElement.Escape(str: title) ?? string.Empty;
 				int titleY = Math.Max(val1: 0, val2: currentY - 24);
-				currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
+				_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
 				currentY += lineHeight;
 
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string safeH = System.Security.SecurityElement.Escape(str: headers[c]) ?? string.Empty;
-					currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeH}\"/>");
+					_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeH}\"/>");
 				}
 				currentY += lineHeight;
 			}
 			// The FinishCurrentPage function finalizes the current page by closing the XML tags, creating a new entry in the ZIP archive for the page, and writing the page content to that entry. It also creates a relationships entry for the page that references the font resource used in the page.
 			void FinishCurrentPage()
 			{
-				currentPageBuilder.AppendLine(value: "</FixedPage>");
+				_ = currentPageBuilder.AppendLine(value: "</FixedPage>");
 				string pageName = $"{pageNumber}.fpage";
 				string pagePath = $"Documents/1/Pages/{pageName}";
 				pageEntries.Add(item: pageName);
@@ -2225,7 +2225,7 @@ public static partial class ListViewExporter
 					string safeCell = System.Security.SecurityElement.Escape(str: cell) ?? string.Empty;
 					if (!string.IsNullOrEmpty(value: safeCell))
 					{
-						currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"10\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeCell}\"/>");
+						_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"10\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeCell}\"/>");
 					}
 				}
 				currentY += lineHeight;
@@ -2263,12 +2263,12 @@ public static partial class ListViewExporter
 				writer.Write(value: "DUMMY");
 			}
 			// Show a success message after the XPS file has been successfully created.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
 		}
 	}
 

--- a/Helpers/TableLayoutPanelExporter.cs
+++ b/Helpers/TableLayoutPanelExporter.cs
@@ -89,12 +89,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: string.Join(separator: " ", values: row));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
 		}
 	}
 
@@ -135,12 +135,12 @@ public static class TableLayoutPanelExporter
 			writer.WriteLine(value: "\\end{table}");
 			writer.WriteLine(value: "\\end{document}");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
 		}
 	}
 
@@ -169,12 +169,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "| " + string.Join(separator: " | ", values: row.Select(selector: ExportEscapeHelper.EscapeMarkdownCell)) + " |");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
 		}
 	}
 
@@ -206,12 +206,12 @@ public static class TableLayoutPanelExporter
 			}
 			writer.WriteLine(value: "|===");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
 		}
 	}
 
@@ -278,12 +278,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: separator);
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
 		}
 	}
 
@@ -312,12 +312,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "| " + string.Join(separator: " | ", values: escaped) + " |");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
 		}
 	}
 
@@ -346,12 +346,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "| " + string.Join(separator: " | ", values: row.Select(selector: ExportEscapeHelper.EscapeTypstCell)) + " |");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
 		}
 	}
 
@@ -424,12 +424,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "</w:document>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
 		}
 	}
 
@@ -498,12 +498,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
 		}
 	}
 
@@ -548,12 +548,12 @@ public static class TableLayoutPanelExporter
 			}
 			writer.WriteLine(value: "}");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
 		}
 	}
 
@@ -605,12 +605,12 @@ public static class TableLayoutPanelExporter
 			writer.WriteLine(value: "  </section>");
 			writer.WriteLine(value: "</abiword>");
 			//
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
 		}
 	}
 
@@ -654,12 +654,12 @@ public static class TableLayoutPanelExporter
 			}
 			writer.WriteLine(value: "</table></body></html>");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
 		}
 	}
 
@@ -746,12 +746,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "</worksheet>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
 		}
 	}
 
@@ -819,12 +819,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
 		}
 	}
 
@@ -849,16 +849,16 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: string.Join(separator: ";", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c =>
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					return ExportEscapeHelper.EscapeCsvField(field: cell);
+					return ExportEscapeHelper.EscapeCsvField(input: cell);
 				})));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
 		}
 	}
 
@@ -883,12 +883,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: string.Join(separator: "\t", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c => c < row.Length ? row[c] : string.Empty)));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
 		}
 	}
 
@@ -913,12 +913,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: string.Join(separator: "|", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c => c < row.Length ? row[c] : string.Empty)));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
 		}
 	}
 
@@ -943,16 +943,16 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: string.Join(separator: ";", values: Enumerable.Range(start: 0, count: headers.Length).Select(selector: c =>
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					return ExportEscapeHelper.EscapeCsvField(field: cell);
+					return ExportEscapeHelper.EscapeCsvField(input: cell);
 				})));
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
 		}
 	}
 
@@ -996,12 +996,12 @@ public static class TableLayoutPanelExporter
 			}
 			writer.WriteLine(value: "</tbody></table></body></html>");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
 		}
 	}
 
@@ -1041,12 +1041,12 @@ public static class TableLayoutPanelExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
 		}
 	}
 
@@ -1109,12 +1109,12 @@ public static class TableLayoutPanelExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
 		}
 	}
 
@@ -1147,12 +1147,12 @@ public static class TableLayoutPanelExporter
 			string json = JsonSerializer.Serialize(value: doc, options: jsonSerializerOptions);
 			File.WriteAllText(path: fileName, contents: json);
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
 		}
 	}
 
@@ -1187,12 +1187,12 @@ public static class TableLayoutPanelExporter
 				}
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
 		}
 	}
 
@@ -1210,7 +1210,7 @@ public static class TableLayoutPanelExporter
 			string[] headers = GetHeaders(tableLayoutPanel: tableLayoutPanel);
 			// Use a StreamWriter to write the output file in TOML format with UTF-8 encoding. The 'append: false' parameter ensures that the file is overwritten if it already exists. The TOML document has a "title" key at the top of the file and a list of tables for each row in the TableLayoutPanel. Each table is represented as a TOML array of tables with keys corresponding to the column headers. Special characters in the headers and cell data are escaped by replacing double quotes with escaped double quotes to ensure that the TOML document is well-formed.
 			using StreamWriter writer = new(path: fileName, append: false, encoding: Encoding.UTF8);
-			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(value: title)}\"");
+			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(input: title)}\"");
 			writer.WriteLine(value: $"created_at = {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
 			writer.WriteLine();
 			foreach (string[] row in GetRows(tableLayoutPanel: tableLayoutPanel))
@@ -1220,17 +1220,17 @@ public static class TableLayoutPanelExporter
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(value: headers[c])} = \"{ExportEscapeHelper.EscapeToml(value: cell)}\"");
+					writer.WriteLine(value: $"{ExportEscapeHelper.EscapeToml(input: headers[c])} = \"{ExportEscapeHelper.EscapeToml(input: cell)}\"");
 				}
 				writer.WriteLine();
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
 		}
 	}
 
@@ -1275,12 +1275,12 @@ public static class TableLayoutPanelExporter
 			}
 			writer.WriteLine(value: "COMMIT;");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
 		}
 	}
 
@@ -1338,12 +1338,12 @@ public static class TableLayoutPanelExporter
 			transaction.Commit();
 			connection.Close();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
 		}
 	}
 
@@ -1390,11 +1390,11 @@ public static class TableLayoutPanelExporter
 			pageContentObjIds.Add(item: currentContentObjId);
 			w.WriteLine(value: "<< >> stream");
 			w.WriteLine(value: "BT /F1 10 Tf");
-			w.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(text: title)}) Tj");
+			w.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(input: title)}) Tj");
 			for (int c = 0; c < headers.Length; c++)
 			{
 				// Write the column headers on the PDF page. Each header is positioned based on the calculated column X coordinates and a fixed Y coordinate near the top of the page. The headers are repeated on each new page to maintain context for the data rows.
-				w.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(text: headers[c])}) Tj");
+				w.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(input: headers[c])}) Tj");
 			}
 			currentY = startY - 30;
 			foreach (string[] row in GetRows(tableLayoutPanel: tableLayoutPanel))
@@ -1409,10 +1409,10 @@ public static class TableLayoutPanelExporter
 					pageContentObjIds.Add(item: currentContentObjId);
 					w.WriteLine(value: "<< >> stream");
 					w.WriteLine(value: "BT /F1 10 Tf");
-					w.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(text: title)} - Cont.) Tj");
+					w.WriteLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(input: title)} - Cont.) Tj");
 					for (int c = 0; c < headers.Length; c++)
 					{
-						w.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(text: headers[c])}) Tj");
+						w.WriteLine(value: $"1 0 0 1 {colX[c]} {pageHeight - 60} Tm ({ExportEscapeHelper.EscapePdf(input: headers[c])}) Tj");
 					}
 					currentY = startY - 30;
 				}
@@ -1420,7 +1420,7 @@ public static class TableLayoutPanelExporter
 				{
 					// Write each cell in the current row. If a row has fewer cells than headers, the missing cells are treated as empty strings.
 					string cell = c < row.Length ? row[c] : string.Empty;
-					w.WriteLine(value: $"1 0 0 1 {colX[c]} {currentY} Tm ({ExportEscapeHelper.EscapePdf(text: cell)}) Tj");
+					w.WriteLine(value: $"1 0 0 1 {colX[c]} {currentY} Tm ({ExportEscapeHelper.EscapePdf(input: cell)}) Tj");
 				}
 				currentY -= lineHeight;
 			}
@@ -1488,12 +1488,12 @@ public static class TableLayoutPanelExporter
 			w.WriteLine(value: xrefOffset);
 			w.WriteLine(value: "%%EOF");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
 		}
 	}
 
@@ -1568,12 +1568,12 @@ public static class TableLayoutPanelExporter
 			writer.WriteLine(value: $"%%Pages: {pageNumber}");
 			writer.WriteLine(value: "%%EOF");
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
 		}
 	}
 
@@ -1668,12 +1668,12 @@ public static class TableLayoutPanelExporter
 				writer.WriteLine(value: "</tbody></table></body></html>");
 			}
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
 		}
 	}
 
@@ -1691,27 +1691,27 @@ public static class TableLayoutPanelExporter
 			string[] headers = GetHeaders(tableLayoutPanel: tableLayoutPanel);
 			// Build the HTML content for the MOBI file. The HTML includes a title, a heading with the title, and a table with the column headers and data rows. Special characters in the title, headers, and cell data are encoded using HTML encoding to ensure that the resulting HTML is well-formed and can be rendered correctly by the CHM compiler and viewers.
 			StringBuilder html = new();
-			html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{WebUtility.HtmlEncode(value: title)}</title></head><body>");
-			html.Append(value: $"<h1>{WebUtility.HtmlEncode(value: title)}</h1>");
-			html.Append(value: "<table><tr>");
+			_ = html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{WebUtility.HtmlEncode(value: title)}</title></head><body>");
+			_ = html.Append(value: $"<h1>{WebUtility.HtmlEncode(value: title)}</h1>");
+			_ = html.Append(value: "<table><tr>");
 			foreach (string h in headers)
 			{
 				// Write the column headers in the HTML table. Each header is encoded using HTML encoding to ensure that special characters are properly handled in the resulting HTML content.
-				html.Append(value: $"<th>{WebUtility.HtmlEncode(value: h)}</th>");
+				_ = html.Append(value: $"<th>{WebUtility.HtmlEncode(value: h)}</th>");
 			}
-			html.Append(value: "</tr>");
+			_ = html.Append(value: "</tr>");
 			foreach (string[] row in GetRows(tableLayoutPanel: tableLayoutPanel))
 			{
 				// Write each data row in the HTML table. Each cell is encoded using HTML encoding to ensure that special characters are properly handled. If a row has fewer cells than headers, the missing cells are treated as empty strings.
-				html.Append(value: "<tr>");
+				_ = html.Append(value: "<tr>");
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string cell = c < row.Length ? row[c] : string.Empty;
-					html.Append(value: $"<td>{WebUtility.HtmlEncode(value: cell)}</td>");
+					_ = html.Append(value: $"<td>{WebUtility.HtmlEncode(value: cell)}</td>");
 				}
-				html.Append(value: "</tr>");
+				_ = html.Append(value: "</tr>");
 			}
-			html.Append(value: "</table></body></html>");
+			_ = html.Append(value: "</table></body></html>");
 			byte[] bodyData = Encoding.UTF8.GetBytes(s: html.ToString());
 			List<byte[]> textRecords = [];
 			for (int i = 0; i < bodyData.Length; i += 4096)
@@ -1788,12 +1788,12 @@ public static class TableLayoutPanelExporter
 			}
 			w.Write(buffer: eofRecord);
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
 		}
 	}
 
@@ -1871,12 +1871,12 @@ public static class TableLayoutPanelExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// Show a success message after the file has been saved.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
 		}
 	}
 
@@ -1892,7 +1892,7 @@ public static class TableLayoutPanelExporter
 		string hhcPath = Path.Combine(path1: Environment.GetFolderPath(folder: Environment.SpecialFolder.ProgramFilesX86), path2: @"HTML Help Workshop\hhc.exe");
 		if (!File.Exists(path: hhcPath))
 		{
-			ExportEscapeHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
+			ExportFeedbackHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
 			return;
 		}
 		// Create a temporary directory to store the intermediate files needed for CHM compilation. The directory is created in the system's temporary path with a unique name generated using a GUID. After the compilation process, the temporary directory and its contents will be deleted to clean up any intermediate files.
@@ -1971,18 +1971,18 @@ public static class TableLayoutPanelExporter
 			{
 				File.Copy(sourceFileName: chmTempPath, destFileName: fileName, overwrite: true);
 				// Show a success message after the CHM file has been successfully created.
-				ExportEscapeHelper.ShowSuccess();
+				ExportFeedbackHelper.ShowSuccess();
 			}
 			else
 			{
 				// If the CHM file was not created, show an error message to the user.
-				ExportEscapeHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
+				ExportFeedbackHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
 			}
 		}
 		// Catch any exceptions that occur during the file generation and compilation process, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
 		}
 		// Finally, clean up the temporary directory used for intermediate files.
 		finally
@@ -2067,22 +2067,22 @@ public static class TableLayoutPanelExporter
 			void StartNewPage()
 			{
 				currentPageBuilder.Clear();
-				currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-				currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
+				_ = currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+				_ = currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
 				string safeTitle = System.Security.SecurityElement.Escape(str: title) ?? string.Empty;
 				int titleY = Math.Max(val1: 0, val2: currentY - 24);
-				currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
+				_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
 				for (int c = 0; c < headers.Length; c++)
 				{
 					string safeH = System.Security.SecurityElement.Escape(str: headers[c]) ?? string.Empty;
-					currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeH}\"/>");
+					_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"{colX[c]}\" OriginY=\"{currentY}\" UnicodeString=\"{safeH}\"/>");
 				}
 				currentY += lineHeight * 2;
 			}
 			// The FinishCurrentPage function finalizes the current page by closing the XML tags, creating a new entry in the ZIP archive for the page, and writing the page content to that entry. It also creates a relationships entry for the page that references the font resource used in the page.
 			void FinishCurrentPage()
 			{
-				currentPageBuilder.AppendLine(value: "</FixedPage>");
+				_ = currentPageBuilder.AppendLine(value: "</FixedPage>");
 				string pageName = $"{pageNumber}.fpage";
 				string pagePath = $"Documents/1/Pages/{pageName}";
 				pageEntries.Add(item: pageName);
@@ -2152,12 +2152,12 @@ public static class TableLayoutPanelExporter
 				writer.Write(value: "DUMMY");
 			}
 			// Show a success message after the XPS file has been successfully created.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
 		}
 	}
 

--- a/Helpers/TextBoxExporter.cs
+++ b/Helpers/TextBoxExporter.cs
@@ -39,12 +39,12 @@ public static partial class TextBoxExporter
 			writer.WriteLine(value: new string(c: '-', count: title.Length));
 			writer.WriteLine(value: textBox.Text);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Text", filePath: fileName);
 		}
 	}
 
@@ -72,12 +72,12 @@ public static partial class TextBoxExporter
 			}
 			writer.WriteLine(value: "\\end{document}");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "LaTeX", filePath: fileName);
 		}
 	}
 
@@ -98,11 +98,11 @@ public static partial class TextBoxExporter
 			writer.WriteLine();
 			writer.WriteLine(value: textBox.Text);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Markdown", filePath: fileName);
 		}
 	}
 
@@ -123,12 +123,12 @@ public static partial class TextBoxExporter
 			writer.WriteLine();
 			writer.WriteLine(value: textBox.Text);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AsciiDoc", filePath: fileName);
 		}
 	}
 
@@ -151,12 +151,12 @@ public static partial class TextBoxExporter
 			writer.WriteLine();
 			writer.WriteLine(value: textBox.Text);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "reStructuredText", filePath: fileName);
 		}
 	}
 
@@ -180,12 +180,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: $"p. {line}");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Textile", filePath: fileName);
 		}
 	}
 
@@ -209,12 +209,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: line);
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Typst", filePath: fileName);
 		}
 	}
 
@@ -272,12 +272,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "</w:document>");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Word", filePath: fileName);
 		}
 	}
 
@@ -332,12 +332,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODT", filePath: fileName);
 		}
 	}
 
@@ -411,12 +411,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "</worksheet>");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "Excel", filePath: fileName);
 		}
 	}
 
@@ -470,12 +470,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "</office:document-content>");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ODS", filePath: fileName);
 		}
 	}
 
@@ -502,12 +502,12 @@ public static partial class TextBoxExporter
 			}
 			writer.WriteLine(value: "}");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "RTF", filePath: fileName);
 		}
 	}
 
@@ -561,12 +561,12 @@ public static partial class TextBoxExporter
 			writer.WriteEndDocument();
 			writer.Flush();
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "AbiWord", filePath: fileName);
 		}
 	}
 
@@ -594,12 +594,12 @@ public static partial class TextBoxExporter
 			}
 			writer.WriteLine(value: "</body></html>");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "WPS", filePath: fileName);
 		}
 	}
 
@@ -701,10 +701,10 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "endobj");
 				// Build the page content stream in a MemoryStream so the /Length value is known before writing.
 				StringBuilder sb = new();
-				sb.AppendLine(value: "BT /F1 10 Tf");
+				_ = sb.AppendLine(value: "BT /F1 10 Tf");
 				if (pageIndex == 0)
 				{
-					sb.AppendLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(text: title)}) Tj");
+					_ = sb.AppendLine(value: $"1 0 0 1 50 {pageHeight - 40} Tm ({ExportEscapeHelper.EscapePdf(input: title)}) Tj");
 				}
 				// Start the body text 30 points below the top content margin to leave space after the title line.
 				int currentY = startY - 30;
@@ -712,10 +712,10 @@ public static partial class TextBoxExporter
 				int endLineIndex = Math.Min(val1: startLineIndex + linesPerPage, val2: textBox.Lines.Length);
 				for (int lineIndex = startLineIndex; lineIndex < endLineIndex; lineIndex++)
 				{
-					sb.AppendLine(value: $"1 0 0 1 50 {currentY} Tm ({ExportEscapeHelper.EscapePdf(text: textBox.Lines[lineIndex])}) Tj");
+					_ = sb.AppendLine(value: $"1 0 0 1 50 {currentY} Tm ({ExportEscapeHelper.EscapePdf(input: textBox.Lines[lineIndex])}) Tj");
 					currentY -= lineHeight;
 				}
-				sb.AppendLine(value: "ET");
+				_ = sb.AppendLine(value: "ET");
 				// Encode the content to ASCII bytes so the byte length is exact.
 				using MemoryStream ms = new();
 				using (StreamWriter sw = new(stream: ms, encoding: Encoding.ASCII, bufferSize: 1024, leaveOpen: true) { NewLine = "\n" })
@@ -765,12 +765,12 @@ public static partial class TextBoxExporter
 			writer.WriteLine(value: xrefOffset.ToString());
 			writer.WriteLine(value: "%%EOF");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PDF", filePath: fileName);
 		}
 	}
 
@@ -869,12 +869,12 @@ public static partial class TextBoxExporter
 			// End the XML document after writing all content for the FB2 file.
 			xmlWriter.WriteEndDocument();
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "FictionBook2", filePath: fileName);
 		}
 	}
 
@@ -890,7 +890,7 @@ public static partial class TextBoxExporter
 		// Check if the hhc.exe file exists at the expected location. If it does not exist, show an error message to the user indicating that Microsoft HTML Help Workshop is not installed or not found, and return from the method without attempting to compile the CHM file.
 		if (!File.Exists(path: hhcPath))
 		{
-			ExportEscapeHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
+			ExportFeedbackHelper.ShowErrorMessage(message: "Microsoft HTML Help Workshop is not installed or not found at the default location. Cannot compile CHM file.");
 			return;
 		}
 		// Create a temporary directory to store the HTML, HHC, and HHP files needed for compiling the CHM. The directory is created in the system's temporary folder with a unique name generated using a GUID. This ensures that the temporary files do not conflict with any existing files and can be safely cleaned up after the compilation process.
@@ -961,17 +961,17 @@ public static partial class TextBoxExporter
 			if (File.Exists(path: chmTempPath))
 			{
 				File.Copy(sourceFileName: chmTempPath, destFileName: fileName, overwrite: true);
-				ExportEscapeHelper.ShowSuccess();
+				ExportFeedbackHelper.ShowSuccess();
 			}
 			else
 			{
-				ExportEscapeHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
+				ExportFeedbackHelper.ShowErrorMessage(message: "Failed to compile the CHM file.");
 			}
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CHM", filePath: fileName);
 		}
 		// The finally block ensures that the temporary directory is deleted after the compilation process, regardless of whether it succeeds or fails. This is important for cleaning up any temporary files created during the process and preventing clutter in the system's temporary folder.
 		finally
@@ -1052,18 +1052,18 @@ public static partial class TextBoxExporter
 			// Define a local function to start a new page in the XPS document. This function initializes the currentPageBuilder with the necessary XML structure for a fixed page, including the title and page number. The title is displayed at the top of the page, and the current Y position is updated to account for the space taken by the title. This function is called whenever a new page needs to be started, such as when the content exceeds the bottom margin.
 			void StartNewPage()
 			{
-				currentPageBuilder.Clear();
-				currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-				currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
+				_ = currentPageBuilder.Clear();
+				_ = currentPageBuilder.AppendLine(value: "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+				_ = currentPageBuilder.AppendLine(value: "<FixedPage Width=\"816\" Height=\"1056\" xmlns=\"http://schemas.microsoft.com/xps/2005/06\" xml:lang=\"en-US\">");
 				string safeTitle = System.Security.SecurityElement.Escape(str: title) ?? string.Empty;
 				int titleY = Math.Max(val1: 0, val2: currentY - 24);
-				currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
+				_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"14\" OriginX=\"96\" OriginY=\"{titleY}\" UnicodeString=\"{safeTitle} - Page {pageNumber}\"/>");
 				currentY += lineHeight * 2;
 			}
 			// Define a local function to finish the current page and add it to the XPS document. This function appends the closing tag for the fixed page, creates a new entry in the ZIP archive for the page, and writes the XML content for the page. It also creates a relationships entry for the page that references a dummy font resource. This function is called whenever a page is completed, such as when the content exceeds the bottom margin or when all lines have been processed.
 			void FinishCurrentPage()
 			{
-				currentPageBuilder.AppendLine(value: "</FixedPage>");
+				_ = currentPageBuilder.AppendLine(value: "</FixedPage>");
 				string pageName = $"{pageNumber}.fpage";
 				string pagePath = $"Documents/1/Pages/{pageName}";
 				pageEntries.Add(item: pageName);
@@ -1092,7 +1092,7 @@ public static partial class TextBoxExporter
 				string safeCell = System.Security.SecurityElement.Escape(str: line) ?? string.Empty;
 				if (!string.IsNullOrEmpty(value: safeCell))
 				{
-					currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"96\" OriginY=\"{currentY}\" UnicodeString=\"{safeCell}\"/>");
+					_ = currentPageBuilder.AppendLine(value: $"  <Glyphs Fill=\"#FF000000\" FontUri=\"/Resources/Dummy.ttf\" DeviceFontName=\"Arial\" FontRenderingEmSize=\"12\" OriginX=\"96\" OriginY=\"{currentY}\" UnicodeString=\"{safeCell}\"/>");
 				}
 				currentY += lineHeight;
 			}
@@ -1132,12 +1132,12 @@ public static partial class TextBoxExporter
 				writer.Write(value: "DUMMY");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XPS", filePath: fileName);
 		}
 	}
 
@@ -1154,18 +1154,18 @@ public static partial class TextBoxExporter
 			// The 'using' statement ensures that the StreamWriter is properly disposed after use, which will flush and close the underlying file stream.
 			using StreamWriter writer = new(path: fileName, append: false, encoding: Encoding.UTF8);
 			// Write the title as the first row, followed by each line from the TextBox as a separate row in the CSV file. Fields are escaped to handle special characters.
-			writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(field: title));
+			writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(input: title));
 			foreach (string line in textBox.Lines)
 			{
-				writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(field: line));
+				writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(input: line));
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "CSV", filePath: fileName);
 		}
 	}
 
@@ -1188,12 +1188,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: line);
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TSV", filePath: fileName);
 		}
 	}
 
@@ -1216,12 +1216,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: line);
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PSV", filePath: fileName);
 		}
 	}
 
@@ -1238,18 +1238,18 @@ public static partial class TextBoxExporter
 			// The 'using' statement ensures that the StreamWriter is properly disposed after use, which will flush and close the underlying file stream.
 			using StreamWriter writer = new(path: fileName, append: false, encoding: Encoding.UTF8);
 			// Write the title as the first row, followed by each line from the TextBox as a separate row in the CSV file. Fields are escaped to handle special characters.
-			writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(field: title));
+			writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(input: title));
 			foreach (string line in textBox.Lines)
 			{
-				writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(field: line));
+				writer.WriteLine(value: ExportEscapeHelper.EscapeCsvField(input: line));
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "ET", filePath: fileName);
 		}
 	}
 
@@ -1278,12 +1278,12 @@ public static partial class TextBoxExporter
 			}
 			writer.WriteLine(value: "</body></html>");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "HTML", filePath: fileName);
 		}
 	}
 
@@ -1311,12 +1311,12 @@ public static partial class TextBoxExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "XML", filePath: fileName);
 		}
 	}
 
@@ -1349,12 +1349,12 @@ public static partial class TextBoxExporter
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndDocument();
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "DocBook", filePath: fileName);
 		}
 	}
 
@@ -1373,12 +1373,12 @@ public static partial class TextBoxExporter
 			string json = JsonSerializer.Serialize(value: doc, options: jsonSerializerOptions);
 			File.WriteAllText(path: fileName, contents: json);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "JSON", filePath: fileName);
 		}
 	}
 
@@ -1413,12 +1413,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: $"  - {EscapeYamlSingleQuotedScalar(value: line)}");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "YAML", filePath: fileName);
 		}
 	}
 
@@ -1434,7 +1434,7 @@ public static partial class TextBoxExporter
 		{
 			// The 'using' statement ensures that the StreamWriter is properly disposed after use, which will flush and close the underlying file stream.
 			using StreamWriter writer = new(path: fileName, append: false, encoding: Encoding.UTF8);
-			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(value: title)}\"");
+			writer.WriteLine(value: $"title = \"{ExportEscapeHelper.EscapeToml(input: title)}\"");
 			writer.WriteLine(value: $"created_at = {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
 			writer.WriteLine();
 			writer.Write(value: "lines = [");
@@ -1445,16 +1445,16 @@ public static partial class TextBoxExporter
 				{
 					writer.Write(value: ", ");
 				}
-				writer.Write(value: $"\"{ExportEscapeHelper.EscapeToml(value: textBox.Lines[i])}\"");
+				writer.Write(value: $"\"{ExportEscapeHelper.EscapeToml(input: textBox.Lines[i])}\"");
 			}
 			writer.WriteLine(value: "]");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "TOML", filePath: fileName);
 		}
 	}
 
@@ -1492,12 +1492,12 @@ public static partial class TextBoxExporter
 			}
 			writer.WriteLine(value: "COMMIT;");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQL", filePath: fileName);
 		}
 	}
 
@@ -1545,12 +1545,12 @@ public static partial class TextBoxExporter
 			transaction.Commit();
 			connection.Close();
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch any exceptions during SQLite operations, log the error, and show an error message to the user.
 		catch (Exception ex)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "SQLite", filePath: fileName);
 		}
 	}
 
@@ -1610,12 +1610,12 @@ public static partial class TextBoxExporter
 			writer.WriteLine(value: "showpage");
 			writer.WriteLine(value: "%%EOF");
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "PostScript", filePath: fileName);
 		}
 	}
 
@@ -1697,12 +1697,12 @@ public static partial class TextBoxExporter
 				writer.WriteLine(value: "</body></html>");
 			}
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "EPUB", filePath: fileName);
 		}
 	}
 
@@ -1718,13 +1718,13 @@ public static partial class TextBoxExporter
 		{
 			// Build the HTML content for the MOBI file. The HTML includes a title, a heading with the title, and paragraphs for each line from the TextBox. Special characters are HTML-encoded to ensure valid output.
 			StringBuilder html = new();
-			html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{System.Net.WebUtility.HtmlEncode(value: title)}</title></head><body>");
-			html.Append(value: $"<h1>{System.Net.WebUtility.HtmlEncode(value: title)}</h1>");
+			_ = html.Append(value: $"<html><head><meta charset=\"UTF-8\"><title>{System.Net.WebUtility.HtmlEncode(value: title)}</title></head><body>");
+			_ = html.Append(value: $"<h1>{System.Net.WebUtility.HtmlEncode(value: title)}</h1>");
 			foreach (string line in textBox.Lines)
 			{
-				html.Append(value: $"<p>{System.Net.WebUtility.HtmlEncode(value: line)}</p>");
+				_ = html.Append(value: $"<p>{System.Net.WebUtility.HtmlEncode(value: line)}</p>");
 			}
-			html.Append(value: "</body></html>");
+			_ = html.Append(value: "</body></html>");
 			byte[] bodyData = Encoding.UTF8.GetBytes(s: html.ToString());
 			// Split the HTML content into chunks of 4096 bytes to create multiple text records for the MOBI file.
 			List<byte[]> textRecords = [];
@@ -1803,12 +1803,12 @@ public static partial class TextBoxExporter
 			}
 			w.Write(buffer: eofRecord);
 			// If the save operation completes successfully, show a success message to the user.
-			ExportEscapeHelper.ShowSuccess();
+			ExportFeedbackHelper.ShowSuccess();
 		}
 		// Catch IO-related exceptions such as IOException and UnauthorizedAccessException, log the error, and show an error message to the user.
 		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			ExportEscapeHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
+			ExportFeedbackHelper.ShowError(ex: ex, format: "MOBI", filePath: fileName);
 		}
 	}
 


### PR DESCRIPTION
This PR refactors export helper responsibilities by separating UI/logging feedback from string-escaping utilities, and updates `TextBoxExporter` to use the new feedback helper during export operations.

**Changes:**
- Introduces `ExportFeedbackHelper` to centralize export success/error UI and error logging.
- Refactors `ExportEscapeHelper` to focus on escaping-only functionality and updates named parameters across call sites.
- Updates `TextBoxExporter` to call `ExportFeedbackHelper` for user feedback instead of `ExportEscapeHelper`.
