### PR TITLE
Added flicker-reduction initialization to `tableLayoutPanelAstorbData`

### DIFF
--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -194,8 +194,8 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 		logger.Info(message: $"PlanetoidDbForm initialized with MPCORB.DAT file path: {mpcorbDatFilePath}");
 	}
 
-	/// <summary>Optimizes the TableLayoutPanel to eliminate flickering during label updates.</summary>
-	/// <remarks>This method enables double buffering and optimized painting styles on the panel and all child labels.</remarks>
+	/// <summary>Optimizes the TableLayoutPanels to eliminate flickering during label updates.</summary>
+	/// <remarks>This method enables double buffering and optimized painting styles on the MPCORB and ASTORB panels and all child labels.</remarks>
 	private void OptimizeTableLayoutPanelForFlickerReduction()
 	{
 		DoubleBufferingHelper.EnableDoubleBuffering(control: tableLayoutPanelMpcorbData, includeChildLabels: true);

--- a/Forms/PlanetoidDBForm.cs
+++ b/Forms/PlanetoidDBForm.cs
@@ -196,7 +196,11 @@ public partial class PlanetoidDbForm : BaseKryptonForm
 
 	/// <summary>Optimizes the TableLayoutPanel to eliminate flickering during label updates.</summary>
 	/// <remarks>This method enables double buffering and optimized painting styles on the panel and all child labels.</remarks>
-	private void OptimizeTableLayoutPanelForFlickerReduction() => DoubleBufferingHelper.EnableDoubleBuffering(control: tableLayoutPanelMpcorbData, includeChildLabels: true);
+	private void OptimizeTableLayoutPanelForFlickerReduction()
+	{
+		DoubleBufferingHelper.EnableDoubleBuffering(control: tableLayoutPanelMpcorbData, includeChildLabels: true);
+		DoubleBufferingHelper.EnableDoubleBuffering(control: tableLayoutPanelAstorbData, includeChildLabels: true);
+	}
 
 	#endregion
 }


### PR DESCRIPTION
This PR updates the main WinForms form initialization to reduce UI flicker by enabling double buffering on the ASTORB data panel in addition to the existing MPCORB panel.

**Changes:**
- Expanded `OptimizeTableLayoutPanelForFlickerReduction()` from an expression-bodied method to a block body.
- Enabled double buffering for `tableLayoutPanelAstorbData` alongside `tableLayoutPanelMpcorbData`.
