### PR TITLE
Added checking database updates on startup

### DIFF
--- a/App.config
+++ b/App.config
@@ -114,6 +114,9 @@
                 serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="systemCheckingDatabaseUpdatesOnStartup" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Planetoid_DB.Properties.Settings>
     </applicationSettings>
     <userSettings>
@@ -181,6 +184,9 @@
             </setting>
             <setting name="userLoadAdditionalDatabaseOnStartupAstorbDat"
                 serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="userCheckingDatabaseUpdatesOnStartup" serializeAs="String">
                 <value>False</value>
             </setting>
         </Planetoid_DB.Properties.Settings>

--- a/Forms/PlanetoidDBForm.DatabaseUpdates.cs
+++ b/Forms/PlanetoidDBForm.DatabaseUpdates.cs
@@ -28,32 +28,116 @@ public partial class PlanetoidDbForm
 	/// <summary>Checks if an update for the MPCORB.DAT database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the MPCORB.DAT database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsMpcorbDatUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameMpcorbDat, sourceUri: uriMpcorbDat, readContentLength: true);
+	private bool IsMpcorbDatUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for MPCORB.DAT is available
+			logger.Info(message: "Database update check on startup is enabled. Checking MPCORB.DAT update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameMpcorbDat, sourceUri: uriMpcorbDat, readContentLength: true);
+		}
+		// If the user has disabled the option to check for database updates on startup, log this information and return false
+		logger.Info(message: "Database update check on startup is disabled. Skipping MPCORB.DAT update check.");
+		return false;
+	}
 
 	/// <summary>Checks if an update for the MPCORB.JSON database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the MPCORB.JSON database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsMpcorbJsonUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameMpcorbJson, sourceUri: uriMpcorbJson, readContentLength: true);
+	private bool IsMpcorbJsonUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for MPCORB.JSON is available
+			logger.Info(message: "Database update check on startup is enabled. Checking MPCORB.JSON update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameMpcorbJson, sourceUri: uriMpcorbJson, readContentLength: true);
+		}
+		// If the user has disabled the option to check for database updates on startup, log this information and return false
+		logger.Info(message: "Database update check on startup is disabled. Skipping MPCORB.JSON update check.");
+		return false;
+	}
 
 	/// <summary>Checks if an update for the ASTORB.DAT database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the ASTORB.DAT database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsAstorbDatUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameAstorbDat, sourceUri: uriAstorbDat);
+	private bool IsAstorbDatUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for ASTORB.DAT is available
+			logger.Info(message: "Database update check on startup is enabled. Checking ASTORB.DAT update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameAstorbDat, sourceUri: uriAstorbDat, readContentLength: true);
+		}
+		else
+		{
+			// If the user has disabled the option to check for database updates on startup, log this information and return false
+			logger.Info(message: "Database update check on startup is disabled. Skipping ASTORB.DAT update check.");
+			return false;
+		}
+	}
 
 	/// <summary>Checks if an update for the ALLNUM.CAT database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the ALLNUM.CAT database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsAllnumCatUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameAllnumCat, sourceUri: uriAllnumCat);
+	private bool IsAllnumCatUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for ALLNUM.CAT is available
+			logger.Info(message: "Database update check on startup is enabled. Checking ALLNUM.CAT update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameAllnumCat, sourceUri: uriAllnumCat);
+		}
+		else
+		{
+			// If the user has disabled the option to check for database updates on startup, log this information and return false
+			logger.Info(message: "Database update check on startup is disabled. Skipping ALLNUM.CAT update check.");
+			return false;
+		}
+	}
 
 	/// <summary>Checks if an update for the UFITOBS.CAT database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the UFITOBS.CAT database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsUfitobsCatUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameUfitobsCat, sourceUri: uriUfitobsCat);
+	private bool IsUfitobsCatUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for UFITOBS.CAT is available
+			logger.Info(message: "Database update check on startup is enabled. Checking UFITOBS.CAT update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameUfitobsCat, sourceUri: uriUfitobsCat);
+		}
+		else
+		{
+			// If the user has disabled the option to check for database updates on startup, log this information and return false
+			logger.Info(message: "Database update check on startup is disabled. Skipping UFITOBS.CAT update check.");
+			return false;
+		}
+	}
 
 	/// <summary>Checks if an update for the SINGOPP.CAT database is available.</summary>
 	/// <returns><see langword="true"/> if an update is available; otherwise, <see langword="false"/>.</returns>
 	/// <remarks>This method checks if an update for the SINGOPP.CAT database is available by comparing the last modified date of the local file with the remote file. If the local file does not exist, it returns <see langword="true"/> (update available). If the remote file is newer, it also returns <see langword="true"/>. If any exceptions occur during the process, it returns <see langword="false"/>.</remarks>
