### PR TITLE
Updated `System.Data.SQLite` to version 2.0.4

### DIFF
--- a/Planetoid-DB.csproj
+++ b/Planetoid-DB.csproj
@@ -860,7 +860,7 @@ Public License instead of this License.  But first, please read
     <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
     <PackageReference Include="ScottPlot" Version="5.1.59" />
     <PackageReference Include="ScottPlot.WinForms" Version="5.1.59" />
-    <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
   </ItemGroup>
 
   <!-- Remove the old monolithic OpenTK.dll (3.x) bundled by Krypton.Toolkit.Suite.Extended.Ultimate.Nightly


### PR DESCRIPTION
This PR updates the project’s SQLite dependency to the latest `System.Data.SQLite` NuGet release, keeping Planetoid-DB’s export functionality (which relies on `System.Data.SQLite`) current.

**Changes:**
- Bumped `System.Data.SQLite` package reference from `2.0.3` to `2.0.4`.
