### PR TITLE
Updated image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The MPCORB.DAT dataset originates from the Minor Planet Center, the central repo
 
 Planetoid-DB serves this purpose by providing a user-friendly interface to read, filter, and graphically/tabularly examine this large text file — especially for users who do not want to work directly with scripts or data parsing in Python/Fortran etc.
 
-<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/8662cacc-db1c-430c-abfb-8e63667486bd" />
+<img width="868" height="449" alt="Screenshot of Planetoid-DB showing a tabular view of MPCORB.DAT orbital data" src="https://github.com/user-attachments/assets/b66fb377-e877-437b-b445-f76aa7c5ad40" />


### PR DESCRIPTION
Updates the embedded screenshot in `README.md` to point to a new GitHub user-attachments asset, keeping the documentation’s visual preview of the Planetoid-DB UI current.

**Changes:**
- Replaced the `<img>` tag’s `src` URL to reference a new uploaded screenshot asset.