-	private bool IsSingoppCatUpdateAvailable() => IsDatabaseUpdateAvailable(localFilePath: filenameSingoppCat, sourceUri: uriSingoppCat);
+	private bool IsSingoppCatUpdateAvailable()
+	{
+		// Check if the user has enabled the option to check for database updates on startup
+		if (toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked)
+		{
+			// Call the generic method to check if an update for SINGOPP.CAT is available
+			logger.Info(message: "Database update check on startup is enabled. Checking SINGOPP.CAT update availability.");
+			return IsDatabaseUpdateAvailable(localFilePath: filenameSingoppCat, sourceUri: uriSingoppCat);
+		}
+		else
+		{
+			// If the user has disabled the option to check for database updates on startup, log this information and return false
+			logger.Info(message: "Database update check on startup is disabled. Skipping SINGOPP.CAT update check.");
+			return false;
+		}
+	}
 
 	/// <summary>Shows the downloader form for the MPCORB.DAT database.</summary>
 	/// <remarks>This method is used to display the downloader form for the MPCORB.DAT database.</remarks>

--- a/Forms/PlanetoidDBForm.Designer.cs
+++ b/Forms/PlanetoidDBForm.Designer.cs
@@ -219,6 +219,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemAsteroidsDynamicSite = new ToolStripMenuItem();
 		toolStripMenuItemNearEarthObjectsDynamicSite = new ToolStripMenuItem();
 		toolStripMenuItemNearEarthObjectCoordinationCentre = new ToolStripMenuItem();
+		toolStripMenuItemSsoCard = new ToolStripMenuItem();
+		toolStripMenuItemNeotoolsOrbitVisualisationTool = new ToolStripMenuItem();
 		toolStripSeparator17 = new ToolStripSeparator();
 		toolStripMenuItemOpenAllDataPages = new ToolStripMenuItem();
 		toolStripMenuItemUpdate = new ToolStripMenuItem();
@@ -258,7 +260,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking = new ToolStripMenuItem();
 		toolStripMenuItemOptionEnableLinkingToTerminology = new ToolStripMenuItem();
 		toolStripMenuItemExperimentalFeatures = new ToolStripMenuItem();
-		toolStripMenuItemLogging = new ToolStripMenuItem();
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup = new ToolStripMenuItem();
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup = new ToolStripMenuItem();
 		contextMenuLoadAdditionalDatabasesOnStartup = new ContextMenuStrip(components);
 		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson = new ToolStripMenuItem();
@@ -266,6 +268,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupAllnumCat = new ToolStripMenuItem();
 		toolStripMenuItemLoadDatabaseOnStartupSingoppCat = new ToolStripMenuItem();
 		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat = new ToolStripMenuItem();
+		toolStripMenuItemLogging = new ToolStripMenuItem();
 		toolStripSeparatorOptions = new ToolStripSeparator();
 		toolStripMenuItemImportSettings = new ToolStripMenuItem();
 		toolStripMenuItemExportSettings = new ToolStripMenuItem();
@@ -507,8 +510,6 @@ partial class PlanetoidDbForm
 		openFileDialog = new OpenFileDialog();
 		kryptonManager = new KryptonManager(components);
 		timerCheckForNewAstorbDatFile = new Timer(components);
-		toolStripMenuItemNeotoolsOrbitVisualisationTool = new ToolStripMenuItem();
-		toolStripMenuItemSsoCard = new ToolStripMenuItem();
 		contextMenuNavigationStep.SuspendLayout();
 		tableLayoutPanelMpcorbData.SuspendLayout();
 		contextMenuCopyToClipboard.SuspendLayout();
@@ -3364,6 +3365,34 @@ partial class PlanetoidDbForm
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseEnter += Control_Enter;
 		toolStripMenuItemNearEarthObjectCoordinationCentre.MouseLeave += Control_Leave;
 		// 
