### PR TITLE
Refactored `TisserandParameterCalculator.cs`

### DIFF
--- a/Forms/TisserandParameterOfAllMinorPlanetsForm.cs
+++ b/Forms/TisserandParameterOfAllMinorPlanetsForm.cs
@@ -153,15 +153,15 @@ public partial class TisserandParameterOfAllMinorPlanetsForm : BaseKryptonForm
 			designation = line[..7].Trim();
 		}
 		// Calculate the Tisserand parameters for all eight planets
-		List<TisserandParameterCalculator.TisserandResult> tisserandResults = TisserandParameterCalculator.CalculateTisserandParameters(
+		TisserandParameterCalculator.TisserandResult[] tisserandResults = TisserandParameterCalculator.CalculateTisserandParameters(
 			semiMajorAxis: semiMajorAxis,
 			eccentricity: eccentricity,
 			inclinationDeg: inclinationDeg);
 		// Build the Tisserand parameter array in planet order (Mercury … Neptune)
 		double[] tisserandValues = new double[PlanetCount];
-		for (int i = 0; i < Math.Min(val1: tisserandResults.Count, val2: PlanetCount); i++)
+		for (int i = 0; i < Math.Min(val1: tisserandResults.Length, val2: PlanetCount); i++)
 		{
-			tisserandValues[i] = tisserandResults[index: i].TisserandValue;
+			tisserandValues[i] = tisserandResults[i].TisserandValue;
 		}
 		results.Add(item: new TisserandRowResult(PlanetoidName: designation, TisserandValues: tisserandValues));
 	}
@@ -196,7 +196,7 @@ public partial class TisserandParameterOfAllMinorPlanetsForm : BaseKryptonForm
 		{
 			return;
 		}
-		int index = listView.SelectedIndices[index: 0];
+		int index = listView.SelectedIndices[0];
 		if (index < 0 || index >= _results.Count)
 		{
 			return;
@@ -249,7 +249,7 @@ public partial class TisserandParameterOfAllMinorPlanetsForm : BaseKryptonForm
 			e.Item = new ListViewItem();
 			return;
 		}
-		TisserandRowResult result = _results[index: e.ItemIndex];
+		TisserandRowResult result = _results[e.ItemIndex];
 		ListViewItem item = new(text: result.PlanetoidName);
 		string[] subItems = new string[PlanetCount];
 		for (int i = 0; i < PlanetCount; i++)
