### PR TITLE
Added experimental features to the application settings

### DIFF
--- a/App.config
+++ b/App.config
@@ -82,6 +82,9 @@
             <setting name="systemFilenameMpcorbJsonTemp" serializeAs="String">
                 <value>_</value>
             </setting>
+            <setting name="systemEnableExperimentalFeatures" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Planetoid_DB.Properties.Settings>
     </applicationSettings>
     <userSettings>
@@ -115,6 +118,9 @@
             </setting>
             <setting name="userMpcorbJsonGzUrl" serializeAs="String">
                 <value />
+            </setting>
+            <setting name="userEnableExperimentalFeatures" serializeAs="String">
+                <value>False</value>
             </setting>
         </Planetoid_DB.Properties.Settings>
     </userSettings>

--- a/Forms/PlanetoidDBForm.EventHandlers.cs
+++ b/Forms/PlanetoidDBForm.EventHandlers.cs
@@ -20,7 +20,16 @@ public partial class PlanetoidDbForm
 	/// <remarks>This method is used to initialize the form and its controls.</remarks>
 	private void PlanetoidDBForm_Load(object sender, EventArgs e)
 	{
+		// Set the initial status bar text to indicate that the database is loading
 		ClearStatusBar(label: labelInformation);
+		// Reload the application settings to ensure the latest configuration is applied
+		Settings.Default.Reload();
+		// Check if experimental features are enabled in the settings and enable them if so
+		if (Settings.Default.userEnableExperimentalFeatures)
+		{
+			toolStripMenuItemExperimentalFeatures.Checked = Settings.Default.userEnableExperimentalFeatures;
+			EnableExperimentalFeatures(silent: true);
+		}
 		// Set the initial text of the MPCORB.DAT tab to indicate that the database is loading
 		kryptonPageMpcorbDat.Text = $"MPCORB.DAT ({I18nStrings.DataLoading})";
 		// Configure the BackgroundWorker for loading the database
@@ -900,7 +909,7 @@ public partial class PlanetoidDbForm
 	/// <param name="sender">The event source.</param>
 	/// <param name="e">The <see cref="EventArgs"/> instance that contains the event data.</param>
 	///	<remarks>This method is used to show the histogram form for the selected parameter.</remarks>
-	private void Histograms_Click(object sender, EventArgs e) => ShowHistogram();
+	private void Distributions_Click(object sender, EventArgs e) => ShowHistogram();
 
 	/// <summary>Handles the click event for the scatter plot menu item or button. Shows the scatter plot form.</summary>
 	/// <param name="sender">The event source.</param>

--- a/Forms/PlanetoidDBForm.Helpers.cs
+++ b/Forms/PlanetoidDBForm.Helpers.cs
@@ -1447,7 +1447,7 @@ public partial class PlanetoidDbForm
 		}
 	}
 
-	private void EnableExperimentalFeatures()
+	private void EnableExperimentalFeatures(bool silent = false)
 	{
 		// Enable experimental features in the application
 		toolStripMenuItemDistributions.Enabled = true;
@@ -1457,25 +1457,29 @@ public partial class PlanetoidDbForm
 		toolStripButtonDistributions.Enabled = true;
 		toolStripButtonScatterPlots.Enabled = true;
 		toolStripDropDownButtonOrbit.Enabled = true;
-		//Settings.Default.EnableExperimentalFeatures = true;
-		//Settings.Default.Save();
+		// Update the user setting to enable experimental features
+		Settings.Default.userEnableExperimentalFeatures = true;
+		Settings.Default.Save();
 		// Log the enabling of experimental features
 		logger.Info(message: "Experimental features enabled.");
 		// Show a message box to inform the user about the enabled experimental features
-		_ = KryptonMessageBox.Show(
-			owner: this,
-			text: "Experimental features have been enabled. Please note that these features are in development and may not be fully stable.\n\n" +
-				"- distributions\n" +
-				"- scatter plots\n" +
-				"- a/e/i 3D diagram\n" +
-				"- orbit visualization",
+		if (silent != true)
+		{
+			_ = KryptonMessageBox.Show(
+				owner: this,
+				text: "Experimental features have been enabled. Please note that these features are in development and may not be fully stable.\n\n" +
+					"- distributions\n" +
+					"- scatter plots\n" +
+					"- a/e/i 3D diagram\n" +
+					"- orbit visualization",
 			caption: I18nStrings.InformationCaption,
 			buttons: KryptonMessageBoxButtons.OK,
 			icon: KryptonMessageBoxIcon.Information,
 			defaultButton: KryptonMessageBoxDefaultButton.Button1);
+		}
 	}
 
-	private void DisableExperimentalFeatures()
+	private void DisableExperimentalFeatures(bool silent = false)
 	{
 		// Disable experimental features in the application
 		toolStripMenuItemDistributions.Enabled = false;
@@ -1485,18 +1489,22 @@ public partial class PlanetoidDbForm
 		toolStripButtonDistributions.Enabled = false;
 		toolStripButtonScatterPlots.Enabled = false;
 		toolStripDropDownButtonOrbit.Enabled = false;
-		//Settings.Default.EnableExperimentalFeatures = false;
-		//Settings.Default.Save();
+		// Update the user setting to disable experimental features
+		Settings.Default.userEnableExperimentalFeatures = false;
+		Settings.Default.Save();
 		// Log the disabling of experimental features
 		logger.Info(message: "Experimental features disabled.");
 		// Show a message box to inform the user about the disabled experimental features
-		_ = KryptonMessageBox.Show(
-			owner: this,
-			text: "Experimental features have been disabled.",
-			caption: I18nStrings.InformationCaption,
-			buttons: KryptonMessageBoxButtons.OK,
-			icon: KryptonMessageBoxIcon.Information,
-			defaultButton: KryptonMessageBoxDefaultButton.Button1);
+		if (silent != true)
+		{
+			_ = KryptonMessageBox.Show(
+				owner: this,
+				text: "Experimental features have been disabled.",
+				caption: I18nStrings.InformationCaption,
+				buttons: KryptonMessageBoxButtons.OK,
+				icon: KryptonMessageBoxIcon.Information,
+				defaultButton: KryptonMessageBoxDefaultButton.Button1);
+		}
 	}
 
 	#endregion

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -168,7 +168,6 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		// Initialize the form components
 		InitializeComponent();
 		TextExtra = $"{Assembly.GetExecutingAssembly().GetName().Version}";
-		ClearStatusBar(label: labelInformation);
 		MpcOrbDatFilePath = mpcorbDatFilePath;
 		// Apply comprehensive flicker reduction for the TableLayoutPanel
 		OptimizeTableLayoutPanelForFlickerReduction();


### PR DESCRIPTION
This PR aims to make the “Experimental features” toggle persist across application restarts by storing it in application/user settings and re-applying it on startup, aligning the UI state with the saved configuration.

**Changes:**
- Persist experimental-features enable/disable state via `Settings.Default.userEnableExperimentalFeatures` and save it when toggled.
- Reload settings during `PlanetoidDBForm_Load` and enable experimental features silently when the saved flag is set.
- Rename the histogram click handler to `Distributions_Click` (matching the UI terminology) and shift initial status-bar clearing into the Load event.