+		// toolStripMenuItemSsoCard
+		// 
+		toolStripMenuItemSsoCard.AccessibleDescription = "Opens the data page of the SsODNet.ssoCard";
+		toolStripMenuItemSsoCard.AccessibleName = "SsODNet.ssoCard";
+		toolStripMenuItemSsoCard.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemSsoCard.AutoToolTip = true;
+		toolStripMenuItemSsoCard.Image = FatcowIcons16px.fatcow_external_16px;
+		toolStripMenuItemSsoCard.Name = "toolStripMenuItemSsoCard";
+		toolStripMenuItemSsoCard.Size = new Size(331, 22);
+		toolStripMenuItemSsoCard.Text = "SsODNet.ssoCard";
+		toolStripMenuItemSsoCard.Click += OpenDataPageSsoCard_Click;
+		toolStripMenuItemSsoCard.MouseEnter += Control_Enter;
+		toolStripMenuItemSsoCard.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemNeotoolsOrbitVisualisationTool
+		// 
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleDescription = "Opens the data page of the Neotools Orbit Visualisation Tool (Neotools OVT)";
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleName = "Neotools Orbit Visualisation Tool (Neotools OVT)";
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.AutoToolTip = true;
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.Image = FatcowIcons16px.fatcow_external_16px;
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.Name = "toolStripMenuItemNeotoolsOrbitVisualisationTool";
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.Size = new Size(331, 22);
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.Text = "Neotools Orbit Visualisation Tool (Neotools OVT)";
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.Click += OpenDataPageNeoToolsOvt_Click;
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.MouseEnter += Control_Enter;
+		toolStripMenuItemNeotoolsOrbitVisualisationTool.MouseLeave += Control_Leave;
+		// 
 		// toolStripSeparator17
 		// 
 		toolStripSeparator17.AccessibleDescription = "Just a separator";
@@ -3757,7 +3786,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptions.AccessibleName = "Options";
 		toolStripMenuItemOptions.AccessibleRole = AccessibleRole.MenuPopup;
 		toolStripMenuItemOptions.AutoToolTip = true;
-		toolStripMenuItemOptions.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSettings, toolStripMenuItemStyle, toolStripSeparator19, toolStripMenuItemOptionStayOnTop, toolStripMenuItemOptionEnabledCopyingByDoubleClicking, toolStripMenuItemOptionEnableLinkingToTerminology, toolStripMenuItemExperimentalFeatures, toolStripMenuItemLogging, toolStripMenuItemLoadAdditionalDatabasesOnStartup, toolStripSeparatorOptions, toolStripMenuItemImportSettings, toolStripMenuItemExportSettings });
+		toolStripMenuItemOptions.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemSettings, toolStripMenuItemStyle, toolStripSeparator19, toolStripMenuItemOptionStayOnTop, toolStripMenuItemOptionEnabledCopyingByDoubleClicking, toolStripMenuItemOptionEnableLinkingToTerminology, toolStripMenuItemExperimentalFeatures, toolStripMenuItemCheckingDatabaseUpdatesOnStartup, toolStripMenuItemLoadAdditionalDatabasesOnStartup, toolStripMenuItemLogging, toolStripSeparatorOptions, toolStripMenuItemImportSettings, toolStripMenuItemExportSettings });
 		toolStripMenuItemOptions.Name = "toolStripMenuItemOptions";
 		toolStripMenuItemOptions.ShortcutKeys = Keys.Alt | Keys.O;
 		toolStripMenuItemOptions.Size = new Size(61, 24);
@@ -3773,7 +3802,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemSettings.AutoToolTip = true;
 		toolStripMenuItemSettings.Image = FatcowIcons16px.fatcow_wrench_16px;
 		toolStripMenuItemSettings.Name = "toolStripMenuItemSettings";
-		toolStripMenuItemSettings.Size = new Size(268, 22);
+		toolStripMenuItemSettings.Size = new Size(276, 22);
 		toolStripMenuItemSettings.Text = "&Settings";
 		toolStripMenuItemSettings.Visible = false;
 		toolStripMenuItemSettings.Click += Settings_Click;
@@ -3790,7 +3819,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemStyle.Image = FatcowIcons16px.fatcow_style_16px;
 		toolStripMenuItemStyle.Name = "toolStripMenuItemStyle";
 		toolStripMenuItemStyle.ShortcutKeyDisplayString = "";
-		toolStripMenuItemStyle.Size = new Size(268, 22);
+		toolStripMenuItemStyle.Size = new Size(276, 22);
 		toolStripMenuItemStyle.Text = "&Look and Feel";
 		toolStripMenuItemStyle.Visible = false;
 		toolStripMenuItemStyle.MouseEnter += Control_Enter;
@@ -3849,7 +3878,7 @@ partial class PlanetoidDbForm
 		toolStripSeparator19.AccessibleName = "Just a separator";
 		toolStripSeparator19.AccessibleRole = AccessibleRole.Separator;
 		toolStripSeparator19.Name = "toolStripSeparator19";
-		toolStripSeparator19.Size = new Size(265, 6);
+		toolStripSeparator19.Size = new Size(273, 6);
 		toolStripSeparator19.Visible = false;
 		toolStripSeparator19.Click += AsteroidGame_Click;
 		toolStripSeparator19.MouseEnter += Control_Enter;
