### PR TITLE
Added new publishing profiles

### DIFF
--- a/Properties/PublishProfiles/ClickOnceProfile_win-arm64.pubxml
+++ b/Properties/PublishProfiles/ClickOnceProfile_win-arm64.pubxml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>31</ApplicationRevision>
+    <ApplicationVersion>0.9.27.*</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateDesktopShortcut>True</CreateDesktopShortcut>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <ErrorReportUrl>https://github.com/mjohne/Planetoid-DB</ErrorReportUrl>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <IsRevisionIncremented>True</IsRevisionIncremented>
+    <IsWebBootstrapper>False</IsWebBootstrapper>
+    <MapFileExtensions>True</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>ARM64</Platform>
+    <ProductName>Planetoid-DB</ProductName>
+    <PublishDir>bin\Release\net10.0-windows7.0\win-arm64\app.publish\</PublishDir>
+    <PublishUrl>bin\publish\win-arm64\</PublishUrl>
+    <PublisherName>Michael Johne (Mijo Software)</PublisherName>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>(Keine)</SignatureAlgorithm>
+    <SignManifests>False</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <SuiteName>Planetoid_DB</SuiteName>
+    <SupportUrl>https://github.com/mjohne/Planetoid-DB</SupportUrl>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <TrustUrlParameters>True</TrustUrlParameters>
+    <UpdateEnabled>False</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <UseApplicationTrust>True</UseApplicationTrust>
+    <WebPageFileName>Publish.html</WebPageFileName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.DesktopRuntime.10.0.Arm64">
+      <Install>true</Install>
+      <ProductName>.NET Desktop-Runtime 10.0.11 (Arm64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+</Project>

--- a/Properties/PublishProfiles/ClickOnceProfile_win-x64.pubxml
+++ b/Properties/PublishProfiles/ClickOnceProfile_win-x64.pubxml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>90</ApplicationRevision>
+    <ApplicationVersion>0.9.27.90</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateDesktopShortcut>True</CreateDesktopShortcut>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <ErrorReportUrl>https://github.com/mjohne/Planetoid-DB</ErrorReportUrl>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <IsRevisionIncremented>False</IsRevisionIncremented>
+    <IsWebBootstrapper>False</IsWebBootstrapper>
+    <MapFileExtensions>True</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>x64</Platform>
+    <ProductName>Planetoid-DB</ProductName>
+    <PublishDir>bin\Release\net10.0-windows7.0\win-x64\app.publish\</PublishDir>
+    <PublishUrl>bin\publish\win-x64\</PublishUrl>
+    <PublisherName>Michael Johne (Mijo Software)</PublisherName>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>(Keine)</SignatureAlgorithm>
+    <SignManifests>False</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <SuiteName>Planetoid_DB</SuiteName>
+    <SupportUrl>https://github.com/mjohne/Planetoid-DB</SupportUrl>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <TrustUrlParameters>True</TrustUrlParameters>
+    <UpdateEnabled>False</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <WebPageFileName>Publish.html</WebPageFileName>
+    <DisallowUrlActivation>False</DisallowUrlActivation>
+    <UseApplicationTrust>True</UseApplicationTrust>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.DesktopRuntime.10.0.x64">
+      <Install>true</Install>
+      <ProductName>.NET Desktop-Runtime 10.0.11 (x64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <PublishFile Include="Resources\Planetoid-DB-3.ico">
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>true</IncludeHash>
+      <FileType>File</FileType>
+    </PublishFile>
+  </ItemGroup>
+</Project>

--- a/Properties/PublishProfiles/ClickOnceProfile_win-x86.pubxml
+++ b/Properties/PublishProfiles/ClickOnceProfile_win-x86.pubxml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>31</ApplicationRevision>
+    <ApplicationVersion>0.9.27.*</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateDesktopShortcut>True</CreateDesktopShortcut>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <ErrorReportUrl>https://github.com/mjohne/Planetoid-DB</ErrorReportUrl>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <IsRevisionIncremented>True</IsRevisionIncremented>
+    <IsWebBootstrapper>False</IsWebBootstrapper>
+    <MapFileExtensions>True</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>x86</Platform>
+    <ProductName>Planetoid-DB</ProductName>
+    <PublishDir>bin\Release\net10.0-windows7.0\win-x86\app.publish\</PublishDir>
+    <PublishUrl>bin\publish\win-x86\</PublishUrl>
+    <PublisherName>Michael Johne (Mijo Software)</PublisherName>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishSingleFile>False</PublishSingleFile>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>False</SelfContained>
+    <SignatureAlgorithm>(Keine)</SignatureAlgorithm>
+    <SignManifests>False</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <SuiteName>Planetoid_DB</SuiteName>
+    <SupportUrl>https://github.com/mjohne/Planetoid-DB</SupportUrl>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <TrustUrlParameters>True</TrustUrlParameters>
+    <UpdateEnabled>False</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <UseApplicationTrust>True</UseApplicationTrust>
+    <WebPageFileName>Publish.html</WebPageFileName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.NetCore.DesktopRuntime.10.0.x86">
+      <Install>true</Install>
+      <ProductName>.NET Desktop-Runtime 10.0.11 (x86)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <PublishFile Include="Resources\Planetoid-DB-3.ico">
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>true</IncludeHash>
+      <FileType>File</FileType>
+    </PublishFile>
+  </ItemGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-arm64.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-arm64.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>ARM64</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-arm64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-arm64_standalone.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-arm64_standalone.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>ARM64</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-arm64-sa</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-x64.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-x64.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>X64</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-x64_standalone.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-x64_standalone.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>X64</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x64-sa</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-x86.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-x86.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>X86</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x86</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/Properties/PublishProfiles/FolderProfile_win-x86_standalone.pubxml
+++ b/Properties/PublishProfiles/FolderProfile_win-x86_standalone.pubxml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>X86</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x86-sa</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Adds new MSBuild publish profiles under `Properties/PublishProfiles` to support Folder (FileSystem) publishing and ClickOnce publishing for multiple Windows runtimes (x86, x64, arm64) in Planetoid-DB.

**Changes:**
- Added Folder publish profiles for win-x86 / win-x64 / win-arm64, including “standalone” variants.
- Added ClickOnce publish profiles for win-x86 / win-x64 / win-arm64.
- Introduced per-architecture output directories and runtime identifiers for publishing.