@@ -307,7 +307,7 @@ public partial class TisserandParameterOfAllMinorPlanetsForm : BaseKryptonForm
 				for (int i = 0; i < total; i++)
 				{
 					token.ThrowIfCancellationRequested();
-					ProcessPlanetoidLine(line: _planetoids[index: i], results: localResults);
+					ProcessPlanetoidLine(line: _planetoids[i], results: localResults);
 					if (i % reportInterval == 0 || i == total - 1)
 					{
 						progress.Report(value: (i + 1) * 100 / total);
@@ -413,12 +413,12 @@ public partial class TisserandParameterOfAllMinorPlanetsForm : BaseKryptonForm
 		// Update the column headers to reflect the current sort column and direction
 		for (int i = 0; i < listView.Columns.Count; i++)
 		{
-			string headerText = listView.Columns[index: i].Text;
+			string headerText = listView.Columns[i].Text;
 			if (headerText.StartsWith(value: "▲ ", comparisonType: StringComparison.Ordinal) || headerText.StartsWith(value: "▼ ", comparisonType: StringComparison.Ordinal))
 			{
 				headerText = headerText[SortIndicatorPrefixLength..];
 			}
-			listView.Columns[index: i].Text = i == sortColumn
+			listView.Columns[i].Text = i == sortColumn
 				? $"{(sortOrder == SortOrder.Ascending ? "▲" : "▼")} {headerText}"
 				: headerText;
 		}

--- a/Forms/TisserandParameterOfOneMinorPlanetForm.cs
+++ b/Forms/TisserandParameterOfOneMinorPlanetForm.cs
@@ -99,21 +99,21 @@ public partial class TisserandParameterOfOneMinorPlanetForm : BaseKryptonForm
 		try
 		{
 			// Calculate Tisserand parameters for all 8 planets
-			List<TisserandParameterCalculator.TisserandResult> results = TisserandParameterCalculator.CalculateTisserandParameters(
+			TisserandParameterCalculator.TisserandResult[] tisserandResults = TisserandParameterCalculator.CalculateTisserandParameters(
 				semiMajorAxis: semiMajorAxis,
 				eccentricity: eccentricity,
 				inclinationDeg: inclinationDeg);
 			// Populate the data labels (one per planet row, index 0 = Mercury … 7 = Neptune)
-			if (results.Count >= 8)
+			if (tisserandResults.Length >= 8)
 			{
-				labelMercuryData.Text = results[index: 0].TisserandValue.ToString(format: "F6");
-				labelVenusData.Text = results[index: 1].TisserandValue.ToString(format: "F6");
-				labelEarthData.Text = results[index: 2].TisserandValue.ToString(format: "F6");
-				labelMarsData.Text = results[index: 3].TisserandValue.ToString(format: "F6");
-				labelJupiterData.Text = results[index: 4].TisserandValue.ToString(format: "F6");
-				labelSaturnData.Text = results[index: 5].TisserandValue.ToString(format: "F6");
-				labelUranusData.Text = results[index: 6].TisserandValue.ToString(format: "F6");
-				labelNeptuneData.Text = results[index: 7].TisserandValue.ToString(format: "F6");
+				labelMercuryData.Text = tisserandResults[0].TisserandValue.ToString(format: "F6");
+				labelVenusData.Text = tisserandResults[1].TisserandValue.ToString(format: "F6");
+				labelEarthData.Text = tisserandResults[2].TisserandValue.ToString(format: "F6");
+				labelMarsData.Text = tisserandResults[3].TisserandValue.ToString(format: "F6");
+				labelJupiterData.Text = tisserandResults[4].TisserandValue.ToString(format: "F6");
+				labelSaturnData.Text = tisserandResults[5].TisserandValue.ToString(format: "F6");
+				labelUranusData.Text = tisserandResults[6].TisserandValue.ToString(format: "F6");
+				labelNeptuneData.Text = tisserandResults[7].TisserandValue.ToString(format: "F6");
 			}
 		}
 		// Log any exceptions that occur during the calculation and show an error message to the user

--- a/Helpers/TisserandParameterCalculator.cs
+++ b/Helpers/TisserandParameterCalculator.cs
@@ -13,13 +13,13 @@ internal class TisserandParameterCalculator
 	/// <param name="Name">The common name of the planet.</param>
 	/// <param name="SemiMajorAxis">The semi-major axis in AU (J2000.0 mean elements).</param>
 	/// <remarks>Only the semi-major axis is required for the Tisserand parameter formula.</remarks>
-	public record PlanetData(string Name, double SemiMajorAxis);
+	public readonly record struct PlanetData(string Name, double SemiMajorAxis);
 
 	/// <summary>Represents the Tisserand parameter result for a minor planet relative to a specific solar system planet.</summary>
 	/// <param name="PlanetName">The name of the reference planet.</param>
 	/// <param name="TisserandValue">The computed Tisserand parameter value (dimensionless).</param>
 	/// <remarks>Values near 3 (relative to Jupiter) indicate a Jupiter-family comet or Jupiter-crossing orbit. Values greater than 3 typically indicate an asteroid, while values less than 2 suggest a nearly isotropic comet.</remarks>
-	public record TisserandResult(string PlanetName, double TisserandValue);
+	public readonly record struct TisserandResult(string PlanetName, double TisserandValue);
 
 	/// <summary>Mean semi-major axes of the eight solar system planets at J2000.0.</summary>
 	/// <remarks>Values are taken from the standard IAU/JPL mean orbital elements (Standish, E.M. 1992, "Keplerian Elements for Approximate Planetary Positions").</remarks>
@@ -37,36 +37,47 @@ internal class TisserandParameterCalculator
 
 	/// <summary>Calculates the Tisserand parameter of a minor planet relative to each of the eight solar system planets.</summary>
 	/// <param name="semiMajorAxis">The semi-major axis of the minor planet in AU.</param>
-	/// <param name="eccentricity">The orbital eccentricity of the minor planet (dimensionless, 0 ≤ e &lt; 1).</param>
+	/// <param name="eccentricity">The orbital eccentricity of the minor planet (dimensionless, 0 &lt;= e &lt; 1).</param>
 	/// <param name="inclinationDeg">The orbital inclination of the minor planet to the ecliptic in degrees.</param>
-	/// <returns>A list of <see cref="TisserandResult"/> records, one per planet, ordered from Mercury to Neptune.</returns>
-	/// <remarks>Uses the standard three-body Tisserand formula: <para><c>T_P = a_P / a + 2 * cos(i) * sqrt(a / a_P * (1 - e²))</c></para> The result is undefined (and returned as <see cref="double.NaN"/>) when <paramref name="semiMajorAxis"/> is zero or negative.</remarks>
-	public static List<TisserandResult> CalculateTisserandParameters(
-		double semiMajorAxis,
-		double eccentricity,
-		double inclinationDeg)
+	/// <returns>An array of <see cref="TisserandResult"/> records, one per planet, ordered from Mercury to Neptune.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when eccentricity is not strictly between 0 and 1.</exception>
+	/// <remarks>The Tisserand parameter is a quasi-conserved quantity derived from the Jacobi constant in the circular restricted three-body problem. It is defined as: <para><c>T_P = a_P / a + 2 * cos(i) * sqrt(a / a_P * (1 - e²))</c></para> where <c>a_P</c> is the semi-major axis of the reference planet, <c>a</c> is the semi-major axis of the minor planet, <c>e</c> is the eccentricity of the minor planet, and <c>i</c> is the orbital inclination of the minor planet. By convention <c>T_J</c> (relative to Jupiter) is the most commonly used form and is widely employed to classify small solar-system bodies.</remarks>
+	public static TisserandResult[] CalculateTisserandParameters(double semiMajorAxis, double eccentricity, double inclinationDeg)
 	{
-		List<TisserandResult> results = [];
+		// Guard against invalid math domains (hyperbolic/parabolic orbits)
+		if (eccentricity is < 0.0 or >= 1.0)
+		{
+			// Throw an exception for invalid eccentricity values to prevent NaN results in the square root calculation
+			throw new ArgumentOutOfRangeException(paramName: nameof(eccentricity), message: "Eccentricity must be between 0 (inclusive) and 1 (exclusive) for valid Tisserand parameters.");
+		}
+		// Pre-allocate the array based on known length to prevent dynamic resizing
+		TisserandResult[] results = new TisserandResult[Planets.Length];
 		// Guard against degenerate orbits
 		if (semiMajorAxis <= 0.0)
 		{
-			foreach (PlanetData planet in Planets)
+			// If the semi-major axis is zero or negative, return NaN for all planets to indicate an invalid orbit
+			for (int i = 0; i < Planets.Length; i++)
 			{
-				results.Add(item: new TisserandResult(PlanetName: planet.Name, TisserandValue: double.NaN));
+				// Use double.NaN to indicate that the Tisserand parameter cannot be computed for a degenerate orbit
+				results[i] = new TisserandResult(PlanetName: Planets[i].Name, TisserandValue: double.NaN);
 			}
 			return results;
 		}
-		// Convert inclination to radians once
-		double inclinationRad = inclinationDeg * Math.PI / 180.0;
+		// Perform calculations once outside the loop
+		double inclinationRad = double.DegreesToRadians(degrees: inclinationDeg);
 		double cosInclination = Math.Cos(d: inclinationRad);
 		double oneMinusESq = 1.0 - (eccentricity * eccentricity);
-		foreach (PlanetData planet in Planets)
+		// Use a standard for-loop (slightly faster than foreach for arrays in performance-critical code)
+		for (int i = 0; i < Planets.Length; i++)
 		{
-			// T_P = a_P / a + 2 * cos(i) * sqrt(a / a_P * (1 - e²))
-			double tisserand = (planet.SemiMajorAxis / semiMajorAxis)
-				+ (2.0 * cosInclination * Math.Sqrt(d: semiMajorAxis / planet.SemiMajorAxis * oneMinusESq));
-			results.Add(item: new TisserandResult(PlanetName: planet.Name, TisserandValue: tisserand));
+			// Retrieve the planet data for the current iteration
+			PlanetData planet = Planets[i];
+			// Calculate the Tisserand parameter using the formula: T_P = a_P / a + 2 * cos(i) * sqrt(a / a_P * (1 - e²))
+			double tisserand = (planet.SemiMajorAxis / semiMajorAxis) + (2.0 * cosInclination * Math.Sqrt(d: semiMajorAxis / planet.SemiMajorAxis * oneMinusESq));
+			// Store the result in the pre-allocated array
+			results[i] = new TisserandResult(PlanetName: planet.Name, TisserandValue: tisserand);
 		}
+		// Return the array of Tisserand results for all planets
 		return results;
 	}
 }


### PR DESCRIPTION
This PR refactors the Tisserand-parameter calculation API to be more allocation-friendly (record structs + fixed-size result array) and updates the UI forms that consume it.

**Changes:**
- Refactored `TisserandParameterCalculator` to return a fixed-size `TisserandResult[]` and to validate eccentricity.
- Converted result/planet data carriers to `readonly record struct` to reduce allocations.
- Updated both Tisserand-parameter forms to consume the new array-based API.