@@ -3863,7 +3892,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionStayOnTop.AutoToolTip = true;
 		toolStripMenuItemOptionStayOnTop.CheckOnClick = true;
 		toolStripMenuItemOptionStayOnTop.Name = "toolStripMenuItemOptionStayOnTop";
-		toolStripMenuItemOptionStayOnTop.Size = new Size(268, 22);
+		toolStripMenuItemOptionStayOnTop.Size = new Size(276, 22);
 		toolStripMenuItemOptionStayOnTop.Text = "Stay always on &top";
 		toolStripMenuItemOptionStayOnTop.Visible = false;
 		toolStripMenuItemOptionStayOnTop.Click += StayOnTop_Click;
@@ -3872,8 +3901,8 @@ partial class PlanetoidDbForm
 		// 
 		// toolStripMenuItemOptionEnabledCopyingByDoubleClicking
 		// 
-		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AccessibleDescription = "Enableds copying data to the clipboard by double-clicking";
-		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AccessibleName = "Enableds copying by double-clicking";
+		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AccessibleDescription = "Enables copying data to the clipboard by double-clicking";
+		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AccessibleName = "Enable copying by double-clicking";
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.AutoToolTip = true;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Checked = true;
@@ -3881,7 +3910,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.CheckState = CheckState.Checked;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Font = new Font("Segoe UI", 9F);
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Name = "toolStripMenuItemOptionEnabledCopyingByDoubleClicking";
-		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Size = new Size(268, 22);
+		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Size = new Size(276, 22);
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Text = "Enabled &copying by double-clicking";
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Visible = false;
 		toolStripMenuItemOptionEnabledCopyingByDoubleClicking.Click += EnableCopyingByDoubleClicking_Click;
@@ -3899,7 +3928,7 @@ partial class PlanetoidDbForm
 		toolStripMenuItemOptionEnableLinkingToTerminology.CheckState = CheckState.Checked;
 		toolStripMenuItemOptionEnableLinkingToTerminology.Enabled = false;
 		toolStripMenuItemOptionEnableLinkingToTerminology.Name = "toolStripMenuItemOptionEnableLinkingToTerminology";
-		toolStripMenuItemOptionEnableLinkingToTerminology.Size = new Size(268, 22);
+		toolStripMenuItemOptionEnableLinkingToTerminology.Size = new Size(276, 22);
 		toolStripMenuItemOptionEnableLinkingToTerminology.Text = "Enable linking to terminolog&y";
 		toolStripMenuItemOptionEnableLinkingToTerminology.Visible = false;
 		toolStripMenuItemOptionEnableLinkingToTerminology.Click += EnableLinkingToTerminology_Click;
@@ -3915,24 +3944,26 @@ partial class PlanetoidDbForm
 		toolStripMenuItemExperimentalFeatures.CheckOnClick = true;
 		toolStripMenuItemExperimentalFeatures.Image = FatcowIcons16px.fatcow_warning_16px;
 		toolStripMenuItemExperimentalFeatures.Name = "toolStripMenuItemExperimentalFeatures";
-		toolStripMenuItemExperimentalFeatures.Size = new Size(268, 22);
+		toolStripMenuItemExperimentalFeatures.Size = new Size(276, 22);
 		toolStripMenuItemExperimentalFeatures.Text = "Enable/disable experimental features";
 		toolStripMenuItemExperimentalFeatures.Click += ToolStripMenuItemExperimentalFeatures_Click;
 		toolStripMenuItemExperimentalFeatures.MouseEnter += Control_Enter;
 		toolStripMenuItemExperimentalFeatures.MouseLeave += Control_Leave;
 		// 
-		// toolStripMenuItemLogging
+		// toolStripMenuItemCheckingDatabaseUpdatesOnStartup
 		// 
-		toolStripMenuItemLogging.AccessibleDescription = "Enables or disables logging";
-		toolStripMenuItemLogging.AccessibleName = "Enable/disable logging";
-		toolStripMenuItemLogging.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemLogging.AutoToolTip = true;
-		toolStripMenuItemLogging.CheckOnClick = true;
-		toolStripMenuItemLogging.Image = FatcowIcons16px.fatcow_livejournal_16px;
-		toolStripMenuItemLogging.Name = "toolStripMenuItemLogging";
-		toolStripMenuItemLogging.Size = new Size(268, 22);
-		toolStripMenuItemLogging.Text = "Enable lo&gging";
-		toolStripMenuItemLogging.Click += ToolStripMenuItemLogging_Click;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.AccessibleDescription = "Enables or disables checking database updates on startup";
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.AccessibleName = "Checking database updates on startup";
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.AutoToolTip = true;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.CheckOnClick = true;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Image = FatcowIcons16px.fatcow_database_lightning_16px;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Name = "toolStripMenuItemCheckingDatabaseUpdatesOnStartup";
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Size = new Size(276, 22);
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Text = "Checking database updates on startup";
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Click += ToolStripMenuItemCheckingDatabaseUpdatesOnStartup_Click;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.MouseEnter += Control_Enter;
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadAdditionalDatabasesOnStartup
 		// 
