### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/ab6429b3-19f7-4b69-8ecb-6a9d0dfd3667" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/792e7bd9-3c0c-4c27-8901-5ecf831941aa" />


### PR DESCRIPTION
This PR updates the screenshot image reference in `README.md` to point to a new GitHub user-attachments asset, keeping the project documentation’s UI preview current.

**Changes:**
- Replaced the `<img>` tag’s `src` URL in `README.md` with a new asset link.
