### PR TITLE
Removed embed resource group

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -824,12 +824,6 @@ Public License instead of this License.  But first, please read
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Remove="PlanetoidDBForm.CalculateDerivatedElements.resx" />
-    <EmbeddedResource Remove="PlanetoidDBForm.DerivatedElements.resx" />
-    <EmbeddedResource Remove="Forms\PlanetoidDBForm.Helpers.resx" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="LICENSE" />
     <None Remove="README.md" />
     <None Remove="Resources\demoset-10000.txt" />


### PR DESCRIPTION
This PR removes an obsolete `<ItemGroup>` from `Planetoid-DB.csproj` that was excluding several `.resx` files from `EmbeddedResource`.

**Changes:**
- Deleted an `<ItemGroup>` containing three `<EmbeddedResource Remove="...">` entries.
- Leaves existing compile/item exclusions and embedded packaging entries unchanged.