@@ -3940,11 +3971,15 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.AccessibleName = "Additional databases on startup";
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.AutoToolTip = true;
+		toolStripMenuItemLoadAdditionalDatabasesOnStartup.DoubleClickEnabled = true;
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.DropDown = contextMenuLoadAdditionalDatabasesOnStartup;
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Image = FatcowIcons16px.fatcow_database_go_16px;
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Name = "toolStripMenuItemLoadAdditionalDatabasesOnStartup";
-		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Size = new Size(268, 22);
+		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Size = new Size(276, 22);
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Text = "Load additional databases on startup";
+		toolStripMenuItemLoadAdditionalDatabasesOnStartup.DoubleClick += ToolStripMenuItemLoadAdditionalDatabasesOnStartup_DoubleClick;
+		toolStripMenuItemLoadAdditionalDatabasesOnStartup.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadAdditionalDatabasesOnStartup.MouseLeave += Control_Leave;
 		// 
 		// contextMenuLoadAdditionalDatabasesOnStartup
 		// 
@@ -3959,6 +3994,10 @@ partial class PlanetoidDbForm
 		contextMenuLoadAdditionalDatabasesOnStartup.Size = new Size(155, 114);
 		contextMenuLoadAdditionalDatabasesOnStartup.TabStop = true;
 		contextMenuLoadAdditionalDatabasesOnStartup.Text = "Load additional databases on startup";
+		contextMenuLoadAdditionalDatabasesOnStartup.Enter += Control_Enter;
+		contextMenuLoadAdditionalDatabasesOnStartup.Leave += Control_Leave;
+		contextMenuLoadAdditionalDatabasesOnStartup.MouseEnter += Control_Enter;
+		contextMenuLoadAdditionalDatabasesOnStartup.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadDatabaseOnStartupMpcorbJson
 		// 
@@ -3972,6 +4011,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Size = new Size(154, 22);
 		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Text = "MPCORB.JSON";
 		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Click += ToolStripMenuItemLoadDatabaseOnStartupMpcorbJson_Click;
+		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadDatabaseOnStartupAstorbDat
 		// 
@@ -3985,6 +4026,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Size = new Size(154, 22);
 		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Text = "ASTORB.DAT";
 		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Click += ToolStripMenuItemLoadDatabaseOnStartupAstorbDat_Click;
+		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadDatabaseOnStartupAllnumCat
 		// 
@@ -3998,6 +4041,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Size = new Size(154, 22);
 		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Text = "ALLNUM.CAT";
 		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Click += ToolStripMenuItemLoadDatabaseOnStartupAllnumCat_Click;
+		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadDatabaseOnStartupSingoppCat
 		// 
@@ -4011,6 +4056,8 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Size = new Size(154, 22);
 		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Text = "SINGOPP.CAT";
 		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Click += ToolStripMenuItemLoadDatabaseOnStartupSingoppCat_Click;
+		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemLoadDatabaseOnStartupUfitobsCat
 		// 
@@ -4024,6 +4071,23 @@ partial class PlanetoidDbForm
 		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Size = new Size(154, 22);
 		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Text = "UFITOBS.CAT";
 		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Click += ToolStripMenuItemLoadDatabaseOnStartupUfitobsCat_Click;
+		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.MouseEnter += Control_Enter;
+		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.MouseLeave += Control_Leave;
+		// 
+		// toolStripMenuItemLogging
+		// 
+		toolStripMenuItemLogging.AccessibleDescription = "Enables or disables logging";
+		toolStripMenuItemLogging.AccessibleName = "Enable/disable logging";
+		toolStripMenuItemLogging.AccessibleRole = AccessibleRole.MenuItem;
+		toolStripMenuItemLogging.AutoToolTip = true;
+		toolStripMenuItemLogging.CheckOnClick = true;
+		toolStripMenuItemLogging.Image = FatcowIcons16px.fatcow_livejournal_16px;
+		toolStripMenuItemLogging.Name = "toolStripMenuItemLogging";
+		toolStripMenuItemLogging.Size = new Size(276, 22);
+		toolStripMenuItemLogging.Text = "Enable lo&gging";
+		toolStripMenuItemLogging.Click += ToolStripMenuItemLogging_Click;
+		toolStripMenuItemLogging.MouseEnter += Control_Enter;
+		toolStripMenuItemLogging.MouseLeave += Control_Leave;
 		// 
 		// toolStripSeparatorOptions
 		// 
