### PR TITLE
Updated to version 0.9.21.84

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -10,7 +10,7 @@
     <StartupObject>Planetoid_DB.Program</StartupObject>
     <ApplicationIcon>Resources\Planetoid-DB-3.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>0.9.20.83</Version>
+    <Version>0.9.21.84</Version>
     <Company>Mijo Software</Company>
     <Description>Viewer for the MPC Orbit (MPCORB) Database</Description>
     <Copyright>2010-2026 Michael Johne</Copyright>


### PR DESCRIPTION
Bumps the project version metadata for Planetoid-DB to align the build/package output with the new release version.

**Changes:**
- Updated the `<Version>` property from `0.9.20.83` to `0.9.21.84`.