@@ -4031,20 +4095,20 @@ partial class PlanetoidDbForm
 		toolStripSeparatorOptions.AccessibleName = "Just a separator";
 		toolStripSeparatorOptions.AccessibleRole = AccessibleRole.Separator;
 		toolStripSeparatorOptions.Name = "toolStripSeparatorOptions";
-		toolStripSeparatorOptions.Size = new Size(265, 6);
+		toolStripSeparatorOptions.Size = new Size(273, 6);
 		toolStripSeparatorOptions.Click += AsteroidGame_Click;
 		toolStripSeparatorOptions.MouseEnter += Control_Enter;
 		toolStripSeparatorOptions.MouseLeave += Control_Leave;
 		// 
 		// toolStripMenuItemImportSettings
 		// 
-		toolStripMenuItemImportSettings.AccessibleDescription = "Imports program settings from a file";
+		toolStripMenuItemImportSettings.AccessibleDescription = "Imports application settings from a file";
 		toolStripMenuItemImportSettings.AccessibleName = "Import settings";
 		toolStripMenuItemImportSettings.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemImportSettings.AutoToolTip = true;
 		toolStripMenuItemImportSettings.Image = FatcowIcons16px.fatcow_page_add_16px;
 		toolStripMenuItemImportSettings.Name = "toolStripMenuItemImportSettings";
-		toolStripMenuItemImportSettings.Size = new Size(268, 22);
+		toolStripMenuItemImportSettings.Size = new Size(276, 22);
 		toolStripMenuItemImportSettings.Text = "I&mport Settings";
 		toolStripMenuItemImportSettings.ToolTipText = "Import settings";
 		toolStripMenuItemImportSettings.Click += ImportSettings_Click;
@@ -4053,13 +4117,13 @@ partial class PlanetoidDbForm
 		// 
 		// toolStripMenuItemExportSettings
 		// 
-		toolStripMenuItemExportSettings.AccessibleDescription = "Exports program settings to a file";
+		toolStripMenuItemExportSettings.AccessibleDescription = "Exports application settings to a file";
 		toolStripMenuItemExportSettings.AccessibleName = "Export settings";
 		toolStripMenuItemExportSettings.AccessibleRole = AccessibleRole.MenuItem;
 		toolStripMenuItemExportSettings.AutoToolTip = true;
 		toolStripMenuItemExportSettings.Image = FatcowIcons16px.fatcow_page_save_16px;
 		toolStripMenuItemExportSettings.Name = "toolStripMenuItemExportSettings";
-		toolStripMenuItemExportSettings.Size = new Size(268, 22);
+		toolStripMenuItemExportSettings.Size = new Size(276, 22);
 		toolStripMenuItemExportSettings.Text = "E&xport Settings";
 		toolStripMenuItemExportSettings.ToolTipText = "Export settings";
 		toolStripMenuItemExportSettings.Click += ExportSettings_Click;
@@ -9141,35 +9205,6 @@ partial class PlanetoidDbForm
 		timerCheckForNewAstorbDatFile.Interval = 1440000;
 		timerCheckForNewAstorbDatFile.Tick += TimerCheckForNewAstorbDatFile_Tick;
 		// 
-		// toolStripMenuItemNeotoolsOrbitVisualisationTool
-		// 
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleDescription = "Opens the data page of the Neotools Orbit Visualisation Tool (Neotools OVT)";
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleName = "Neotools Orbit Visualisation Tool (Neotools OVT)";
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.AutoToolTip = true;
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.Image = FatcowIcons16px.fatcow_external_16px;
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.Name = "toolStripMenuItemNeotoolsOrbitVisualisationTool";
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.Size = new Size(331, 22);
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.Text = "Neotools Orbit Visualisation Tool (Neotools OVT)";
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.Click += OpenDataPageNeoToolsOvt_Click;
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.MouseEnter += Control_Enter;
-		toolStripMenuItemNeotoolsOrbitVisualisationTool.MouseLeave += Control_Leave;
-
-		// 
-		// toolStripMenuItemSsoCard
-		// 
-		toolStripMenuItemSsoCard.AccessibleDescription = "Opens the data page of the SsODNet.ssoCard";
-		toolStripMenuItemSsoCard.AccessibleName = "SsODNet.ssoCard";
-		toolStripMenuItemSsoCard.AccessibleRole = AccessibleRole.MenuItem;
-		toolStripMenuItemSsoCard.AutoToolTip = true;
-		toolStripMenuItemSsoCard.Image = FatcowIcons16px.fatcow_external_16px;
-		toolStripMenuItemSsoCard.Name = "toolStripMenuItemSsoCard";
-		toolStripMenuItemSsoCard.Size = new Size(331, 22);
-		toolStripMenuItemSsoCard.Text = "SsODNet.ssoCard";
-		toolStripMenuItemSsoCard.Click += OpenDataPageSsoCard_Click;
-		toolStripMenuItemSsoCard.MouseEnter += Control_Enter;
-		toolStripMenuItemSsoCard.MouseLeave += Control_Leave;
-		// 
 		// PlanetoidDbForm
 		// 
 		AccessibleDescription = "Viewer for the MPC Orbit (MPCORB) Database";
@@ -9702,4 +9737,5 @@ partial class PlanetoidDbForm
 	private ToolStripMenuItem toolStripMenuItemLoadDatabaseOnStartupUfitobsCat;
 	private ToolStripMenuItem toolStripMenuItemSsoCard;
 	private ToolStripMenuItem toolStripMenuItemNeotoolsOrbitVisualisationTool;
+	private ToolStripMenuItem toolStripMenuItemCheckingDatabaseUpdatesOnStartup;
 }

--- a/Forms/PlanetoidDBForm.EventHandlers.cs
+++ b/Forms/PlanetoidDBForm.EventHandlers.cs
@@ -49,6 +49,8 @@ public partial class PlanetoidDbForm
 		}
 		// Set the checked state of the logging menu item based on the user settings
 		toolStripMenuItemLogging.Checked = Settings.Default.userEnableLogging;
+		// Set the checked state of the check for database updates on startup menu item based on the user settings
+		toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked = Settings.Default.userCheckingDatabaseUpdatesOnStartup;
 		// Set the checked state of the load database on startup menu items based on the user settings
 		toolStripMenuItemLoadAdditionalDatabasesOnStartup.Enabled = Settings.Default.userEnableExperimentalFeatures; // TODO: Remove this line when the other databases are implemented
 		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Checked = Settings.Default.userLoadAdditionalDatabaseOnStartupMpcorbJson;
@@ -1868,6 +1870,19 @@ public partial class PlanetoidDbForm
 		Settings.Default.Save();
 	}
 
+	/// <summary>Handles the click event for the "Checking Database Updates on Startup" menu item.</summary>
+	/// <param name="e">The event data associated with the click event.</param>
+	/// <param name="sender">The source of the event, typically the menu item that was clicked.</param>
+	/// <remarks>This method updates the user setting for checking database updates on startup and saves the settings.</remarks>
+	private void ToolStripMenuItemCheckingDatabaseUpdatesOnStartup_Click(object sender, EventArgs e)
+	{
+		// Log the action of toggling the setting and the new checked state
+		logger.Info(message: $"Toggling the 'Checking Database Updates on Startup' setting. Check state: {toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked}");
+		// Update the user setting based on the checked state of the menu item
+		Settings.Default.userCheckingDatabaseUpdatesOnStartup = toolStripMenuItemCheckingDatabaseUpdatesOnStartup.Checked;
+		Settings.Default.Save();
+	}
+
 	#endregion
 
 	#region DoubleClick event handlers
@@ -1890,6 +1905,35 @@ public partial class PlanetoidDbForm
 		// Log the error and show an error message
 		logger.Error(message: $"Failed to parse index from tag text '{currentTagText}': {errorMessage}");
 		ShowErrorMessage(message: $"Failed to parse index from tag text '{currentTagText}': {errorMessage}");
+	}
+
+	/// <summary>Handles the double-click event on the "Load Additional Databases on Startup" menu item.</summary>
+	/// <param name="sender">The source of the event.</param>
+	/// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+	/// <remarks>This method sets the checked state of the menu items to true and updates the visibility of the corresponding pages based on the checked state.</remarks>
+	private void ToolStripMenuItemLoadAdditionalDatabasesOnStartup_DoubleClick(object sender, EventArgs e)
+	{
+		// Log the action of loading additional databases on startup via double-click
+		logger.Info(message: "Loading additional databases on startup via double-click.");
+		// Set the checked state of the menu items to true for loading additional databases on startup
+		toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Checked = true;
+		toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Checked = true;
+		toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Checked = true;
+		toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Checked = true;
+		toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Checked = true;
+		// Update the visibility of the corresponding pages based on the checked state of the menu items
+		kryptonPageMpcorbJson.Visible = toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Checked;
+		kryptonPageAstorbDat.Visible = toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Checked;
+		kryptonPageAllnumCat.Visible = toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Checked;
+		kryptonPageSingoppCat.Visible = toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Checked;
+		kryptonPageUfitobsCat.Visible = toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Checked;
+		// Save the user preferences for loading additional databases on startup
+		Settings.Default.userLoadAdditionalDatabaseOnStartupMpcorbJson = toolStripMenuItemLoadDatabaseOnStartupMpcorbJson.Checked;
+		Settings.Default.userLoadAdditionalDatabaseOnStartupAstorbDat = toolStripMenuItemLoadDatabaseOnStartupAstorbDat.Checked;
+		Settings.Default.userLoadAdditionalDatabaseOnStartupAllnumCat = toolStripMenuItemLoadDatabaseOnStartupAllnumCat.Checked;
+		Settings.Default.userLoadAdditionalDatabaseOnStartupSingoppCat = toolStripMenuItemLoadDatabaseOnStartupSingoppCat.Checked;
+		Settings.Default.userLoadAdditionalDatabaseOnStartupUfitobsCat = toolStripMenuItemLoadDatabaseOnStartupUfitobsCat.Checked;
+		Settings.Default.Save();
 	}
 
 	/// <summary>Handles the double-click event to show an Easter egg message.</summary>

--- a/Planetoid-DB.csproj.user
+++ b/Planetoid-DB.csproj.user
@@ -1,0 +1,196 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_LastSelectedProfileId>D:\Programming\Visual Studio 2026\Planetoid-DB\Properties\PublishProfiles\FolderProfile.pubxml</_LastSelectedProfileId>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="Forms\AEIDiagram3DForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\AppInfoForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ArchiveMpcorbForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\AsteroidFamiliesForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\AsteroidGameForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\BaseKryptonForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\BulkObservationsDataDownloaderForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\BulkObservationsDownloadErrorsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\CheckDatabaseForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\DatabaseDifferencesForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\DatabaseInformationForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\DerivedOrbitElementsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\AverageAsteroidForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\EphemerisForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ExportDataSheetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\FilterForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\DatabaseDownloaderForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\DistributionsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\LicenseForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ListReadableDesignationsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\LogViewerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MaxoidsOfAllMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MaxoidsOfOneMinorPlanetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MaxoidsRelativeToMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MoidsAndMaxoidsOfOneMinorPlanetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MoidsOfAllMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MoidsOfOneMinorPlanetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\MoidsRelativeToMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ObservationsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ObservatoryCodesForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Orbit3DForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\OrbitalResonancesOfOneMinorPlanetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\OrbitalResonancesOfAllMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\OrbitElementsGroupingForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Orbit2DTopViewForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Orbit2DSideViewForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.DatabaseUpdates.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.Decoders.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.EventHandlers.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PlanetoidDBForm.Helpers.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PreloadForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\PrintDataSheetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\RecordsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\RecordsTop10Form.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\ScatterplotsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\SearchForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\SettingsExportForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\SettingsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\SettingsImportForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\SplashScreenForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\TableModeForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\TerminologyForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\TerminologyForm.TerminologyElement.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\TisserandParameterOfAllMinorPlanetsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\TisserandParameterOfOneMinorPlanetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Forms\AEIDiagram3DForm.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\AsteroidGameForm.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="I18nStrings.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\FatcowIcons16px.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\SettingsForm.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+</Project>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -559,5 +559,26 @@ namespace Planetoid_DB.Properties {
                 this["userLoadAdditionalDatabaseOnStartupAstorbDat"] = value;
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool systemCheckingDatabaseUpdatesOnStartup {
+            get {
+                return ((bool)(this["systemCheckingDatabaseUpdatesOnStartup"]));
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool userCheckingDatabaseUpdatesOnStartup {
+            get {
+                return ((bool)(this["userCheckingDatabaseUpdatesOnStartup"]));
+            }
+            set {
+                this["userCheckingDatabaseUpdatesOnStartup"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -161,5 +161,11 @@
     <Setting Name="userLoadAdditionalDatabaseOnStartupAstorbDat" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="systemCheckingDatabaseUpdatesOnStartup" Type="System.Boolean" Scope="Application">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="userCheckingDatabaseUpdatesOnStartup" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Adds a new user-configurable option in the WinForms UI to control whether database update checks are performed on application startup, wiring it through settings and the Options menu.

**Changes:**
- Added new application/user settings entries for “checking database updates on startup”.
- Added an Options menu toggle and persists the user preference.
- Gated the startup update-availability checks based on the new toggle.
